### PR TITLE
Bring up to date with nightly...

### DIFF
--- a/sdl2-sys/src/audio.rs
+++ b/sdl2-sys/src/audio.rs
@@ -56,7 +56,7 @@ pub struct SDL_AudioCVT {
     pub len_cvt: c_int,
     pub len_mult: c_int,
     pub len_ratio: c_double,
-    filters: [SDL_AudioFilter, ..10u],
+    filters: [SDL_AudioFilter; 10u],
     filter_index: c_int,
 }
 pub type SDL_AudioDeviceID = uint32_t;

--- a/sdl2-sys/src/controller.rs
+++ b/sdl2-sys/src/controller.rs
@@ -12,7 +12,7 @@ pub const SDL_CONTROLLER_BINDTYPE_AXIS: SDL_GameControllerBindType = 2;
 pub const SDL_CONTROLLER_BINDTYPE_HAT: SDL_GameControllerBindType = 3;
 
 #[allow(dead_code, non_snake_case)]
-#[deriving(Copy, Clone)]
+#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct SDL_GameControllerButtonBind {
     bindType: SDL_GameControllerBindType,
@@ -20,14 +20,14 @@ pub struct SDL_GameControllerButtonBind {
 }
 
 #[allow(dead_code)]
-#[deriving(Copy, Clone)]
+#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct SDL_GameControllerButtonBindData {
-    data: [c_uchar, ..8u],
+    data: [c_uchar; 8u],
 }
 
 #[allow(dead_code)]
-#[deriving(Copy, Clone)]
+#[derive(Copy, Clone)]
 pub struct SDL_GameControllerButtonBindDataHat {
     hat: c_int,
     hat_mask: c_int,

--- a/sdl2-sys/src/event.rs
+++ b/sdl2-sys/src/event.rs
@@ -60,14 +60,14 @@ pub const SDL_DROPFILE: SDL_EventType = 4096;
 pub const SDL_USEREVENT: SDL_EventType = 32768;
 pub const SDL_LASTEVENT: SDL_EventType = 65535;
 
-#[deriving(Copy, Clone)]
+#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct SDL_CommonEvent {
     pub _type: uint32_t,
     pub timestamp: uint32_t,
 }
 
-#[deriving(Copy, Clone)]
+#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct SDL_WindowEvent {
     pub _type: uint32_t,
@@ -81,7 +81,7 @@ pub struct SDL_WindowEvent {
     pub data2: int32_t,
 }
 
-#[deriving(Copy, Clone)]
+#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct SDL_KeyboardEvent {
     pub _type: uint32_t,
@@ -94,27 +94,27 @@ pub struct SDL_KeyboardEvent {
     pub keysym: SDL_Keysym,
 }
 
-#[deriving(Copy, Clone)]
+#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct SDL_TextEditingEvent {
     pub _type: uint32_t,
     pub timestamp: uint32_t,
     pub windowID: uint32_t,
-    pub text: [c_char, ..32u],
+    pub text: [c_char; 32u],
     pub start: int32_t,
     pub length: int32_t,
 }
 
-#[deriving(Copy, Clone)]
+#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct SDL_TextInputEvent {
     pub _type: uint32_t,
     pub timestamp: uint32_t,
     pub windowID: uint32_t,
-    pub text: [c_char, ..32u],
+    pub text: [c_char; 32u],
 }
 
-#[deriving(Copy, Clone)]
+#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct SDL_MouseMotionEvent {
     pub _type: uint32_t,
@@ -128,7 +128,7 @@ pub struct SDL_MouseMotionEvent {
     pub yrel: int32_t,
 }
 
-#[deriving(Copy, Clone)]
+#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct SDL_MouseButtonEvent {
     pub _type: uint32_t,
@@ -143,7 +143,7 @@ pub struct SDL_MouseButtonEvent {
     pub y: int32_t,
 }
 
-#[deriving(Copy, Clone)]
+#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct SDL_MouseWheelEvent {
     pub _type: uint32_t,
@@ -154,7 +154,7 @@ pub struct SDL_MouseWheelEvent {
     pub y: int32_t,
 }
 
-#[deriving(Copy, Clone)]
+#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct SDL_JoyAxisEvent {
     pub _type: uint32_t,
@@ -168,7 +168,7 @@ pub struct SDL_JoyAxisEvent {
     pub padding4: uint16_t,
 }
 
