### PR TITLE
Copy SDL2_image as an optional feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,16 @@ keywords = ["SDL", "windowing", "graphics"]
 name       = "sdl2"
 path       = "src/sdl2/lib.rs"
 
+[features]
+
+image = ["sdl2_image"]
+
 [dependencies.sdl2-sys]
 
 path = "sdl2-sys"
 version = "0.0.16"
+
+[dependencies.sdl2_image]
+
+optional = true
+path = "sdl2_image"

--- a/sdl2_image/.gitignore
+++ b/sdl2_image/.gitignore
@@ -1,0 +1,9 @@
+.rust/
+build/
+bin/
+lib/
+src/generated
+/rustpkg_db.json
+*.so
+target/
+Cargo.lock

--- a/sdl2_image/Cargo.toml
+++ b/sdl2_image/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+
+name    = "sdl2_image"
+version = "0.0.1-alpha.1"
+authors = [ "xsleonard" ]
+
+[lib]
+
+name       = "sdl2_image"
+crate-type = ["dylib"]
+
+[dependencies.sdl2]
+sdl2 = "^0"

--- a/sdl2_image/Cargo.toml
+++ b/sdl2_image/Cargo.toml
@@ -10,4 +10,4 @@ name       = "sdl2_image"
 crate-type = ["dylib"]
 
 [dependencies.sdl2]
-sdl2 = "^0"
+version = "^0"

