### PR TITLE
Use unboxed closures throghout the code.

### DIFF
--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -615,7 +615,7 @@ impl Texture {
         }
     }
 
-    pub fn with_lock(&self, rect: Option<Rect>, func: |CVec<u8>, i32| -> ()) -> SdlResult<()> {
+    pub fn with_lock<F: FnOnce(CVec<u8>, i32) -> ()>(&self, rect: Option<Rect>, func: F) -> SdlResult<()> {
         match self.unsafe_lock(rect) {
             Ok((cvec, pitch)) => {
                 func(cvec, pitch);
@@ -649,7 +649,7 @@ impl Texture {
         unsafe { ll::SDL_GL_UnbindTexture(self.raw) == 0 }
     }
 
-    pub fn gl_with_bind<R>(&self, f: |tex_w: f64, tex_h: f64| -> R) -> R {
+    pub fn gl_with_bind<R, F: FnOnce(f64, f64) -> R>(&self, f: F) -> R {
         unsafe {
             let texw: c_float = 0.0;
             let texh: c_float = 0.0;

--- a/src/sdl2/surface.rs
+++ b/src/sdl2/surface.rs
@@ -108,7 +108,7 @@ impl Surface {
     }
 
     /// Locks a surface so that the pixels can be directly accessed safely.
-    pub fn with_lock<R>(&mut self, f: |pixels: &mut [u8]| -> R) -> R {
+    pub fn with_lock<R, F: FnOnce(&mut [u8]) -> R>(&mut self, f: F) -> R {
         unsafe {
             if ll::SDL_LockSurface(self.raw) != 0 { panic!("could not lock surface"); }
 


### PR DESCRIPTION
The tricky bit in in `Timer`, which now works a bit differently.
Specifically, we always stop the timer when the `Timer` object is
dropped, because otherwise the closure might run past its lifetime 'a,
rendering the code unsafe.  I'm pretty sure the previous code is buggy.

Note that this pull request is towards the same goal as #263, but does things differently.  I don't use `TraitObject`s -- I don't think it's necessary -- and I already remove the `remove_on_drop` option.  I've been using rust for a week or so so review with care :).

***

Edit: Following the discussion below, I've decided to drop support for Rust closures with SDL timers, and use `extern "C"` functions instead.