### PR TITLE
Upgrade to latest Rust (no breaking changes)

### DIFF
--- a/examples/audio-whitenoise.rs
+++ b/examples/audio-whitenoise.rs
@@ -7,8 +7,8 @@ struct MyCallback {
 }
 impl AudioCallback<f32> for MyCallback {
     fn callback(&mut self, out: &mut [f32]) {
-        use std::rand::{Rng, task_rng};
-        let mut rng = task_rng();
+        use std::rand::{Rng, thread_rng};
+        let mut rng = thread_rng();
 
         // Generate white noise
         for x in out.iter_mut() {

--- a/src/sdl2/audio.rs
+++ b/src/sdl2/audio.rs
@@ -284,37 +284,37 @@ impl Drop for AudioCallbackTask {
 ///
 /// Example: `assert_eq!(AudioFormatNum::<f32>::get_audio_format(), ll::AUDIO_F32);``
 pub trait AudioFormatNum<T> {
-    fn get_audio_format() -> ll::SDL_AudioFormat;
+    fn get_audio_format(self) -> ll::SDL_AudioFormat;
     fn zero() -> Self;
 }
 /// AUDIO_S8
 impl AudioFormatNum<i8> for i8 {
-    fn get_audio_format() -> ll::SDL_AudioFormat { ll::AUDIO_S8 }
+    fn get_audio_format(self) -> ll::SDL_AudioFormat { ll::AUDIO_S8 }
     fn zero() -> i8 { 0 }
 }
 /// AUDIO_U8
 impl AudioFormatNum<u8> for u8 {
-    fn get_audio_format() -> ll::SDL_AudioFormat { ll::AUDIO_U8 }
+    fn get_audio_format(self) -> ll::SDL_AudioFormat { ll::AUDIO_U8 }
     fn zero() -> u8 { 0 }
 }
 /// AUDIO_S16
 impl AudioFormatNum<i16> for i16 {
-    fn get_audio_format() -> ll::SDL_AudioFormat { ll::AUDIO_S16SYS }
+    fn get_audio_format(self) -> ll::SDL_AudioFormat { ll::AUDIO_S16SYS }
     fn zero() -> i16 { 0 }
 }
 /// AUDIO_U16
 impl AudioFormatNum<u16> for u16 {
-    fn get_audio_format() -> ll::SDL_AudioFormat { ll::AUDIO_U16SYS }
+    fn get_audio_format(self) -> ll::SDL_AudioFormat { ll::AUDIO_U16SYS }
     fn zero() -> u16 { 0 }
 }
 /// AUDIO_S32
 impl AudioFormatNum<i32> for i32 {
-    fn get_audio_format() -> ll::SDL_AudioFormat { ll::AUDIO_S32SYS }
+    fn get_audio_format(self) -> ll::SDL_AudioFormat { ll::AUDIO_S32SYS }
     fn zero() -> i32 { 0 }
 }
 /// AUDIO_F32
 impl AudioFormatNum<f32> for f32 {
-    fn get_audio_format() -> ll::SDL_AudioFormat { ll::AUDIO_F32SYS }
+    fn get_audio_format(self) -> ll::SDL_AudioFormat { ll::AUDIO_F32SYS }
     fn zero() -> f32 { 0.0 }
 }
 
@@ -361,10 +361,12 @@ impl<T: AudioFormatNum<T>, CB: AudioCallback<T>> AudioSpecDesired<T, CB> {
     fn convert_to_ll(freq: i32, channels: u8, userdata: &mut AudioCallbackUserdata<CB>) -> ll::SDL_AudioSpec {
         use std::mem::transmute;
 
+        let format_num: T = AudioFormatNum::zero();
+
         unsafe {
             ll::SDL_AudioSpec {
                 freq: freq,
-                format: AudioFormatNum::<T>::get_audio_format(),
+                format: format_num.get_audio_format(),
                 channels: channels,
                 silence: 0,
                 samples: 0,


### PR DESCRIPTION
This changes the phantom type `AudioFormatNum` slightly to facilitate impl selection after recent breaking changes in Rust. It does not appear to break the external API.

Also fixes a rename in one of the examples.

Closes #249.