### PR TITLE
move building via pkg-config to behind a feature.

### DIFF
--- a/sdl2-sys/Cargo.toml
+++ b/sdl2-sys/Cargo.toml
@@ -8,6 +8,12 @@ build = "build.rs"
 
 [lib]
 name = "sdl2-sys"
+path = "src/lib.rs"
 
 [build-dependencies]
 pkg-config = "*"
+
+[features]
+
+default = []
+use-pkgconfig = []

--- a/sdl2-sys/build.rs
+++ b/sdl2-sys/build.rs
@@ -1,8 +1,12 @@
 extern crate "pkg-config" as pkg_config;
 
 fn main() {
-    if build_pkgconfig() { return; }
-    panic!("Could not find SDL2 via pkgconfig");
+    if std::os::getenv("CARGO_FEATURE_USE_PKGCONFIG").is_some() {
+      if build_pkgconfig() { return; }
+      panic!("Could not find SDL2 via pkgconfig");
+    } else {
+      println!("cargo:rustc-flags=-l SDL2");
+    }
 }
 
 fn build_pkgconfig() -> bool {


### PR DESCRIPTION
On OSX using homebrewm at least, building sdl2-sys using pkg-config breaks rustc since the installer places crates in /usr/local/lib, which is where homebrew references dylibs from. This causes rustc to get confused as to which libstd crate it should actually link against, and causes a build error. Since most users were able to make the old build mechanic work, it makes sense (at least for now, I think pkg-config is the way forward in the future) to move building via pkg-config behind a cargo feature.