### PR TITLE
Removes boxed closures to compile w/ latest nightly.

### DIFF
--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -615,7 +615,8 @@ impl Texture {
         }
     }
 
-    pub fn with_lock(&self, rect: Option<Rect>, func: |CVec<u8>, i32| -> ()) -> SdlResult<()> {
+    pub fn with_lock<F>(&self, rect: Option<Rect>, func: F) -> SdlResult<()> 
+    where F: Fn(CVec<u8>, i32) -> () {
         match self.unsafe_lock(rect) {
             Ok((cvec, pitch)) => {
                 func(cvec, pitch);
@@ -649,7 +650,8 @@ impl Texture {
         unsafe { ll::SDL_GL_UnbindTexture(self.raw) == 0 }
     }
 
-    pub fn gl_with_bind<R>(&self, f: |tex_w: f64, tex_h: f64| -> R) -> R {
+    pub fn gl_with_bind<R,F>(&self, f: F) -> R 
+    where F: Fn(f64, f64) -> R {
         unsafe {
             let texw: c_float = 0.0;
             let texh: c_float = 0.0;

--- a/src/sdl2/surface.rs
+++ b/src/sdl2/surface.rs
@@ -108,7 +108,8 @@ impl Surface {
     }
 
     /// Locks a surface so that the pixels can be directly accessed safely.
-    pub fn with_lock<R>(&mut self, f: |pixels: &mut [u8]| -> R) -> R {
+    pub fn with_lock<R,F>(&mut self, f: F) -> R 
+    where F: Fn(&mut [u8]) -> R {
         unsafe {
             if ll::SDL_LockSurface(self.raw) != 0 { panic!("could not lock surface"); }
 


### PR DESCRIPTION
Boxed closures were removed in rust-lang/rust/pull/20578; their use is now a compile error.
Most of these changes are straightforward but I would like to draw special attention to commit 853c36e which fixes up `src/sdl2/timer.rs`

I discovered a safety violation: but I believe it was present in the previous revision with boxed closures as well.
If the `Timer` is dropped before SDL fires the callback, and the `remove_on_drop` flag _is not set:_
then the C code is calling back into a stack-frame which just got freed.

Even putting the closure in a `Box<Fn() -> uint>` does not help here. The boxed closure would just be stored inside the `Timer` which was just dropped.

I believe the constructor should be split in two. A safe constructor which forces `remove_on_drop` to true as well as an
unsafe constructor which allows the caller to set the `remove_on_drop` flags themselves.

`remove_on_drop: false` will only work in the case that the closure lives longer than the `Timer<'a>`.
Perhaps there is some other way we could express this w/ lifetime bounds, though?

---

Let me know your thoughts... but I believe this patch preserves the semantics of the previous revision.