--- a/sdl2_image/LICENSE
+++ b/sdl2_image/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2013 Mozilla Foundation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/sdl2_image/src/ffi.rs
+++ b/sdl2_image/src/ffi.rs
@@ -1,0 +1,90 @@
+extern crate sdl2;
+
+use libc::{c_int, c_char};
+use sdl2::surface::ll::SDL_Surface;
+use sdl2::rwops::ll::SDL_RWops;
+use sdl2::render::ll::SDL_Texture;
+use sdl2::render::ll::SDL_Renderer;
+use sdl2::version::ll::SDL_version;
+
+pub type IMG_InitFlags = c_int;
+pub const IMG_INIT_JPG: IMG_InitFlags = 0x00000001;
+pub const IMG_INIT_PNG: IMG_InitFlags = 0x00000002;
+pub const IMG_INIT_TIF: IMG_InitFlags = 0x00000004;
+pub const IMG_INIT_WEBP: IMG_InitFlags = 0x00000008;
+
+extern "C" {
+
+// This function gets the version of the dynamically linked SDL_image library.
+pub fn IMG_Linked_Version() -> *const SDL_version;
+
+// Loads dynamic libraries and prepares them for use.  Flags should be
+// one or more flags from IMG_InitFlags OR'd together.
+// It returns the flags successfully initialized, or 0 on failure.
+pub fn IMG_Init(flags: c_int) -> c_int;
+
+// Unloads libraries loaded with IMG_Init
+pub fn IMG_Quit();
+
+// Load an image from an SDL data source.
+// The 'type' may be one of: "BMP", "GIF", "PNG", etc.
+// If the image format supports a transparent pixel, SDL will set the
+// colorkey for the surface.  You can enable RLE acceleration on the
+// surface afterwards by calling:
+//  SDL_SetColorKey(image, SDL_RLEACCEL, image->format->colorkey);
+pub fn IMG_LoadTyped_RW(src: *const SDL_RWops, freesrc: c_int,
+                        fmt: *const c_char) -> *const SDL_Surface;
+
+// Convenience functions
+pub fn IMG_Load(file: *const c_char) -> *const SDL_Surface;
+pub fn IMG_Load_RW(src: *const SDL_RWops, freesrc: c_int) -> *const SDL_Surface;
+
+// Load an image directly into a render texture.
+// Requires SDL2
+pub fn IMG_LoadTexture(renderer: *const SDL_Renderer,
+                       file: *const c_char) -> *const SDL_Texture;
+pub fn IMG_LoadTexture_RW(renderer: *const SDL_Renderer, src: *const SDL_RWops,
+                          freesrc: c_int) -> *const SDL_Texture;
+pub fn IMG_LoadTextureTyped_RW(renderer: *const SDL_Renderer, src: *const SDL_RWops,
+                               freesrc: c_int, fmt: *const c_char) -> *const SDL_Texture;
+
+// Functions to detect a file type, given a seekable source
+pub fn IMG_isICO(src: *const SDL_RWops) -> c_int;
+pub fn IMG_isCUR(src: *const SDL_RWops) -> c_int;
+pub fn IMG_isBMP(src: *const SDL_RWops) -> c_int;
+pub fn IMG_isGIF(src: *const SDL_RWops) -> c_int;
+pub fn IMG_isJPG(src: *const SDL_RWops) -> c_int;
+pub fn IMG_isLBM(src: *const SDL_RWops) -> c_int;
+pub fn IMG_isPCX(src: *const SDL_RWops) -> c_int;
+pub fn IMG_isPNG(src: *const SDL_RWops) -> c_int;
+pub fn IMG_isPNM(src: *const SDL_RWops) -> c_int;
+pub fn IMG_isTIF(src: *const SDL_RWops) -> c_int;
+pub fn IMG_isXCF(src: *const SDL_RWops) -> c_int;
+pub fn IMG_isXPM(src: *const SDL_RWops) -> c_int;
+pub fn IMG_isXV(src: *const SDL_RWops) -> c_int;
+pub fn IMG_isWEBP(src: *const SDL_RWops) -> c_int;
+
+// Individual loading functions
+pub fn IMG_LoadICO_RW(src: *const SDL_RWops) -> *const SDL_Surface;
+pub fn IMG_LoadCUR_RW(src: *const SDL_RWops) -> *const SDL_Surface;
+pub fn IMG_LoadBMP_RW(src: *const SDL_RWops) -> *const SDL_Surface;
+pub fn IMG_LoadGIF_RW(src: *const SDL_RWops) -> *const SDL_Surface;
+pub fn IMG_LoadJPG_RW(src: *const SDL_RWops) -> *const SDL_Surface;
+pub fn IMG_LoadLBM_RW(src: *const SDL_RWops) -> *const SDL_Surface;
+pub fn IMG_LoadPCX_RW(src: *const SDL_RWops) -> *const SDL_Surface;
+pub fn IMG_LoadPNG_RW(src: *const SDL_RWops) -> *const SDL_Surface;
+pub fn IMG_LoadPNM_RW(src: *const SDL_RWops) -> *const SDL_Surface;
+pub fn IMG_LoadTGA_RW(src: *const SDL_RWops) -> *const SDL_Surface;
+pub fn IMG_LoadTIF_RW(src: *const SDL_RWops) -> *const SDL_Surface;
+pub fn IMG_LoadXCF_RW(src: *const SDL_RWops) -> *const SDL_Surface;
+pub fn IMG_LoadXPM_RW(src: *const SDL_RWops) -> *const SDL_Surface;
+pub fn IMG_LoadXV_RW(src: *const SDL_RWops) -> *const SDL_Surface;
+pub fn IMG_LoadWEBP_RW(src: *const SDL_RWops) -> *const SDL_Surface;
+pub fn IMG_ReadXPMFromArray(xpm: *const *const c_char) -> *const SDL_Surface;
+
+// Individual saving functions
+pub fn IMG_SavePNG(surface: *const SDL_Surface, file: *const c_char) -> c_int;
+pub fn IMG_SavePNG_RW(surface: *const SDL_Surface, dst: *const SDL_RWops,
+                      freedst: c_int) -> c_int;
+
+}   // extern "C"

--- a/sdl2_image/src/lib.rs
+++ b/sdl2_image/src/lib.rs
@@ -4,6 +4,7 @@
 extern crate sdl2;
 extern crate libc;
 
