### PR TITLE
Fixed references to std::c_str

### DIFF
--- a/src/sdl2/audio.rs
+++ b/src/sdl2/audio.rs
@@ -1,7 +1,7 @@
 //! Audio Functions
 use std::ptr;
 use std::mem;
-use std::c_str::{CString, ToCStr};
+use std::ffi::CString;
 use std::c_vec::CVec;
 use std::borrow::ToOwned;
 use std::num::FromPrimitive;
@@ -216,9 +216,9 @@ impl<T: AudioFormatNum<T>, CB: AudioCallback<T>> AudioSpecDesired<T, CB> {
                 samples: 0,
                 padding: 0,
                 size: 0,
-                callback: Some(audio_callback_marshall::<T, CB> 
+                callback: Some(audio_callback_marshall::<T, CB>
                     as extern "C" fn
-                        (arg1: *const c_void, 
+                        (arg1: *const c_void,
                          arg2: *const uint8_t,
                          arg3: c_int)),
                 userdata: transmute(userdata)
@@ -237,7 +237,6 @@ impl<T: AudioFormatNum<T>, CB: AudioCallback<T>> AudioSpecDesired<T, CB> {
     pub fn open_audio_device(self, device: Option<&str>, iscapture: bool) -> SdlResult<AudioDevice<CB>> {
         use std::mem::uninitialized;
         use std::ptr::null;
-        use std::c_str::CString;
         use libc::c_char;
 
         let mut userdata = AudioSpecDesired::callback_to_userdata(self.callback);

--- a/src/sdl2/clipboard.rs
+++ b/src/sdl2/clipboard.rs
@@ -1,6 +1,5 @@
 use SdlResult;
 use get_error;
-use std::c_str::ToCStr;
 
 pub use sys::clipboard as ll;
 

--- a/src/sdl2/filesystem.rs
+++ b/src/sdl2/filesystem.rs
@@ -1,5 +1,3 @@
-use std::c_str::ToCStr;
-
 use SdlResult;
 use get_error;
 

--- a/src/sdl2/keyboard.rs
+++ b/src/sdl2/keyboard.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 use std::num::FromPrimitive;
 use std::ptr;
-use std::c_str::ToCStr;
 
 use keycode::KeyCode;
 use rect::Rect;

--- a/src/sdl2/messagebox.rs
+++ b/src/sdl2/messagebox.rs
@@ -1,5 +1,4 @@
 use std::ptr;
-use std::c_str::ToCStr;
 
 use video::Window;
 use get_error;

--- a/src/sdl2/rwops.rs
+++ b/src/sdl2/rwops.rs
@@ -1,6 +1,5 @@
 use std::io;
 use std::io::IoResult;
-use std::c_str::ToCStr;
 use libc::{c_void, c_int, size_t};
 use get_error;
 use SdlResult;

--- a/src/sdl2/sdl.rs
+++ b/src/sdl2/sdl.rs
@@ -1,4 +1,4 @@
-use std::c_str::{CString, ToCStr};
+use std::ffi::CString;
 use std::borrow::ToOwned;
 
 use sys::sdl as ll;

--- a/src/sdl2/version.rs
+++ b/src/sdl2/version.rs
@@ -3,7 +3,7 @@ Querying SDL Version
  */
 
 use std::fmt;
-use std::c_str::CString;
+use std::ffi::CString;
 use std::borrow::ToOwned;
 
 pub use sys::version as ll;

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -1,7 +1,6 @@
 use libc::{c_int, c_float, uint32_t};
 use std::ptr;
 use std::vec::Vec;
-use std::c_str::ToCStr;
 
 use rect::Rect;
 use surface::Surface;


### PR DESCRIPTION
This PR updates the references to `std::c_str::CString`, which was moved to `std::ffi::CString` in rust-lang/rust#20444.

Note that this change in Rust also removed `std::c_vec` without a replacement. Sadly, I don't know the code well enough to create a suitable workaround. This is why the build is still failing.