-#[deriving(Copy, Clone)]
+#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct SDL_JoyBallEvent {
     pub _type: uint32_t,
@@ -182,7 +182,7 @@ pub struct SDL_JoyBallEvent {
     pub yrel: int16_t,
 }
 
-#[deriving(Copy, Clone)]
+#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct SDL_JoyHatEvent {
     pub _type: uint32_t,
@@ -194,7 +194,7 @@ pub struct SDL_JoyHatEvent {
     pub padding2: uint8_t,
 }
 
-#[deriving(Copy, Clone)]
+#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct SDL_JoyButtonEvent {
     pub _type: uint32_t,
@@ -206,7 +206,7 @@ pub struct SDL_JoyButtonEvent {
     pub padding2: uint8_t,
 }
 
-#[deriving(Copy, Clone)]
+#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct SDL_JoyDeviceEvent {
     pub _type: uint32_t,
@@ -214,7 +214,7 @@ pub struct SDL_JoyDeviceEvent {
     pub which: int32_t,
 }
 
-#[deriving(Copy, Clone)]
+#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct SDL_ControllerAxisEvent {
     pub _type: uint32_t,
@@ -228,7 +228,7 @@ pub struct SDL_ControllerAxisEvent {
     pub padding4: uint16_t,
 }
 
-#[deriving(Copy, Clone)]
+#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct SDL_ControllerButtonEvent {
     pub _type: uint32_t,
@@ -240,7 +240,7 @@ pub struct SDL_ControllerButtonEvent {
     pub padding2: uint8_t,
 }
 
-#[deriving(Copy, Clone)]
+#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct SDL_ControllerDeviceEvent {
     pub _type: uint32_t,
@@ -248,7 +248,7 @@ pub struct SDL_ControllerDeviceEvent {
     pub which: int32_t,
 }
 
-#[deriving(Copy, Clone)]
+#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct SDL_TouchFingerEvent {
     pub _type: uint32_t,
@@ -262,7 +262,7 @@ pub struct SDL_TouchFingerEvent {
     pub pressure: c_float,
 }
 
-#[deriving(Copy, Clone)]
+#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct SDL_MultiGestureEvent {
     pub _type: uint32_t,
@@ -276,7 +276,7 @@ pub struct SDL_MultiGestureEvent {
     pub padding: uint16_t,
 }
 
-#[deriving(Copy, Clone)]
+#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct SDL_DollarGestureEvent {
     pub _type: uint32_t,
@@ -297,14 +297,14 @@ pub struct SDL_DropEvent {
     pub file: *const c_char,
 }
 
-#[deriving(Copy, Clone)]
+#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct SDL_QuitEvent {
     pub _type: uint32_t,
     pub timestamp: uint32_t,
 }
 
-#[deriving(Copy, Clone)]
+#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct SDL_OSEvent {
     pub _type: uint32_t,