+use std::ffi::{c_str_to_bytes, CString};
 use libc::{c_int, c_char};
 use std::ptr;
 use sdl2::surface::Surface;
@@ -65,7 +66,7 @@ impl LoadSurface for Surface {
     fn from_file(filename: &Path) -> SdlResult<Surface> {
         //! Loads an SDL Surface from a file
         unsafe {
-            let raw = ffi::IMG_Load(filename.to_c_str().into_inner());
+            let raw = ffi::IMG_Load(CString::from_slice(filename.as_vec()).as_ptr());
             if raw == ptr::null() {
                 Err(get_error())
             } else {
@@ -92,7 +93,7 @@ impl SaveSurface for Surface {
         //! Saves an SDL Surface to a file
         unsafe {
             let status = ffi::IMG_SavePNG(self.raw(),
-                                          filename.to_c_str().into_inner());
+                                          CString::from_slice(filename.as_vec()).as_ptr());
             if status != 0 {
                 Err(get_error())
             } else {
@@ -125,7 +126,7 @@ impl LoadTexture for Renderer {
         //! Loads an SDL Texture from a file
         unsafe {
             let raw = ffi::IMG_LoadTexture(self.raw(),
-                                           filename.to_c_str().into_inner());
+                                           CString::from_slice(filename.as_vec()).as_ptr());
             if raw == ptr::null() {
                 Err(get_error())
             } else {
@@ -212,7 +213,7 @@ impl ImageRWops for RWops {
     }
     fn load_typed(&self, _type: &str) -> SdlResult<Surface> {
         let raw = unsafe {
-            ffi::IMG_LoadTyped_RW(self.raw(), 0, _type.to_c_str().into_inner())
+            ffi::IMG_LoadTyped_RW(self.raw(), 0, CString::from_slice(_type.as_bytes()).as_ptr())
         };
         to_surface_result(raw)
     }

--- a/sdl2_image/src/lib.rs
+++ b/sdl2_image/src/lib.rs
@@ -1,0 +1,323 @@
+#![crate_name="sdl2_image"]
+#![crate_type = "lib"]
+
+extern crate sdl2;
+extern crate libc;
+
+use libc::{c_int, c_char};
+use std::ptr;
+use sdl2::surface::Surface;
+use sdl2::render::Texture;
+use sdl2::render::Renderer;
+use sdl2::rwops::RWops;
+use sdl2::version::Version;
+use sdl2::get_error;
+use sdl2::SdlResult;
+
+// Setup linking for all targets.
+#[cfg(target_os="macos")]
+mod mac {
+    #[cfg(mac_framework)]
+    #[link(kind="framework", name="SDL2_image")]
+    extern {}
+
+    #[cfg(not(mac_framework))]
+    #[link(name="SDL2_image")]
+    extern {}
+}
+
+#[cfg(any(target_os="windows", target_os="linux", target_os="freebsd"))]
+mod others {
+    #[link(name="SDL2_image")]
+    extern {}
+}
+
+#[allow(non_camel_case_types, dead_code)]
+mod ffi;
+
+/// InitFlags are passed to init() to control which subsystem
+/// functionality to load.
+bitflags! {
+    flags InitFlag : u32 {
+        const INIT_JPG  = ffi::IMG_INIT_JPG as u32,
+        const INIT_PNG  = ffi::IMG_INIT_PNG as u32,
+        const INIT_TIF  = ffi::IMG_INIT_TIF as u32,
+        const INIT_WEBP = ffi::IMG_INIT_WEBP as u32
+    }
+}
+
+/// Static method extensions for creating Surfaces
+pub trait LoadSurface {
+    // Self is only returned here to type hint to the compiler.
+    // The syntax for type hinting in this case is not yet defined.
+    // The intended return value is SdlResult<~Surface>.
+    fn from_file(filename: &Path) -> SdlResult<Self>;
+    fn from_xpm_array(xpm: *const *const i8) -> SdlResult<Self>;
+}
+
+/// Method extensions to Surface for saving to disk
+pub trait SaveSurface {
+    fn save(&self, filename: &Path) -> SdlResult<()>;
+    fn save_rw(&self, dst: &mut RWops) -> SdlResult<()>;
+}
+
+impl LoadSurface for Surface {
+    fn from_file(filename: &Path) -> SdlResult<Surface> {
+        //! Loads an SDL Surface from a file
+        unsafe {
+            let raw = ffi::IMG_Load(filename.to_c_str().into_inner());
+            if raw == ptr::null() {
+                Err(get_error())
+            } else {
+                Ok(Surface::from_ll(raw, true))
+            }
+        }
+    }
+
+    fn from_xpm_array(xpm: *const *const i8) -> SdlResult<Surface> {
+        //! Loads an SDL Surface from XPM data
+        unsafe {
+            let raw = ffi::IMG_ReadXPMFromArray(xpm as *const *const c_char);
+            if raw == ptr::null() {
+                Err(get_error())
+            } else {
+                Ok(Surface::from_ll(raw, true))
+            }
+        }
+    }
+}
+
+impl SaveSurface for Surface {
+    fn save(&self, filename: &Path) -> SdlResult<()> {
+        //! Saves an SDL Surface to a file
+        unsafe {
+            let status = ffi::IMG_SavePNG(self.raw(),
+                                          filename.to_c_str().into_inner());
+            if status != 0 {
+                Err(get_error())
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    fn save_rw(&self, dst: &mut RWops) -> SdlResult<()> {
+        //! Saves an SDL Surface to an RWops
+        unsafe {
+            let status = ffi::IMG_SavePNG_RW(self.raw(), dst.raw(), 0);
+
+            if status != 0 {
+                Err(get_error())
+            } else {
+                Ok(())
+            }
+        }
+    }
+}
+
+/// Method extensions for creating Textures from a Renderer
+pub trait LoadTexture {
+    fn load_texture(&self, filename: &Path) -> SdlResult<Texture>;
+}
+
+impl LoadTexture for Renderer {
+    fn load_texture(&self, filename: &Path) -> SdlResult<Texture> {
+        //! Loads an SDL Texture from a file
+        unsafe {
+            let raw = ffi::IMG_LoadTexture(self.raw(),
+                                           filename.to_c_str().into_inner());
+            if raw == ptr::null() {
+                Err(get_error())
+            } else {
+                Ok(Texture{ raw: raw, owned: true })
+            }
+        }
+    }
+}
+
+pub fn init(flags: InitFlag) -> InitFlag {
+    //! Initializes SDL2_image with InitFlags and returns which
+    //! InitFlags were actually used.
+    unsafe {
+        let used = ffi::IMG_Init(flags.bits() as c_int);
+        InitFlag::from_bits_truncate(used as u32)
+    }
+}
+
+pub fn quit() {
+    //! Teardown the SDL2_Image subsystem
+    unsafe { ffi::IMG_Quit(); }
+}
+
+pub fn get_linked_version() -> Version {
+    //! Returns the version of the dynamically linked SDL_image library
+    unsafe {
+        Version::from_ll(ffi::IMG_Linked_Version())
+    }
+}
+
+#[inline]
+fn to_surface_result(raw: *const sdl2::surface::ll::SDL_Surface) -> SdlResult<Surface> {
+    if raw == ptr::null() {
+        Err(get_error())
+    } else {
+        unsafe { Ok(Surface::from_ll(raw, true)) }
+    }
+}
+
+pub trait ImageRWops {
+    /// load as a surface. except TGA
+    fn load(&self) -> SdlResult<Surface>;
+    /// load as a surface. This can load all supported image formats.
+    fn load_typed(&self, _type: &str) -> SdlResult<Surface>;
+
+    fn load_cur(&self) -> SdlResult<Surface>;
+    fn load_ico(&self) -> SdlResult<Surface>;
+    fn load_bmp(&self) -> SdlResult<Surface>;
+    fn load_pnm(&self) -> SdlResult<Surface>;
+    fn load_xpm(&self) -> SdlResult<Surface>;
+    fn load_xcf(&self) -> SdlResult<Surface>;
+    fn load_pcx(&self) -> SdlResult<Surface>;
+    fn load_gif(&self) -> SdlResult<Surface>;
+    fn load_jpg(&self) -> SdlResult<Surface>;
+    fn load_tif(&self) -> SdlResult<Surface>;
+    fn load_png(&self) -> SdlResult<Surface>;
+    fn load_tga(&self) -> SdlResult<Surface>;
+    fn load_lbm(&self) -> SdlResult<Surface>;
+    fn load_xv(&self)  -> SdlResult<Surface>;
+    fn load_webp(&self) -> SdlResult<Surface>;
+
+    fn is_cur(&self) -> bool;
+    fn is_ico(&self) -> bool;
+    fn is_bmp(&self) -> bool;
+    fn is_pnm(&self) -> bool;
+    fn is_xpm(&self) -> bool;
+    fn is_xcf(&self) -> bool;
+    fn is_pcx(&self) -> bool;
+    fn is_gif(&self) -> bool;
+    fn is_jpg(&self) -> bool;
+    fn is_tif(&self) -> bool;
+    fn is_png(&self) -> bool;
+    fn is_lbm(&self) -> bool;
+    fn is_xv(&self)  -> bool;
+    fn is_webp(&self) -> bool;
+}
+
+impl ImageRWops for RWops {
+    fn load(&self) -> SdlResult<Surface> {
+        let raw = unsafe {
+            ffi::IMG_Load_RW(self.raw(), 0)
+        };
+        to_surface_result(raw)
+    }
+    fn load_typed(&self, _type: &str) -> SdlResult<Surface> {
+        let raw = unsafe {
+            ffi::IMG_LoadTyped_RW(self.raw(), 0, _type.to_c_str().into_inner())
+        };
+        to_surface_result(raw)
+    }
+
+    fn load_cur(&self) -> SdlResult<Surface> {
+        let raw = unsafe { ffi::IMG_LoadCUR_RW(self.raw()) };
+        to_surface_result(raw)
+    }
+    fn load_ico(&self) -> SdlResult<Surface> {
+        let raw = unsafe { ffi::IMG_LoadICO_RW(self.raw()) };
+        to_surface_result(raw)
+    }
+    fn load_bmp(&self) -> SdlResult<Surface> {
+        let raw = unsafe { ffi::IMG_LoadBMP_RW(self.raw()) };
+        to_surface_result(raw)
+    }
+    fn load_pnm(&self) -> SdlResult<Surface> {
+        let raw = unsafe { ffi::IMG_LoadPNM_RW(self.raw()) };
+        to_surface_result(raw)
+    }
+    fn load_xpm(&self) -> SdlResult<Surface> {
+        let raw = unsafe { ffi::IMG_LoadXPM_RW(self.raw()) };
+        to_surface_result(raw)
+    }
+    fn load_xcf(&self) -> SdlResult<Surface> {
+        let raw = unsafe { ffi::IMG_LoadXCF_RW(self.raw()) };
+        to_surface_result(raw)
+    }
+    fn load_pcx(&self) -> SdlResult<Surface> {
+        let raw = unsafe { ffi::IMG_LoadPCX_RW(self.raw()) };
+        to_surface_result(raw)
+    }
+    fn load_gif(&self) -> SdlResult<Surface> {
+        let raw = unsafe { ffi::IMG_LoadGIF_RW(self.raw()) };
+        to_surface_result(raw)
+    }
+    fn load_jpg(&self) -> SdlResult<Surface> {
+        let raw = unsafe { ffi::IMG_LoadJPG_RW(self.raw()) };
+        to_surface_result(raw)
+    }
+    fn load_tif(&self) -> SdlResult<Surface> {
+        let raw = unsafe { ffi::IMG_LoadTIF_RW(self.raw()) };
+        to_surface_result(raw)
+    }
+    fn load_png(&self) -> SdlResult<Surface> {
+        let raw = unsafe { ffi::IMG_LoadPNG_RW(self.raw()) };
+        to_surface_result(raw)
+    }
+    fn load_tga(&self) -> SdlResult<Surface> {
+        let raw = unsafe { ffi::IMG_LoadTGA_RW(self.raw()) };
+        to_surface_result(raw)
+    }
+    fn load_lbm(&self) -> SdlResult<Surface> {
+        let raw = unsafe { ffi::IMG_LoadLBM_RW(self.raw()) };
+        to_surface_result(raw)
+    }
+    fn load_xv(&self)  -> SdlResult<Surface> {
+        let raw = unsafe { ffi::IMG_LoadXV_RW(self.raw()) };
+        to_surface_result(raw)
+    }
+    fn load_webp(&self)  -> SdlResult<Surface> {
+        let raw = unsafe { ffi::IMG_LoadWEBP_RW(self.raw()) };
+        to_surface_result(raw)
+    }
+
+    fn is_cur(&self) -> bool {
+        unsafe { ffi::IMG_isCUR(self.raw()) == 1 }
+    }
+    fn is_ico(&self) -> bool {
+        unsafe { ffi::IMG_isICO(self.raw()) == 1 }
+    }
+    fn is_bmp(&self) -> bool {
+        unsafe { ffi::IMG_isBMP(self.raw()) == 1 }
+    }
+    fn is_pnm(&self) -> bool {
+        unsafe { ffi::IMG_isPNM(self.raw()) == 1 }
+    }
+    fn is_xpm(&self) -> bool {
+        unsafe { ffi::IMG_isXPM(self.raw()) == 1 }
+    }
+    fn is_xcf(&self) -> bool {
+        unsafe { ffi::IMG_isXCF(self.raw()) == 1 }
+    }
+    fn is_pcx(&self) -> bool {
+        unsafe { ffi::IMG_isPCX(self.raw()) == 1 }
+    }
+    fn is_gif(&self) -> bool {
+        unsafe { ffi::IMG_isGIF(self.raw()) == 1 }
+    }
+    fn is_jpg(&self) -> bool {
+        unsafe { ffi::IMG_isJPG(self.raw()) == 1 }
+    }
+    fn is_tif(&self) -> bool {
+        unsafe { ffi::IMG_isTIF(self.raw()) == 1 }
+    }
+    fn is_png(&self) -> bool {
+        unsafe { ffi::IMG_isPNG(self.raw()) == 1 }
+    }
+    fn is_lbm(&self) -> bool {
+        unsafe { ffi::IMG_isLBM(self.raw()) == 1 }
+    }
+    fn is_xv(&self)  -> bool {
+        unsafe { ffi::IMG_isXV(self.raw())  == 1 }
+    }
+    fn is_webp(&self) -> bool {
+        unsafe { ffi::IMG_isWEBP(self.raw())  == 1 }
+    }
+}


### PR DESCRIPTION
This adds [SDL2_image](https://github.com/xsleonard/rust-sdl2_image) as an example for #233. Enabling this in a project is as easy as adding this to your `Cargo.toml`:

``` toml
[dependencies.sdl2]
features = ["image"]
```

The extension source has been added under `src/sdl2_image`. This is not required but, without it there is a circular dependency and adding the crate via the `path` directive gets around this. If a `sys` or `ll` crate is created for all the direct ffi, then all of the primary crates could depend on this and the circle would be broken.

My motivation for doing this would be to encourage a consistent & working API for the extensions, so moving the source is desirable from my point of view.