@@ -333,7 +333,7 @@ pub struct SDL_SysWMEvent {
 #[allow(missing_copy_implementations)]
 #[repr(C)]
 pub struct SDL_Event {
-    pub data: [uint8_t, ..56u],
+    pub data: [uint8_t; 56u],
 }
 
 impl SDL_Event {

--- a/sdl2-sys/src/haptic.rs
+++ b/sdl2-sys/src/haptic.rs
@@ -20,14 +20,14 @@ pub const SDL_HAPTIC_PAUSE: uint16_t = 1 << 15;
 
 pub type SDL_Haptic = c_void;
 
-#[deriving(Copy, Clone)]
+#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct SDL_HapticDirection {
     pub _type: uint8_t,
-    pub dir: [int32_t, ..3],
+    pub dir: [int32_t; 3],
 }
 
-#[deriving(Copy, Clone)]
+#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct SDL_HapticConstant {
     pub _type: uint16_t,
@@ -43,7 +43,7 @@ pub struct SDL_HapticConstant {
     pub fade_level: uint16_t,
 }
 
-#[deriving(Copy, Clone)]
+#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct SDL_HapticPeriodic {
     pub _type: uint16_t,
@@ -62,7 +62,7 @@ pub struct SDL_HapticPeriodic {
     pub fade_level: uint16_t,
 }
 
-#[deriving(Copy, Clone)]
+#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct SDL_HapticCondition {
     pub _type: uint16_t,
@@ -71,15 +71,15 @@ pub struct SDL_HapticCondition {
     pub delay: uint16_t,
     pub button: uint16_t,
     pub interval: uint16_t,
-    pub right_sat: [uint16_t, ..3],
-    pub left_sat: [uint16_t, ..3],
-    pub right_coeff: [int16_t, ..3],
-    pub left_coeff: [int16_t, ..3],
-    pub deadband: [uint16_t, ..3],
-    pub center: [int16_t, ..3],
+    pub right_sat: [uint16_t; 3],
+    pub left_sat: [uint16_t; 3],
+    pub right_coeff: [int16_t; 3],
+    pub left_coeff: [int16_t; 3],
+    pub deadband: [uint16_t; 3],
+    pub center: [int16_t; 3],
 }
 
-#[deriving(Copy, Clone)]
+#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct SDL_HapticRamp {
     pub _type: uint16_t,
@@ -95,7 +95,7 @@ pub struct SDL_HapticRamp {
     pub fade_level: uint16_t,
 }
 
-#[deriving(Copy, Clone)]
+#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct SDL_HapticLeftRight {
     pub _type: uint16_t,
@@ -126,7 +126,7 @@ pub struct SDL_HapticCustom {
 #[allow(missing_copy_implementations)]
 #[repr(C)]
 pub struct SDL_HapticEffect {
-    pub data: [uint8_t, ..72u],
+    pub data: [uint8_t; 72u],
 }
 
 impl SDL_HapticEffect {

--- a/sdl2-sys/src/joystick.rs
+++ b/sdl2-sys/src/joystick.rs
@@ -5,10 +5,10 @@ pub type SDL_bool = c_int;
 pub type SDL_Joystick = c_void;
 
 #[allow(dead_code)]
-#[deriving(Copy, Clone)]
+#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct SDL_JoystickGUID {
-    pub data: [uint8_t, ..16u],
+    pub data: [uint8_t; 16u],
 }
 
 extern "C" {

--- a/sdl2-sys/src/keyboard.rs
+++ b/sdl2-sys/src/keyboard.rs
@@ -10,7 +10,7 @@ pub type SDL_Keymod = c_uint;
 pub type SDL_Scancode = c_uint;
 
 // SDL_keyboard.h
-#[deriving(Copy, Clone)]
+#[derive(Copy, Clone)]
 pub struct SDL_Keysym {
     pub scancode: SDL_Scancode,
     pub sym: SDL_Keycode,

--- a/sdl2-sys/src/pixels.rs
+++ b/sdl2-sys/src/pixels.rs
@@ -1,7 +1,7 @@
 use libc::{c_int, uint8_t, uint32_t};
 
 //SDL_pixels.h
-#[deriving(Copy, Clone)]
+#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct SDL_Color {
     pub r: uint8_t,
@@ -26,7 +26,7 @@ pub struct SDL_PixelFormat {
     pub palette: *const SDL_Palette,
     pub BitsPerPixel: uint8_t,
     pub BytesPerPixel: uint8_t,
-    pub padding: [uint8_t, ..2],
+    pub padding: [uint8_t; 2],
     pub Rmask: uint8_t,
     pub Gmask: uint8_t,
     pub Bmask: uint8_t,

--- a/sdl2-sys/src/rect.rs
+++ b/sdl2-sys/src/rect.rs
@@ -6,7 +6,7 @@ use std::mem;
 use libc::c_int;
 
 /// A structure that defines a two dimensional point.
-#[deriving(PartialEq, Clone, Show, Copy)]
+#[derive(PartialEq, Clone, Show, Copy)]
 #[repr(C)]
 pub struct Point {
     pub x: i32,
@@ -14,7 +14,7 @@ pub struct Point {
 }
 
 /// A structure that defines a rectangle, with the origin at the upper left.
-#[deriving(PartialEq, Clone, Show, Copy)]
+#[derive(PartialEq, Clone, Show, Copy)]
 #[repr(C)]
 pub struct Rect {
     pub x: i32,

--- a/sdl2-sys/src/rect_2.rs
+++ b/sdl2-sys/src/rect_2.rs
@@ -1,7 +1,7 @@
 use libc::c_int;
 
 /// A structure that defines a two dimensional point.
-#[deriving(PartialEq, Clone, Show, Copy)]
+#[derive(PartialEq, Clone, Show, Copy)]
 #[repr(C)]
 pub struct SDL_Point {
     pub x: i32,
@@ -9,7 +9,7 @@ pub struct SDL_Point {
 }
 
 /// A structure that defines a rectangle, with the origin at the upper left.
-#[deriving(PartialEq, Clone, Show, Copy)]
+#[derive(PartialEq, Clone, Show, Copy)]
 #[repr(C)]
 pub struct SDL_Rect {
     pub x: i32,

--- a/sdl2-sys/src/render.rs
+++ b/sdl2-sys/src/render.rs
@@ -24,7 +24,7 @@ pub struct SDL_RendererInfo
     pub name: *const c_char,
     pub flags: uint32_t,
     pub num_texture_formats: uint32_t,
-    pub texture_formats: [uint32_t, ..16],
+    pub texture_formats: [uint32_t; 16],
     pub max_texture_width: c_int,
     pub max_texture_height: c_int,
 }

--- a/sdl2-sys/src/rwops.rs
+++ b/sdl2-sys/src/rwops.rs
@@ -4,7 +4,7 @@ use libc::{c_int, int64_t, size_t};
 #[allow(dead_code)]
 #[repr(C)]
 struct SDL_RWops_Anon {
-    data: [c_uchar, ..24],
+    data: [c_uchar; 24],
 }
 
 pub type SDL_bool = c_int;

--- a/sdl2-sys/src/touch.rs
+++ b/sdl2-sys/src/touch.rs
@@ -5,7 +5,7 @@ pub type SDL_FingerID = int64_t;
 pub type SDL_Finger = Finger;
 pub type TouchDevice = SDL_TouchID;
 
-#[deriving(PartialEq, Copy)]
+#[derive(PartialEq, Copy)]
 #[repr(C)]
 pub struct Finger {
     id: TouchDevice,

--- a/sdl2-sys/src/version.rs
+++ b/sdl2-sys/src/version.rs
@@ -2,7 +2,7 @@
 
 use libc::{uint8_t, c_char, c_int};
 
-#[deriving(Copy, Clone)]
+#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct SDL_version {
     pub major: uint8_t,

--- a/sdl2-sys/src/video.rs
+++ b/sdl2-sys/src/video.rs
@@ -25,7 +25,7 @@ pub type SDL_WindowPos = c_int;
 pub const SDL_WINDOWPOS_CENTERED: SDL_WindowPos = 0x2FFF0000;
 pub const SDL_WINDOWPOS_UNDEFINED: SDL_WindowPos = 0x1FFF0000;
 
-#[deriving(Copy, Clone)]
+#[derive(Copy, Clone)]
 pub enum SDL_WindowFlags {
     SDL_WINDOW_FULLSCREEN = 0x00000001,
     SDL_WINDOW_OPENGL = 0x00000002,
@@ -43,7 +43,7 @@ pub enum SDL_WindowFlags {
     SDL_WINDOW_ALLOW_HIGHDPI = 0x00002000
 }
 
-#[deriving(Copy, Clone)]
+#[derive(Copy, Clone)]
 pub enum SDL_WindowEventID {
     SDL_WINDOWEVENT_NONE,
     SDL_WINDOWEVENT_SHOWN,
@@ -64,7 +64,7 @@ pub enum SDL_WindowEventID {
 
 pub type SDL_GLContext = *const c_void;
 
-#[deriving(Copy, Clone, FromPrimitive)]
+#[derive(Copy, Clone, FromPrimitive)]
 #[repr(C)]
 pub enum SDL_GLattr {
     SDL_GL_RED_SIZE = 0,
@@ -93,7 +93,7 @@ pub enum SDL_GLattr {
     SDL_GL_FRAMEBUFFER_SRGB_CAPABLE = 23
 }
 
-#[deriving(Copy, Clone)]
+#[derive(Copy, Clone)]
 pub enum SDL_GLprofile {
     SDL_GL_CONTEXT_PROFILE_CORE = 0x0001,
     SDL_GL_CONTEXT_PROFILE_COMPATIBILITY = 0x0002,

--- a/src/sdl2/audio.rs
+++ b/src/sdl2/audio.rs
@@ -1,13 +1,14 @@
 //! Audio Functions
-
 use std::ptr;
 use std::mem;
-use std::c_str::CString;
+use std::c_str::{CString, ToCStr};
 use std::c_vec::CVec;
 use std::borrow::ToOwned;
 use libc;
 use libc::{c_int, size_t, c_void};
 use libc::{uint8_t};
+use std::num::FromPrimitive;
+use std::ops::{Deref, DerefMut};
 
 use get_error;
 use rwops::RWops;
@@ -37,7 +38,7 @@ pub const AUDIOS32SYS : AudioFormat = ll::AUDIO_S32SYS;
 pub const AUDIOF32SYS : AudioFormat = ll::AUDIO_F32SYS;
 
 #[repr(C)]
-#[deriving(Copy, Clone, PartialEq, Hash, Show, FromPrimitive)]
+#[derive(Copy, Clone, PartialEq, Hash, Show, FromPrimitive)]
 pub enum AudioStatus {
     Stopped = ll::SDL_AUDIO_STOPPED as int,
     Playing = ll::SDL_AUDIO_PLAYING as int,
@@ -88,7 +89,7 @@ pub fn get_current_audio_driver() -> String {
     }
 }
 
-#[deriving(Copy, Clone, Show)]
+#[derive(Copy, Clone, Show)]
 pub struct AudioSpecWAV {
     pub freq: i32,
     // TODO: Showing format should be prettier
@@ -278,7 +279,7 @@ impl<T: AudioFormatNum<T>, CB: AudioCallback<T>> AudioSpecDesired<T, CB> {
 }
 
 #[allow(missing_copy_implementations)]
-#[deriving(Show)]
+#[derive(Show)]
 pub struct AudioSpec {
     pub freq: i32,
     // TODO: Showing format should be prettier
@@ -380,11 +381,12 @@ pub struct AudioDeviceLockGuard<'a, CB: 'a> {
     device: &'a mut AudioDevice<CB>
 }
 
-impl<'a, CB> Deref<CB> for AudioDeviceLockGuard<'a, CB> {
+impl<'a, CB: 'a> Deref for AudioDeviceLockGuard<'a, CB> {
+    type Target = CB;
     fn deref(&self) -> &CB { &self.device.userdata.callback }
 }
 
-impl<'a, CB> DerefMut<CB> for AudioDeviceLockGuard<'a, CB> {
+impl<'a, CB: 'a> DerefMut for AudioDeviceLockGuard<'a, CB> {
     fn deref_mut(&mut self) -> &mut CB { &mut self.device.userdata.callback }
 }
 
@@ -395,7 +397,7 @@ impl<'a, CB> Drop for AudioDeviceLockGuard<'a, CB> {
     }
 }
 
-#[deriving(PartialEq)] #[allow(raw_pointer_deriving)]
+#[derive(PartialEq)] #[allow(raw_pointer_deriving)]
 pub struct AudioCVT {
     raw: *mut ll::SDL_AudioCVT,
     owned: bool,

--- a/src/sdl2/clipboard.rs
+++ b/src/sdl2/clipboard.rs
@@ -1,5 +1,6 @@
 use SdlResult;
 use get_error;
+use std::c_str::ToCStr;
 
 pub use sys::clipboard as ll;
 

--- a/src/sdl2/controller.rs
+++ b/src/sdl2/controller.rs
@@ -2,7 +2,7 @@ use libc::c_int;
 
 pub use sys::controller as ll;
 
-#[deriving(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, PartialEq)]
 #[repr(i32)]
 pub enum ControllerAxis {
     Invalid      = ll::SDL_CONTROLLER_AXIS_INVALID,
@@ -26,7 +26,7 @@ pub fn wrap_controller_axis(bitflags: u8) -> ControllerAxis {
     }
 }
 
-#[deriving(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, PartialEq)]
 #[repr(i32)]
 pub enum ControllerButton {
     Invalid       = ll::SDL_CONTROLLER_BUTTON_INVALID,

--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -26,7 +26,7 @@ use SdlResult;
 pub use sys::event as ll;
 
 /// Types of events that can be delivered.
-#[deriving(Copy, Clone, FromPrimitive)]
+#[derive(Copy, Clone, FromPrimitive)]
 #[repr(u32)]
 pub enum EventType {
     First = ll::SDL_FIRSTEVENT,
@@ -81,7 +81,7 @@ pub enum EventType {
     Last = ll::SDL_LASTEVENT,
 }
 
-#[deriving(Copy, Clone, Show)]
+#[derive(Copy, Clone, Show)]
 /// An enum of window events.
 pub enum WindowEventId {
     None,
@@ -203,7 +203,7 @@ pub enum Event {
 
 impl ::std::fmt::Show for Event {
     fn fmt(&self, out: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        out.write(match *self {
+        out.write_str(match *self {
             Event::None => "Event::None",
             Event::Quit(..) => "Event::Quit",
             Event::AppTerminating(..) => "Event::AppTerminating",
@@ -243,7 +243,7 @@ impl ::std::fmt::Show for Event {
             Event::ClipboardUpdate(..) => "Event::ClipboardUpdate",
             Event::DropFile(..) => "Event::DropFile",
             Event::User(..) => "Event::User",
-        }.as_bytes())
+        })
     }
 }
 
@@ -625,7 +625,7 @@ impl Event {
 }
 
 fn null_event() -> ll::SDL_Event {
-    ll::SDL_Event { data: [0, ..56] }
+    ll::SDL_Event { data: [0; 56] }
 }
 
 /// Pump the event loop, gathering events from the input devices.

--- a/src/sdl2/filesystem.rs
+++ b/src/sdl2/filesystem.rs
@@ -1,3 +1,5 @@
+use std::c_str::ToCStr;
+
 use SdlResult;
 use get_error;
 

--- a/src/sdl2/keyboard.rs
+++ b/src/sdl2/keyboard.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::num::FromPrimitive;
 use std::ptr;
+use std::c_str::ToCStr;
 
 use keycode::KeyCode;
 use rect::Rect;

--- a/src/sdl2/keycode.rs
+++ b/src/sdl2/keycode.rs
@@ -1,6 +1,7 @@
-use std::hash::{mod, Hash};
+use std::hash::{self, Hash};
+use std::num::{ToPrimitive};
 
-#[deriving(PartialEq, Eq, FromPrimitive, Show, Copy)]
+#[derive(PartialEq, Eq, FromPrimitive, Show, Copy)]
 pub enum KeyCode {
     Unknown            = 0,
     Backspace          = 8,

--- a/src/sdl2/lib.rs
+++ b/src/sdl2/lib.rs
@@ -1,7 +1,7 @@
 #![crate_name = "sdl2"]
 #![crate_type = "lib"]
 
-#![feature(default_type_params, globs, macro_rules, slicing_syntax, unsafe_destructor)]
+#![feature(default_type_params, globs, macro_rules, slicing_syntax, unsafe_destructor, associated_types, old_orphan_check)]
 
 extern crate libc;
 extern crate collections;

--- a/src/sdl2/messagebox.rs
+++ b/src/sdl2/messagebox.rs
@@ -1,4 +1,5 @@
 use std::ptr;
+use std::c_str::ToCStr;
 
 use video::Window;
 use get_error;

--- a/src/sdl2/mouse.rs
+++ b/src/sdl2/mouse.rs
@@ -7,7 +7,7 @@ use video;
 
 pub use sys::mouse as ll;
 
-#[deriving(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, PartialEq)]
 #[repr(u32)]
 pub enum SystemCursor {
     Arrow = ll::SDL_SYSTEM_CURSOR_ARROW,
@@ -24,7 +24,7 @@ pub enum SystemCursor {
     Hand = ll::SDL_SYSTEM_CURSOR_HAND,
 }
 
-#[deriving(PartialEq)] #[allow(raw_pointer_deriving)]
+#[derive(PartialEq)] #[allow(raw_pointer_deriving)]
 pub struct Cursor {
     raw: *const ll::SDL_Cursor,
     owned: bool
@@ -87,7 +87,7 @@ impl Cursor {
     }
 }
 
-#[deriving(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, PartialEq)]
 pub enum Mouse {
     Left,
     Middle,

--- a/src/sdl2/pixels.rs
+++ b/src/sdl2/pixels.rs
@@ -2,14 +2,14 @@ extern crate rand;
 
 pub use sys::pixels as ll;
 
-#[deriving(PartialEq)] #[allow(raw_pointer_deriving, missing_copy_implementations)]
+#[derive(PartialEq)] #[allow(raw_pointer_deriving, missing_copy_implementations)]
 pub struct Palette {
     raw: *const ll::SDL_Palette
 }
 
 impl_raw_accessors!(Palette, *const ll::SDL_Palette);
 
-#[deriving(PartialEq, Clone, Copy)]
+#[derive(PartialEq, Clone, Copy)]
 pub enum Color {
     RGB(u8, u8, u8),
     RGBA(u8, u8, u8, u8)
@@ -54,7 +54,7 @@ impl rand::Rand for Color {
     }
 }
 
-#[deriving(PartialEq)] #[allow(raw_pointer_deriving, missing_copy_implementations)]
+#[derive(PartialEq)] #[allow(raw_pointer_deriving, missing_copy_implementations)]
 pub struct PixelFormat {
     raw: *const ll::SDL_PixelFormat
 }
@@ -62,7 +62,7 @@ pub struct PixelFormat {
 impl_raw_accessors!(PixelFormat, *const ll::SDL_PixelFormat);
 impl_raw_constructor!(PixelFormat -> PixelFormat (raw: *const ll::SDL_PixelFormat));
 
-#[deriving(Copy, Clone, PartialEq, Show, FromPrimitive)]
+#[derive(Copy, Clone, PartialEq, Show, FromPrimitive)]
 pub enum PixelFormatFlag {
     Unknown = ll::SDL_PIXELFORMAT_UNKNOWN as int,
     Index1LSB = ll::SDL_PIXELFORMAT_INDEX1LSB as int,

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -17,13 +17,13 @@ use std::borrow::ToOwned;
 
 pub use sys::render as ll;
 
-#[deriving(Copy, Clone)]
+#[derive(Copy, Clone)]
 pub enum RenderDriverIndex {
     Auto,
     Index(int)
 }
 
-#[deriving(Copy, Clone, PartialEq, FromPrimitive)]
+#[derive(Copy, Clone, PartialEq, FromPrimitive)]
 pub enum TextureAccess {
     Static = ll::SDL_TEXTUREACCESS_STATIC as int,
     Streaming = ll::SDL_TEXTUREACCESS_STREAMING as int,
@@ -39,7 +39,7 @@ bitflags! {
     }
 }
 
-#[deriving(PartialEq)]
+#[derive(PartialEq)]
 pub struct RendererInfo {
     pub name: String,
     pub flags: RendererFlags,
@@ -48,7 +48,7 @@ pub struct RendererInfo {
     pub max_texture_height: int
 }
 
-#[deriving(Copy, Clone, PartialEq, FromPrimitive)]
+#[derive(Copy, Clone, PartialEq, FromPrimitive)]
 pub enum BlendMode {
     None = ll::SDL_BLENDMODE_NONE as int,
     Blend = ll::SDL_BLENDMODE_BLEND as int,
@@ -56,7 +56,7 @@ pub enum BlendMode {
     Mod = ll::SDL_BLENDMODE_MOD as int
 }
 
-#[deriving(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, PartialEq)]
 pub enum RendererFlip {
     None = ll::SDL_FLIP_NONE as int,
     Horizontal = ll::SDL_FLIP_HORIZONTAL as int,
@@ -482,7 +482,7 @@ impl Renderer {
 }
 
 
-#[deriving(Copy, Clone)]
+#[derive(Copy, Clone)]
 pub struct TextureQuery {
     pub format: pixels::PixelFormatFlag,
     pub access: TextureAccess,
@@ -490,7 +490,7 @@ pub struct TextureQuery {
     pub height: int
 }
 
-#[deriving(PartialEq)] #[allow(raw_pointer_deriving)]
+#[derive(PartialEq)] #[allow(raw_pointer_deriving)]
 pub struct Texture {
     pub raw: *const ll::SDL_Texture,
     pub owned: bool

--- a/src/sdl2/rwops.rs
+++ b/src/sdl2/rwops.rs
@@ -1,12 +1,13 @@
 use std::io;
 use std::io::IoResult;
+use std::c_str::ToCStr;
 use libc::{c_void, c_int, size_t};
 use get_error;
 use SdlResult;
 
 pub use sys::rwops as ll;
 
-#[deriving(PartialEq)] #[allow(raw_pointer_deriving)]
+#[derive(PartialEq)] #[allow(raw_pointer_deriving)]
 pub struct RWops {
     raw: *const ll::SDL_RWops,
     close_on_drop: bool

--- a/src/sdl2/scancode.rs
+++ b/src/sdl2/scancode.rs
@@ -1,6 +1,7 @@
-use std::hash::{mod, Hash};
+use std::hash::{self, Hash};
+use std::num::{ToPrimitive};
 
-#[deriving(PartialEq, Eq, FromPrimitive, Show, Copy)]
+#[derive(PartialEq, Eq, FromPrimitive, Show, Copy)]
 pub enum ScanCode {
     Unknown            = 0,
     A                  = 4,

--- a/src/sdl2/sdl.rs
+++ b/src/sdl2/sdl.rs
@@ -1,4 +1,4 @@
-use std::c_str::CString;
+use std::c_str::{CString, ToCStr};
 use std::borrow::ToOwned;
 
 use sys::sdl as ll;
@@ -17,7 +17,7 @@ bitflags! {
     }
 }
 
-#[deriving(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, PartialEq)]
 pub enum Error {
     NoMemError = ll::SDL_ENOMEM as int,
     ReadError = ll::SDL_EFREAD as int,

--- a/src/sdl2/surface.rs
+++ b/src/sdl2/surface.rs
@@ -7,6 +7,7 @@ use libc::{c_int, uint32_t};
 use pixels;
 use render::BlendMode;
 use rwops;
+use std::num::FromPrimitive;
 
 pub use sys::surface as ll;
 
@@ -19,7 +20,7 @@ bitflags! {
     }
 }
 
-#[deriving(PartialEq)]
+#[derive(PartialEq)]
 #[allow(raw_pointer_deriving, missing_copy_implementations)]
 pub struct Surface {
     raw: *const ll::SDL_Surface,

--- a/src/sdl2/version.rs
+++ b/src/sdl2/version.rs
@@ -9,7 +9,7 @@ use std::borrow::ToOwned;
 pub use sys::version as ll;
 
 /// A structure that contains information about the version of SDL in use.
-#[deriving(PartialEq, Copy, Clone)]
+#[derive(PartialEq, Copy, Clone)]
 pub struct Version {
     /// major version
     pub major: int,

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -1,6 +1,7 @@
 use libc::{c_int, c_float, uint32_t};
 use std::ptr;
 use std::vec::Vec;
+use std::c_str::ToCStr;
 
 use rect::Rect;
 use surface::Surface;
@@ -12,7 +13,7 @@ use get_error;
 
 pub use sys::video as ll;
 
-#[deriving(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, PartialEq)]
 pub enum GLAttr {
     GLRedSize = 0,
     GLGreenSize = 1,
@@ -40,7 +41,7 @@ pub enum GLAttr {
     GLFramebufferSRGBCapable = 23,
 }
 
-#[deriving(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, PartialEq)]
 pub enum GLProfile {
   GLCoreProfile = 0x0001,
   GLCompatibilityProfile = 0x0002,
@@ -59,7 +60,7 @@ fn empty_sdl_display_mode() -> ll::SDL_DisplayMode {
 }
 
 #[allow(missing_copy_implementations)]
-#[deriving(Clone, PartialEq)]
+#[derive(Clone, PartialEq)]
 pub struct DisplayMode {
     pub format: u32,
     pub w: int,
@@ -117,14 +118,14 @@ bitflags! {
     }
 }
 
-#[deriving(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, PartialEq)]
 pub enum FullscreenType {
     FTOff = 0,
     FTTrue = 0x00000001,
     FTDesktop = 0x00001001,
 }
 
-#[deriving(PartialEq, Copy)]
+#[derive(PartialEq, Copy)]
 pub enum WindowPos {
     PosUndefined,
     PosCentered,
@@ -139,7 +140,7 @@ fn unwrap_windowpos (pos: WindowPos) -> ll::SDL_WindowPos {
     }
 }
 
-#[deriving(PartialEq)]
+#[derive(PartialEq)]
 pub struct GLContext {
     raw: ll::SDL_GLContext,
     owned: bool
@@ -155,7 +156,7 @@ impl Drop for GLContext {
     }
 }
 
-#[deriving(PartialEq)]
+#[derive(PartialEq)]
 #[allow(raw_pointer_deriving)]
 pub struct Window {
     raw: *const ll::SDL_Window,
@@ -407,7 +408,7 @@ impl Window {
         unsafe { ll::SDL_GetWindowBrightness(self.raw) as f64 }
     }
 
-    pub fn set_gamma_ramp(&self, red: Option<&[u16, ..256]>, green: Option<&[u16, ..256]>, blue: Option<&[u16, ..256]>) -> bool {
+    pub fn set_gamma_ramp(&self, red: Option<&[u16; 256]>, green: Option<&[u16; 256]>, blue: Option<&[u16; 256]>) -> bool {
         unsafe {
             let unwrapped_red = match red {
                 Some(values) => values.as_ptr(),


### PR DESCRIPTION
..which involves:

* Switching to associated types for Iterator and a couple of other
  things,
* deriving => derive
* Some extra imports.
* Syntax change for arrays
* mod => self

The leftover warnings are inevitable and due to the fact that `Hash` doesn't play nice with the new orphan checker.

This PR supersedes pull requests #255 , #257 , #258 , #259 .