### PR TITLE
Use correct numeric types for events

### DIFF
--- a/examples/audio-whitenoise.rs
+++ b/examples/audio-whitenoise.rs
@@ -30,11 +30,11 @@ fn main() {
     // false: Playback
     let mut device = match desired_spec.open_audio_device(None, false) {
         Ok(device) => device,
-        Err(s) => panic!("{}", s)
+        Err(s) => panic!("{:?}", s)
     };
 
     // Show obtained AudioSpec
-    println!("{}", device.get_spec());
+    println!("{:?}", device.get_spec());
 
     // Start playback
     device.resume();

--- a/sdl2-sys/src/audio.rs
+++ b/sdl2-sys/src/audio.rs
@@ -56,7 +56,7 @@ pub struct SDL_AudioCVT {
     pub len_cvt: c_int,
     pub len_mult: c_int,
     pub len_ratio: c_double,
-    filters: [SDL_AudioFilter; 10u],
+    filters: [SDL_AudioFilter; 10us],
     filter_index: c_int,
 }
 pub type SDL_AudioDeviceID = uint32_t;

--- a/sdl2-sys/src/controller.rs
+++ b/sdl2-sys/src/controller.rs
@@ -23,7 +23,7 @@ pub struct SDL_GameControllerButtonBind {
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct SDL_GameControllerButtonBindData {
-    data: [c_uchar; 8u],
+    data: [c_uchar; 8us],
 }
 
 #[allow(dead_code)]

--- a/sdl2-sys/src/event.rs
+++ b/sdl2-sys/src/event.rs
@@ -100,7 +100,7 @@ pub struct SDL_TextEditingEvent {
     pub _type: uint32_t,
     pub timestamp: uint32_t,
     pub windowID: uint32_t,
-    pub text: [c_char; 32u],
+    pub text: [c_char; 32us],
     pub start: int32_t,
     pub length: int32_t,
 }
@@ -111,7 +111,7 @@ pub struct SDL_TextInputEvent {
     pub _type: uint32_t,
     pub timestamp: uint32_t,
     pub windowID: uint32_t,
-    pub text: [c_char; 32u],
+    pub text: [c_char; 32us],
 }
 
 #[derive(Copy, Clone)]
@@ -333,7 +333,7 @@ pub struct SDL_SysWMEvent {
 #[allow(missing_copy_implementations)]
 #[repr(C)]
 pub struct SDL_Event {
-    pub data: [uint8_t; 56u],
+    pub data: [uint8_t; 56us],
 }
 
 impl SDL_Event {

--- a/sdl2-sys/src/haptic.rs
+++ b/sdl2-sys/src/haptic.rs
@@ -126,7 +126,7 @@ pub struct SDL_HapticCustom {
 #[allow(missing_copy_implementations)]
 #[repr(C)]
 pub struct SDL_HapticEffect {
-    pub data: [uint8_t; 72u],
+    pub data: [uint8_t; 72us],
 }
 
 impl SDL_HapticEffect {

--- a/sdl2-sys/src/joystick.rs
+++ b/sdl2-sys/src/joystick.rs
@@ -8,7 +8,7 @@ pub type SDL_Joystick = c_void;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct SDL_JoystickGUID {
-    pub data: [uint8_t; 16u],
+    pub data: [uint8_t; 16us],
 }
 
 extern "C" {

--- a/src/sdl2/audio.rs
+++ b/src/sdl2/audio.rs
@@ -237,9 +237,9 @@ impl<T: AudioFormatNum<T>, CB: AudioCallback<T>> AudioSpecDesired<T, CB> {
     }
 
     fn callback_to_userdata(callback: CB) -> Box<AudioCallbackUserdata<CB>> {
-        box AudioCallbackUserdata {
+        Box::new(AudioCallbackUserdata {
             callback: callback
-        }
+        })
     }
 
     /// Opens a new audio device given the desired parameters and callback.

--- a/src/sdl2/audio.rs
+++ b/src/sdl2/audio.rs
@@ -36,27 +36,27 @@ pub const AUDIOF32SYS : AudioFormat = ll::AUDIO_F32SYS;
 #[repr(C)]
 #[derive(Copy, Clone, PartialEq, Hash, Show, FromPrimitive)]
 pub enum AudioStatus {
-    Stopped = ll::SDL_AUDIO_STOPPED as int,
-    Playing = ll::SDL_AUDIO_PLAYING as int,
-    Paused  = ll::SDL_AUDIO_PAUSED  as int,
+    Stopped = ll::SDL_AUDIO_STOPPED as isize,
+    Playing = ll::SDL_AUDIO_PLAYING as isize,
+    Paused  = ll::SDL_AUDIO_PAUSED  as isize,
 }
 
-pub fn get_num_audio_drivers() -> int {
-    unsafe { ll::SDL_GetNumAudioDrivers() as int }
+pub fn get_num_audio_drivers() -> isize {
+    unsafe { ll::SDL_GetNumAudioDrivers() as isize }
 }
 
-pub fn get_audio_driver(index: int) -> String {
+pub fn get_audio_driver(index: isize) -> String {
     unsafe {
         let driver = ll::SDL_GetAudioDriver(index as c_int);
         String::from_utf8_lossy(c_str_to_bytes(&driver)).to_string()
     }
 }
 
-pub fn get_num_audio_devices(iscapture: int) -> int {
-    unsafe { ll::SDL_GetNumAudioDevices(iscapture as c_int) as int }
+pub fn get_num_audio_devices(iscapture: isize) -> isize {
+    unsafe { ll::SDL_GetNumAudioDevices(iscapture as c_int) as isize }
 }
 
-pub fn get_audio_device_name(index: int, iscapture: int) -> String {
+pub fn get_audio_device_name(index: isize, iscapture: isize) -> String {
     unsafe {
         let dev_name = ll::SDL_GetAudioDeviceName(index as c_int, iscapture as c_int);
         String::from_utf8_lossy(c_str_to_bytes(&dev_name)).to_string()
@@ -130,7 +130,7 @@ impl AudioSpecWAV {
         unsafe {
             transmute(Slice {
                 data: self.audio_buf,
-                len: self.audio_len as uint
+                len: self.audio_len as usize
             })
         }
     }
@@ -198,7 +198,7 @@ extern "C" fn audio_callback_marshall<T: AudioFormatNum<T>, CB: AudioCallback<T>
         let mut cb_userdata: &mut AudioCallbackUserdata<CB> = transmute(userdata);
         let buf: &mut [T] = transmute(Slice {
             data: stream,
-            len: len as uint / size_of::<T>()
+            len: len as usize / size_of::<T>()
         });
 
         cb_userdata.callback.callback(buf);
@@ -346,7 +346,7 @@ impl<CB> AudioDevice<CB> {
     pub fn get_status(&self) -> AudioStatus {
         unsafe {
             let status = ll::SDL_GetAudioDeviceStatus(self.device_id.id());
-            FromPrimitive::from_int(status as int).unwrap()
+            FromPrimitive::from_int(status as isize).unwrap()
         }
     }
 

--- a/src/sdl2/cpuinfo.rs
+++ b/src/sdl2/cpuinfo.rs
@@ -1,13 +1,13 @@
 pub use sys::cpuinfo as ll;
 
-pub const CACHELINESIZE: int = 128;
+pub const CACHELINESIZE: isize = 128;
 
-pub fn get_cpu_count() -> int {
-    unsafe { ll::SDL_GetCPUCount() as int }
+pub fn get_cpu_count() -> isize {
+    unsafe { ll::SDL_GetCPUCount() as isize }
 }
 
-pub fn get_cpu_cache_line_size() -> int {
-    unsafe { ll::SDL_GetCPUCacheLineSize() as int}
+pub fn get_cpu_cache_line_size() -> isize {
+    unsafe { ll::SDL_GetCPUCacheLineSize() as isize}
 }
 
 pub fn has_rdtsc() -> bool {
@@ -50,6 +50,6 @@ pub fn has_avx() -> bool {
     unsafe { ll::SDL_HasAVX() == 1 }
 }
 
-pub fn get_system_ram() -> int {
-    unsafe { ll::SDL_GetSystemRAM() as int }
+pub fn get_system_ram() -> isize {
+    unsafe { ll::SDL_GetSystemRAM() as isize }
 }

--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -129,77 +129,77 @@ pub enum Event {
     None,
 
     /// (timestamp)
-    Quit(uint),
-    AppTerminating(uint),
-    AppLowMemory(uint),
-    AppWillEnterBackground(uint),
-    AppDidEnterBackground(uint),
-    AppWillEnterForeground(uint),
-    AppDidEnterForeground(uint),
+    Quit(usize),
+    AppTerminating(usize),
+    AppLowMemory(usize),
+    AppWillEnterBackground(usize),
+    AppDidEnterBackground(usize),
+    AppWillEnterForeground(usize),
+    AppDidEnterForeground(usize),
 
     /// (timestamp, window, winEventId, data1, data2)
-    Window(uint, video::Window, WindowEventId, int, int),
+    Window(usize, video::Window, WindowEventId, isize, isize),
     // TODO: SysWMEvent
 
     /// (timestamp, window, keycode, scancode, keymod, repeat)
-    KeyDown(uint, video::Window, KeyCode, ScanCode, Mod, bool),
-    KeyUp(uint, video::Window, KeyCode, ScanCode, Mod, bool),
+    KeyDown(usize, video::Window, KeyCode, ScanCode, Mod, bool),
+    KeyUp(usize, video::Window, KeyCode, ScanCode, Mod, bool),
     /// (timestamp, window, text, start, length)
-    TextEditing(uint, video::Window, String, int, int),
+    TextEditing(usize, video::Window, String, isize, isize),
     /// (timestamp, window, text)
-    TextInput(uint, video::Window, String),
+    TextInput(usize, video::Window, String),
 
     /// (timestamp, window, which, [MouseState], x, y, xrel, yrel)
-    MouseMotion(uint, video::Window, uint, MouseState, int, int,
-                     int, int),
+    MouseMotion(usize, video::Window, usize, MouseState, isize, isize,
+                     isize, isize),
     /// (timestamp, window, which, MouseBtn, x, y)
-    MouseButtonDown(uint, video::Window, uint, Mouse, int, int),
-    MouseButtonUp(uint, video::Window, uint, Mouse, int, int),
+    MouseButtonDown(usize, video::Window, usize, Mouse, isize, isize),
+    MouseButtonUp(usize, video::Window, usize, Mouse, isize, isize),
     /// (timestamp, window, whichId, x, y)
-    MouseWheel(uint, video::Window, uint, int, int),
+    MouseWheel(usize, video::Window, usize, isize, isize),
 
     /// (timestamp, whichId, axisIdx, value)
-    JoyAxisMotion(uint, int, int, i16),
+    JoyAxisMotion(usize, isize, isize, i16),
     /// (timestamp, whichId, ballIdx, xrel, yrel)
-    JoyBallMotion(uint, int, int, i16, i16),
+    JoyBallMotion(usize, isize, isize, i16, i16),
     /// (timestamp, whichId, hatIdx, state)
-    JoyHatMotion(uint, int, int, HatState),
+    JoyHatMotion(usize, isize, isize, HatState),
     /// (timestamp, whichId, buttonIdx)
-    JoyButtonDown(uint, int, int),
-    JoyButtonUp(uint, int, int),
+    JoyButtonDown(usize, isize, isize),
+    JoyButtonUp(usize, isize, isize),
     /// (timestamp, whichId)
-    JoyDeviceAdded(uint, int),
-    JoyDeviceRemoved(uint, int),
+    JoyDeviceAdded(usize, isize),
+    JoyDeviceRemoved(usize, isize),
 
     /// (timestamp, whichId, axis, value)
-    ControllerAxisMotion(uint, int, ControllerAxis, i16),
+    ControllerAxisMotion(usize, isize, ControllerAxis, i16),
     /// (timestamp, whichId, button)
-    ControllerButtonDown(uint, int, ControllerButton),
-    ControllerButtonUp(uint, int, ControllerButton),
+    ControllerButtonDown(usize, isize, ControllerButton),
+    ControllerButtonUp(usize, isize, ControllerButton),
     /// (timestamp, whichIdx)
-    ControllerDeviceAdded(uint, int),
-    ControllerDeviceRemoved(uint, int),
-    ControllerDeviceRemapped(uint, int),
+    ControllerDeviceAdded(usize, isize),
+    ControllerDeviceRemoved(usize, isize),
+    ControllerDeviceRemapped(usize, isize),
 
     /// (timestamp, touchId, fingerId, x, y, dx, dy, pressure)
-    FingerDown(uint, i64, i64, f64, f64, f64, f64, f64),
-    FingerUp(uint, i64, i64, f64, f64, f64, f64, f64),
-    FingerMotion(uint, i64, i64, f64, f64, f64, f64, f64),
+    FingerDown(usize, i64, i64, f64, f64, f64, f64, f64),
+    FingerUp(usize, i64, i64, f64, f64, f64, f64, f64),
+    FingerMotion(usize, i64, i64, f64, f64, f64, f64, f64),
 
     /// (timestamp, touchId, gestureId, numFingers, error, x, y)
-    DollarGesture(uint, i64, i64, uint, f64, f64, f64),
-    DollarRecord(uint, i64, i64, uint, f64, f64, f64),
+    DollarGesture(usize, i64, i64, usize, f64, f64, f64),
+    DollarRecord(usize, i64, i64, usize, f64, f64, f64),
     /// (timestamp, touchId, dTheta, dDist, x, y, numFingers)
-    MultiGesture(uint, i64, f64, f64, f64, f64, uint),
+    MultiGesture(usize, i64, f64, f64, f64, f64, usize),
 
     /// (timestamp)
-    ClipboardUpdate(uint),
+    ClipboardUpdate(usize),
 
     /// (timestamp, filename)
-    DropFile(uint, String),
+    DropFile(usize, String),
 
     /// (timestamp, Window, type, code)
-    User(uint, video::Window, uint, int),
+    User(usize, video::Window, usize, isize),
 }
 
 impl ::std::fmt::Show for Event {
@@ -284,35 +284,35 @@ impl Event {
         };
 
         // if event type has not been defined, treat it as a UserEvent
-        let event_type: EventType = FromPrimitive::from_uint(raw_type as uint).unwrap_or(EventType::User);
+        let event_type: EventType = FromPrimitive::from_uint(raw_type as usize).unwrap_or(EventType::User);
         unsafe { match event_type {
             EventType::Quit => {
                 let ref event = *raw.quit();
-                Event::Quit(event.timestamp as uint)
+                Event::Quit(event.timestamp as usize)
             }
             EventType::AppTerminating => {
                 let ref event = *raw.common();
-                Event::AppTerminating(event.timestamp as uint)
+                Event::AppTerminating(event.timestamp as usize)
             }
             EventType::AppLowMemory => {
                 let ref event = *raw.common();
-                Event::AppLowMemory(event.timestamp as uint)
+                Event::AppLowMemory(event.timestamp as usize)
             }
             EventType::AppWillEnterBackground => {
                 let ref event = *raw.common();
-                Event::AppWillEnterBackground(event.timestamp as uint)
+                Event::AppWillEnterBackground(event.timestamp as usize)
             }
             EventType::AppDidEnterBackground => {
                 let ref event = *raw.common();
-                Event::AppDidEnterBackground(event.timestamp as uint)
+                Event::AppDidEnterBackground(event.timestamp as usize)
             }
             EventType::AppWillEnterForeground => {
                 let ref event = *raw.common();
-                Event::AppWillEnterForeground(event.timestamp as uint)
+                Event::AppWillEnterForeground(event.timestamp as usize)
             }
             EventType::AppDidEnterForeground => {
                 let ref event = *raw.common();
-                Event::AppDidEnterForeground(event.timestamp as uint)
+                Event::AppDidEnterForeground(event.timestamp as usize)
             }
 
             EventType::Window => {
@@ -324,9 +324,9 @@ impl Event {
                     Ok(window) => window,
                 };
 
-                Event::Window(event.timestamp as uint, window,
+                Event::Window(event.timestamp as usize, window,
                               WindowEventId::from_ll(event.event),
-                              event.data1 as int, event.data2 as int)
+                              event.data1 as isize, event.data2 as isize)
             }
             // TODO: SysWMEventType
 
@@ -339,10 +339,10 @@ impl Event {
                     Ok(window) => window,
                 };
 
-                Event::KeyDown(event.timestamp as uint, window,
-                               FromPrimitive::from_int(event.keysym.sym as int)
+                Event::KeyDown(event.timestamp as usize, window,
+                               FromPrimitive::from_int(event.keysym.sym as isize)
                                   .unwrap_or(KeyCode::Unknown),
-                                FromPrimitive::from_int(event.keysym.scancode as int)
+                                FromPrimitive::from_int(event.keysym.scancode as isize)
                                   .unwrap_or(ScanCode::Unknown),
                                 keyboard::Mod::from_bits(event.keysym._mod as SDL_Keymod).unwrap(),
                                 event.repeat != 0)
@@ -356,10 +356,10 @@ impl Event {
                     Ok(window) => window,
                 };
 
-                Event::KeyUp(event.timestamp as uint, window,
-                             FromPrimitive::from_int(event.keysym.sym as int)
+                Event::KeyUp(event.timestamp as usize, window,
+                             FromPrimitive::from_int(event.keysym.sym as isize)
                                .unwrap_or(KeyCode::Unknown),
-                             FromPrimitive::from_int(event.keysym.scancode as int)
+                             FromPrimitive::from_int(event.keysym.scancode as isize)
                                .unwrap_or(ScanCode::Unknown),
                              keyboard::Mod::from_bits(event.keysym._mod as SDL_Keymod).unwrap(),
                              event.repeat != 0)
@@ -380,8 +380,8 @@ impl Event {
                             .collect::<Vec<u8>>()
                             .as_slice()
                     ).to_owned().into_owned();
-                Event::TextEditing(event.timestamp as uint, window, text,
-                                   event.start as int, event.length as int)
+                Event::TextEditing(event.timestamp as usize, window, text,
+                                   event.start as isize, event.length as isize)
             }
             EventType::TextInput => {
                 let ref event = *raw.text();
@@ -399,7 +399,7 @@ impl Event {
                             .collect::<Vec<u8>>()
                             .as_slice()
                     ).to_owned().into_owned();
-                Event::TextInput(event.timestamp as uint, window, text)
+                Event::TextInput(event.timestamp as usize, window, text)
             }
 
             EventType::MouseMotion => {
@@ -411,11 +411,11 @@ impl Event {
                     Ok(window) => window,
                 };
 
-                Event::MouseMotion(event.timestamp as uint, window,
-                                   event.which as uint,
+                Event::MouseMotion(event.timestamp as usize, window,
+                                   event.which as usize,
                                    mouse::MouseState::from_bits(event.state).unwrap(),
-                                   event.x as int, event.y as int,
-                                   event.xrel as int, event.yrel as int)
+                                   event.x as isize, event.y as isize,
+                                   event.xrel as isize, event.yrel as isize)
             }
             EventType::MouseButtonDown => {
                 let ref event = *raw.button();
@@ -426,10 +426,10 @@ impl Event {
                     Ok(window) => window,
                 };
 
-                Event::MouseButtonDown(event.timestamp as uint, window,
-                                       event.which as uint,
+                Event::MouseButtonDown(event.timestamp as usize, window,
+                                       event.which as usize,
                                        mouse::wrap_mouse(event.button),
-                                       event.x as int, event.y as int)
+                                       event.x as isize, event.y as isize)
             }
             EventType::MouseButtonUp => {
                 let ref event = *raw.button();
@@ -440,10 +440,10 @@ impl Event {
                     Ok(window) => window,
                 };
 
-                Event::MouseButtonUp(event.timestamp as uint, window,
-                                     event.which as uint,
+                Event::MouseButtonUp(event.timestamp as usize, window,
+                                     event.which as usize,
                                      mouse::wrap_mouse(event.button),
-                                     event.x as int, event.y as int)
+                                     event.x as isize, event.y as isize)
             }
             EventType::MouseWheel => {
                 let ref event = *raw.wheel();
@@ -454,107 +454,107 @@ impl Event {
                     Ok(window) => window,
                 };
 
-                Event::MouseWheel(event.timestamp as uint, window,
-                                  event.which as uint, event.x as int,
-                                  event.y as int)
+                Event::MouseWheel(event.timestamp as usize, window,
+                                  event.which as usize, event.x as isize,
+                                  event.y as isize)
             }
 
             EventType::JoyAxisMotion => {
                 let ref event = *raw.jaxis();
-                Event::JoyAxisMotion(event.timestamp as uint,
-                                     event.which as int, event.axis as int,
+                Event::JoyAxisMotion(event.timestamp as usize,
+                                     event.which as isize, event.axis as isize,
                                      event.value)
             }
             EventType::JoyBallMotion => {
                 let ref event = *raw.jball();
-                Event::JoyBallMotion(event.timestamp as uint,
-                                     event.which as int, event.ball as int,
+                Event::JoyBallMotion(event.timestamp as usize,
+                                     event.which as isize, event.ball as isize,
                                      event.xrel, event.yrel)
             }
             EventType::JoyHatMotion => {
                 let ref event = *raw.jhat();
-                Event::JoyHatMotion(event.timestamp as uint,
-                                    event.which as int, event.hat as int,
+                Event::JoyHatMotion(event.timestamp as usize,
+                                    event.which as isize, event.hat as isize,
                                     joystick::HatState::from_bits(event.value).unwrap())
             }
             EventType::JoyButtonDown => {
                 let ref event = *raw.jbutton();
-                Event::JoyButtonDown(event.timestamp as uint,
-                                     event.which as int,
-                                     event.button as int)
+                Event::JoyButtonDown(event.timestamp as usize,
+                                     event.which as isize,
+                                     event.button as isize)
             }
             EventType::JoyButtonUp => {
                 let ref event = *raw.jbutton();
-                Event::JoyButtonUp(event.timestamp as uint,
-                                   event.which as int,
-                                   event.button as int)
+                Event::JoyButtonUp(event.timestamp as usize,
+                                   event.which as isize,
+                                   event.button as isize)
             }
             EventType::JoyDeviceAdded => {
                 let ref event = *raw.jdevice();
-                Event::JoyDeviceAdded(event.timestamp as uint,
-                                      event.which as int)
+                Event::JoyDeviceAdded(event.timestamp as usize,
+                                      event.which as isize)
             }
             EventType::JoyDeviceRemoved => {
                 let ref event = *raw.jdevice();
-                Event::JoyDeviceRemoved(event.timestamp as uint,
-                                        event.which as int)
+                Event::JoyDeviceRemoved(event.timestamp as usize,
+                                        event.which as isize)
             }
 
             EventType::ControllerAxisMotion => {
                 let ref event = *raw.caxis();
                 let axis = controller::wrap_controller_axis(event.axis);
 
-                Event::ControllerAxisMotion(event.timestamp as uint,
-                                            event.which as int, axis,
+                Event::ControllerAxisMotion(event.timestamp as usize,
+                                            event.which as isize, axis,
                                             event.value)
             }
             EventType::ControllerButtonDown => {
                 let ref event = *raw.cbutton();
                 let button = controller::wrap_controller_button(event.button);
 
-                Event::ControllerButtonDown(event.timestamp as uint,
-                                            event.which as int, button)
+                Event::ControllerButtonDown(event.timestamp as usize,
+                                            event.which as isize, button)
             }
             EventType::ControllerButtonUp => {
                 let ref event = *raw.cbutton();
                 let button = controller::wrap_controller_button(event.button);
 
-                Event::ControllerButtonUp(event.timestamp as uint,
-                                          event.which as int, button)
+                Event::ControllerButtonUp(event.timestamp as usize,
+                                          event.which as isize, button)
             }
             EventType::ControllerDeviceAdded => {
                 let ref event = *raw.cdevice();
-                Event::ControllerDeviceAdded(event.timestamp as uint,
-                                             event.which as int)
+                Event::ControllerDeviceAdded(event.timestamp as usize,
+                                             event.which as isize)
             }
             EventType::ControllerDeviceRemoved => {
                 let ref event = *raw.cdevice();
-                Event::ControllerDeviceRemoved(event.timestamp as uint,
-                                               event.which as int)
+                Event::ControllerDeviceRemoved(event.timestamp as usize,
+                                               event.which as isize)
             }
             EventType::ControllerDeviceRemapped => {
                 let ref event = *raw.cdevice();
-                Event::ControllerDeviceRemapped(event.timestamp as uint,
-                                                event.which as int)
+                Event::ControllerDeviceRemapped(event.timestamp as usize,
+                                                event.which as isize)
             }
 
             EventType::FingerDown => {
                 let ref event = *raw.tfinger();
-                Event::FingerDown(event.timestamp as uint, event.touchId as i64,
+                Event::FingerDown(event.timestamp as usize, event.touchId as i64,
                                   event.fingerId as i64, event.x as f64,
                                   event.y as f64, event.dx as f64,
                                   event.dy as f64, event.pressure as f64)
             }
             EventType::FingerUp => {
                 let ref event = *raw.tfinger();
-                Event::FingerUp(event.timestamp as uint, event.touchId as i64,
+                Event::FingerUp(event.timestamp as usize, event.touchId as i64,
                                 event.fingerId as i64, event.x as f64,
                                 event.y as f64, event.dx as f64,
                                 event.dy as f64, event.pressure as f64)
             }
             EventType::FingerMotion => {
                 let ref event = *raw.tfinger();
-                Event::FingerMotion(event.timestamp as uint,
+                Event::FingerMotion(event.timestamp as usize,
                                     event.touchId as i64, event.fingerId as i64,
                                     event.x as f64, event.y as f64,
                                     event.dx as f64, event.dy as f64,
@@ -562,33 +562,33 @@ impl Event {
             }
             EventType::DollarGesture => {
                 let ref event = *raw.dgesture();
-                Event::DollarGesture(event.timestamp as uint,
+                Event::DollarGesture(event.timestamp as usize,
                                      event.touchId as i64,
                                      event.gestureId as i64,
-                                     event.numFingers as uint,
+                                     event.numFingers as usize,
                                      event.error as f64, event.x as f64,
                                      event.y as f64)
             }
             EventType::DollarRecord => {
                 let ref event = *raw.dgesture();
-                Event::DollarRecord(event.timestamp as uint,
+                Event::DollarRecord(event.timestamp as usize,
                                     event.touchId as i64,
                                     event.gestureId as i64,
-                                    event.numFingers as uint,
+                                    event.numFingers as usize,
                                     event.error as f64, event.x as f64,
                                     event.y as f64)
             }
             EventType::MultiGesture => {
                 let ref event = *raw.mgesture();
-                Event::MultiGesture(event.timestamp as uint,
+                Event::MultiGesture(event.timestamp as usize,
                                     event.touchId as i64, event.dTheta as f64,
                                     event.dDist as f64, event.x as f64,
-                                    event.y as f64, event.numFingers as uint)
+                                    event.y as f64, event.numFingers as usize)
             }
 
             EventType::ClipboardUpdate => {
                 let ref event = *raw.common();
-                Event::ClipboardUpdate(event.timestamp as uint)
+                Event::ClipboardUpdate(event.timestamp as usize)
             }
             EventType::DropFile => {
                 let ref event = *raw.drop();
@@ -597,7 +597,7 @@ impl Event {
                 let text = String::from_utf8_lossy(buf).to_string();
                 ll::SDL_free(event.file as *const c_void);
 
-                Event::DropFile(event.timestamp as uint, text)
+                Event::DropFile(event.timestamp as usize, text)
             }
 
             EventType::First | EventType::Last => Event::None,
@@ -617,8 +617,8 @@ impl Event {
                     Ok(window) => window,
                 };
 
-                Event::User(event.timestamp as uint, window, raw_type as uint,
-                            event.code as int)
+                Event::User(event.timestamp as usize, window, raw_type as usize,
+                            event.code as isize)
             }
         }}                      // close unsafe & match
 
@@ -676,7 +676,7 @@ pub fn wait_event() -> SdlResult<Event> {
 }
 
 /// Wait until the specified timeout (in milliseconds) for the next available event.
-pub fn wait_event_timeout(timeout: int) -> SdlResult<Event> {
+pub fn wait_event_timeout(timeout: isize) -> SdlResult<Event> {
     let raw = null_event();
     let success = unsafe { ll::SDL_WaitEventTimeout(&raw, timeout as c_int) ==
                            1 as c_int };
@@ -728,12 +728,12 @@ pub fn get_event_state(_type: EventType) -> bool {
 }
 
 /// allocate a set of user-defined events, and return the beginning event number for that set of events
-pub fn register_events(num: int) -> Option<uint> {
+pub fn register_events(num: isize) -> Option<usize> {
     let ret = unsafe { ll::SDL_RegisterEvents(num as c_int) };
     if ret == (-1 as uint32_t) {
         None
     } else {
-        Some(ret as uint)
+        Some(ret as usize)
     }
 }
 

--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -181,9 +181,9 @@ pub enum Event {
     ControllerDeviceRemapped(u32, i32),
 
     /// (timestamp, touchId, fingerId, x, y, dx, dy, pressure)
-    FingerDown(u32, i64, i64, f64, f64, f64, f64, f64),
-    FingerUp(u32, i64, i64, f64, f64, f64, f64, f64),
-    FingerMotion(u32, i64, i64, f64, f64, f64, f64, f64),
+    FingerDown(u32, i64, i64, f32, f32, f32, f32, f32),
+    FingerUp(u32, i64, i64, f32, f32, f32, f32, f32),
+    FingerMotion(u32, i64, i64, f32, f32, f32, f32, f32),
 
     /// (timestamp, touchId, gestureId, numFingers, error, x, y)
     DollarGesture(u32, i64, i64, usize, f64, f64, f64),
@@ -520,25 +520,25 @@ impl Event {
 
             EventType::FingerDown => {
                 let ref event = *raw.tfinger();
-                Event::FingerDown(event.timestamp, event.touchId as i64,
-                                  event.fingerId as i64, event.x as f64,
-                                  event.y as f64, event.dx as f64,
-                                  event.dy as f64, event.pressure as f64)
+                Event::FingerDown(event.timestamp, event.touchId,
+                                  event.fingerId, event.x,
+                                  event.y, event.dx,
+                                  event.dy, event.pressure)
             }
             EventType::FingerUp => {
                 let ref event = *raw.tfinger();
-                Event::FingerUp(event.timestamp, event.touchId as i64,
-                                event.fingerId as i64, event.x as f64,
-                                event.y as f64, event.dx as f64,
-                                event.dy as f64, event.pressure as f64)
+                Event::FingerUp(event.timestamp, event.touchId,
+                                event.fingerId, event.x,
+                                event.y, event.dx,
+                                event.dy, event.pressure)
             }
             EventType::FingerMotion => {
                 let ref event = *raw.tfinger();
                 Event::FingerMotion(event.timestamp,
-                                    event.touchId as i64, event.fingerId as i64,
-                                    event.x as f64, event.y as f64,
-                                    event.dx as f64, event.dy as f64,
-                                    event.pressure as f64)
+                                    event.touchId, event.fingerId,
+                                    event.x, event.y,
+                                    event.dx, event.dy,
+                                    event.pressure)
             }
             EventType::DollarGesture => {
                 let ref event = *raw.dgesture();

--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -186,10 +186,10 @@ pub enum Event {
     FingerMotion(u32, i64, i64, f32, f32, f32, f32, f32),
 
     /// (timestamp, touchId, gestureId, numFingers, error, x, y)
-    DollarGesture(u32, i64, i64, u32, f64, f64, f64),
-    DollarRecord(u32, i64, i64, u32, f64, f64, f64),
+    DollarGesture(u32, i64, i64, u32, f32, f32, f32),
+    DollarRecord(u32, i64, i64, u32, f32, f32, f32),
     /// (timestamp, touchId, dTheta, dDist, x, y, numFingers)
-    MultiGesture(u32, i64, f64, f64, f64, f64, u16),
+    MultiGesture(u32, i64, f32, f32, f32, f32, u16),
 
     /// (timestamp)
     ClipboardUpdate(u32),
@@ -542,28 +542,21 @@ impl Event {
             }
             EventType::DollarGesture => {
                 let ref event = *raw.dgesture();
-                Event::DollarGesture(event.timestamp,
-                                     event.touchId as i64,
-                                     event.gestureId as i64,
-                                     event.numFingers,
-                                     event.error as f64, event.x as f64,
-                                     event.y as f64)
+                Event::DollarGesture(event.timestamp, event.touchId,
+                                     event.gestureId, event.numFingers,
+                                     event.error, event.x, event.y)
             }
             EventType::DollarRecord => {
                 let ref event = *raw.dgesture();
-                Event::DollarRecord(event.timestamp,
-                                    event.touchId as i64,
-                                    event.gestureId as i64,
-                                    event.numFingers,
-                                    event.error as f64, event.x as f64,
-                                    event.y as f64)
+                Event::DollarRecord(event.timestamp, event.touchId,
+                                    event.gestureId, event.numFingers,
+                                    event.error, event.x, event.y)
             }
             EventType::MultiGesture => {
                 let ref event = *raw.mgesture();
-                Event::MultiGesture(event.timestamp,
-                                    event.touchId as i64, event.dTheta as f64,
-                                    event.dDist as f64, event.x as f64,
-                                    event.y as f64, event.numFingers)
+                Event::MultiGesture(event.timestamp, event.touchId,
+                                    event.dTheta, event.dDist,
+                                    event.x, event.y, event.numFingers)
             }
 
             EventType::ClipboardUpdate => {

--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -145,7 +145,7 @@ pub enum Event {
     KeyDown(u32, video::Window, KeyCode, ScanCode, Mod, bool),
     KeyUp(u32, video::Window, KeyCode, ScanCode, Mod, bool),
     /// (timestamp, window, text, start, length)
-    TextEditing(u32, video::Window, String, isize, isize),
+    TextEditing(u32, video::Window, String, i32, i32),
     /// (timestamp, window, text)
     TextInput(u32, video::Window, String),
 
@@ -340,12 +340,12 @@ impl Event {
                 };
 
                 Event::KeyDown(event.timestamp, window,
-                               FromPrimitive::from_int(event.keysym.sym as isize)
-                                  .unwrap_or(KeyCode::Unknown),
-                                FromPrimitive::from_int(event.keysym.scancode as isize)
-                                  .unwrap_or(ScanCode::Unknown),
-                                keyboard::Mod::from_bits(event.keysym._mod as SDL_Keymod).unwrap(),
-                                event.repeat != 0)
+                               FromPrimitive::from_i32(event.keysym.sym)
+                                 .unwrap_or(KeyCode::Unknown),
+                               FromPrimitive::from_u32(event.keysym.scancode)
+                                 .unwrap_or(ScanCode::Unknown),
+                               keyboard::Mod::from_bits(event.keysym._mod as SDL_Keymod).unwrap(),
+                               event.repeat != 0)
             }
             EventType::KeyUp => {
                 let ref event = *raw.key();
@@ -357,9 +357,9 @@ impl Event {
                 };
 
                 Event::KeyUp(event.timestamp, window,
-                             FromPrimitive::from_int(event.keysym.sym as isize)
+                             FromPrimitive::from_i32(event.keysym.sym)
                                .unwrap_or(KeyCode::Unknown),
-                             FromPrimitive::from_int(event.keysym.scancode as isize)
+                             FromPrimitive::from_u32(event.keysym.scancode)
                                .unwrap_or(ScanCode::Unknown),
                              keyboard::Mod::from_bits(event.keysym._mod as SDL_Keymod).unwrap(),
                              event.repeat != 0)
@@ -381,7 +381,7 @@ impl Event {
                             .as_slice()
                     ).to_owned().into_owned();
                 Event::TextEditing(event.timestamp, window, text,
-                                   event.start as isize, event.length as isize)
+                                   event.start, event.length)
             }
             EventType::TextInput => {
                 let ref event = *raw.text();

--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -186,10 +186,10 @@ pub enum Event {
     FingerMotion(u32, i64, i64, f32, f32, f32, f32, f32),
 
     /// (timestamp, touchId, gestureId, numFingers, error, x, y)
-    DollarGesture(u32, i64, i64, usize, f64, f64, f64),
-    DollarRecord(u32, i64, i64, usize, f64, f64, f64),
+    DollarGesture(u32, i64, i64, u32, f64, f64, f64),
+    DollarRecord(u32, i64, i64, u32, f64, f64, f64),
     /// (timestamp, touchId, dTheta, dDist, x, y, numFingers)
-    MultiGesture(u32, i64, f64, f64, f64, f64, usize),
+    MultiGesture(u32, i64, f64, f64, f64, f64, u16),
 
     /// (timestamp)
     ClipboardUpdate(u32),
@@ -545,7 +545,7 @@ impl Event {
                 Event::DollarGesture(event.timestamp,
                                      event.touchId as i64,
                                      event.gestureId as i64,
-                                     event.numFingers as usize,
+                                     event.numFingers,
                                      event.error as f64, event.x as f64,
                                      event.y as f64)
             }
@@ -554,7 +554,7 @@ impl Event {
                 Event::DollarRecord(event.timestamp,
                                     event.touchId as i64,
                                     event.gestureId as i64,
-                                    event.numFingers as usize,
+                                    event.numFingers,
                                     event.error as f64, event.x as f64,
                                     event.y as f64)
             }
@@ -563,7 +563,7 @@ impl Event {
                 Event::MultiGesture(event.timestamp,
                                     event.touchId as i64, event.dTheta as f64,
                                     event.dDist as f64, event.x as f64,
-                                    event.y as f64, event.numFingers as usize)
+                                    event.y as f64, event.numFingers)
             }
 
             EventType::ClipboardUpdate => {

--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -150,13 +150,12 @@ pub enum Event {
     TextInput(u32, video::Window, String),
 
     /// (timestamp, window, which, [MouseState], x, y, xrel, yrel)
-    MouseMotion(u32, video::Window, usize, MouseState, isize, isize,
-                     isize, isize),
+    MouseMotion(u32, video::Window, u32, MouseState, i32, i32, i32, i32),
     /// (timestamp, window, which, MouseBtn, x, y)
-    MouseButtonDown(u32, video::Window, usize, Mouse, isize, isize),
-    MouseButtonUp(u32, video::Window, usize, Mouse, isize, isize),
+    MouseButtonDown(u32, video::Window, u32, Mouse, i32, i32),
+    MouseButtonUp(u32, video::Window, u32, Mouse, i32, i32),
     /// (timestamp, window, whichId, x, y)
-    MouseWheel(u32, video::Window, usize, isize, isize),
+    MouseWheel(u32, video::Window, u32, i32, i32),
 
     /// (timestamp, whichId, axisIdx, value)
     JoyAxisMotion(u32, isize, isize, i16),
@@ -411,11 +410,10 @@ impl Event {
                     Ok(window) => window,
                 };
 
-                Event::MouseMotion(event.timestamp, window,
-                                   event.which as usize,
+                Event::MouseMotion(event.timestamp, window, event.which,
                                    mouse::MouseState::from_bits(event.state).unwrap(),
-                                   event.x as isize, event.y as isize,
-                                   event.xrel as isize, event.yrel as isize)
+                                   event.x, event.y,
+                                   event.xrel, event.yrel)
             }
             EventType::MouseButtonDown => {
                 let ref event = *raw.button();
@@ -426,10 +424,9 @@ impl Event {
                     Ok(window) => window,
                 };
 
-                Event::MouseButtonDown(event.timestamp, window,
-                                       event.which as usize,
+                Event::MouseButtonDown(event.timestamp, window, event.which,
                                        mouse::wrap_mouse(event.button),
-                                       event.x as isize, event.y as isize)
+                                       event.x, event.y)
             }
             EventType::MouseButtonUp => {
                 let ref event = *raw.button();
@@ -440,10 +437,9 @@ impl Event {
                     Ok(window) => window,
                 };
 
-                Event::MouseButtonUp(event.timestamp, window,
-                                     event.which as usize,
+                Event::MouseButtonUp(event.timestamp, window, event.which,
                                      mouse::wrap_mouse(event.button),
-                                     event.x as isize, event.y as isize)
+                                     event.x, event.y)
             }
             EventType::MouseWheel => {
                 let ref event = *raw.wheel();
@@ -454,9 +450,8 @@ impl Event {
                     Ok(window) => window,
                 };
 
-                Event::MouseWheel(event.timestamp, window,
-                                  event.which as usize, event.x as isize,
-                                  event.y as isize)
+                Event::MouseWheel(event.timestamp, window, event.which,
+                                  event.x, event.y)
             }
 
             EventType::JoyAxisMotion => {

--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -158,27 +158,27 @@ pub enum Event {
     MouseWheel(u32, video::Window, u32, i32, i32),
 
     /// (timestamp, whichId, axisIdx, value)
-    JoyAxisMotion(u32, isize, isize, i16),
+    JoyAxisMotion(u32, i32, u8, i16),
     /// (timestamp, whichId, ballIdx, xrel, yrel)
-    JoyBallMotion(u32, isize, isize, i16, i16),
+    JoyBallMotion(u32, i32, u8, i16, i16),
     /// (timestamp, whichId, hatIdx, state)
-    JoyHatMotion(u32, isize, isize, HatState),
+    JoyHatMotion(u32, i32, u8, HatState),
     /// (timestamp, whichId, buttonIdx)
-    JoyButtonDown(u32, isize, isize),
-    JoyButtonUp(u32, isize, isize),
+    JoyButtonDown(u32, i32, u8),
+    JoyButtonUp(u32, i32, u8),
     /// (timestamp, whichId)
-    JoyDeviceAdded(u32, isize),
-    JoyDeviceRemoved(u32, isize),
+    JoyDeviceAdded(u32, i32),
+    JoyDeviceRemoved(u32, i32),
 
     /// (timestamp, whichId, axis, value)
-    ControllerAxisMotion(u32, isize, ControllerAxis, i16),
+    ControllerAxisMotion(u32, i32, ControllerAxis, i16),
     /// (timestamp, whichId, button)
-    ControllerButtonDown(u32, isize, ControllerButton),
-    ControllerButtonUp(u32, isize, ControllerButton),
+    ControllerButtonDown(u32, i32, ControllerButton),
+    ControllerButtonUp(u32, i32, ControllerButton),
     /// (timestamp, whichIdx)
-    ControllerDeviceAdded(u32, isize),
-    ControllerDeviceRemoved(u32, isize),
-    ControllerDeviceRemapped(u32, isize),
+    ControllerDeviceAdded(u32, i32),
+    ControllerDeviceRemoved(u32, i32),
+    ControllerDeviceRemapped(u32, i32),
 
     /// (timestamp, touchId, fingerId, x, y, dx, dy, pressure)
     FingerDown(u32, i64, i64, f64, f64, f64, f64, f64),
@@ -456,81 +456,66 @@ impl Event {
 
             EventType::JoyAxisMotion => {
                 let ref event = *raw.jaxis();
-                Event::JoyAxisMotion(event.timestamp,
-                                     event.which as isize, event.axis as isize,
-                                     event.value)
+                Event::JoyAxisMotion(event.timestamp, event.which,
+                                     event.axis, event.value)
             }
             EventType::JoyBallMotion => {
                 let ref event = *raw.jball();
-                Event::JoyBallMotion(event.timestamp,
-                                     event.which as isize, event.ball as isize,
-                                     event.xrel, event.yrel)
+                Event::JoyBallMotion(event.timestamp, event.which,
+                                     event.ball, event.xrel, event.yrel)
             }
             EventType::JoyHatMotion => {
                 let ref event = *raw.jhat();
-                Event::JoyHatMotion(event.timestamp,
-                                    event.which as isize, event.hat as isize,
+                Event::JoyHatMotion(event.timestamp, event.which, event.hat,
                                     joystick::HatState::from_bits(event.value).unwrap())
             }
             EventType::JoyButtonDown => {
                 let ref event = *raw.jbutton();
-                Event::JoyButtonDown(event.timestamp,
-                                     event.which as isize,
-                                     event.button as isize)
+                Event::JoyButtonDown(event.timestamp, event.which, event.button)
             }
             EventType::JoyButtonUp => {
                 let ref event = *raw.jbutton();
-                Event::JoyButtonUp(event.timestamp,
-                                   event.which as isize,
-                                   event.button as isize)
+                Event::JoyButtonUp(event.timestamp, event.which, event.button)
             }
             EventType::JoyDeviceAdded => {
                 let ref event = *raw.jdevice();
-                Event::JoyDeviceAdded(event.timestamp,
-                                      event.which as isize)
+                Event::JoyDeviceAdded(event.timestamp, event.which)
             }
             EventType::JoyDeviceRemoved => {
                 let ref event = *raw.jdevice();
-                Event::JoyDeviceRemoved(event.timestamp,
-                                        event.which as isize)
+                Event::JoyDeviceRemoved(event.timestamp, event.which)
             }
 
             EventType::ControllerAxisMotion => {
                 let ref event = *raw.caxis();
                 let axis = controller::wrap_controller_axis(event.axis);
 
-                Event::ControllerAxisMotion(event.timestamp,
-                                            event.which as isize, axis,
-                                            event.value)
+                Event::ControllerAxisMotion(event.timestamp, event.which,
+                                            axis, event.value)
             }
             EventType::ControllerButtonDown => {
                 let ref event = *raw.cbutton();
                 let button = controller::wrap_controller_button(event.button);
 
-                Event::ControllerButtonDown(event.timestamp,
-                                            event.which as isize, button)
+                Event::ControllerButtonDown(event.timestamp, event.which, button)
             }
             EventType::ControllerButtonUp => {
                 let ref event = *raw.cbutton();
                 let button = controller::wrap_controller_button(event.button);
 
-                Event::ControllerButtonUp(event.timestamp,
-                                          event.which as isize, button)
+                Event::ControllerButtonUp(event.timestamp, event.which, button)
             }
             EventType::ControllerDeviceAdded => {
                 let ref event = *raw.cdevice();
-                Event::ControllerDeviceAdded(event.timestamp,
-                                             event.which as isize)
+                Event::ControllerDeviceAdded(event.timestamp, event.which)
             }
             EventType::ControllerDeviceRemoved => {
                 let ref event = *raw.cdevice();
-                Event::ControllerDeviceRemoved(event.timestamp,
-                                               event.which as isize)
+                Event::ControllerDeviceRemoved(event.timestamp, event.which)
             }
             EventType::ControllerDeviceRemapped => {
                 let ref event = *raw.cdevice();
-                Event::ControllerDeviceRemapped(event.timestamp,
-                                                event.which as isize)
+                Event::ControllerDeviceRemapped(event.timestamp, event.which)
             }
 
             EventType::FingerDown => {

--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -198,7 +198,7 @@ pub enum Event {
     DropFile(u32, String),
 
     /// (timestamp, Window, type, code)
-    User(u32, video::Window, usize, isize),
+    User(u32, video::Window, u32, i32),
 }
 
 impl ::std::fmt::Show for Event {
@@ -597,8 +597,7 @@ impl Event {
                     Ok(window) => window,
                 };
 
-                Event::User(event.timestamp, window, raw_type as usize,
-                            event.code as isize)
+                Event::User(event.timestamp, window, raw_type, event.code)
             }
         }}                      // close unsafe & match
 

--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -129,77 +129,77 @@ pub enum Event {
     None,
 
     /// (timestamp)
-    Quit(usize),
-    AppTerminating(usize),
-    AppLowMemory(usize),
-    AppWillEnterBackground(usize),
-    AppDidEnterBackground(usize),
-    AppWillEnterForeground(usize),
-    AppDidEnterForeground(usize),
+    Quit(u32),
+    AppTerminating(u32),
+    AppLowMemory(u32),
+    AppWillEnterBackground(u32),
+    AppDidEnterBackground(u32),
+    AppWillEnterForeground(u32),
+    AppDidEnterForeground(u32),
 
     /// (timestamp, window, winEventId, data1, data2)
-    Window(usize, video::Window, WindowEventId, isize, isize),
+    Window(u32, video::Window, WindowEventId, isize, isize),
     // TODO: SysWMEvent
 
     /// (timestamp, window, keycode, scancode, keymod, repeat)
-    KeyDown(usize, video::Window, KeyCode, ScanCode, Mod, bool),
-    KeyUp(usize, video::Window, KeyCode, ScanCode, Mod, bool),
+    KeyDown(u32, video::Window, KeyCode, ScanCode, Mod, bool),
+    KeyUp(u32, video::Window, KeyCode, ScanCode, Mod, bool),
     /// (timestamp, window, text, start, length)
-    TextEditing(usize, video::Window, String, isize, isize),
+    TextEditing(u32, video::Window, String, isize, isize),
     /// (timestamp, window, text)
-    TextInput(usize, video::Window, String),
+    TextInput(u32, video::Window, String),
 
     /// (timestamp, window, which, [MouseState], x, y, xrel, yrel)
-    MouseMotion(usize, video::Window, usize, MouseState, isize, isize,
+    MouseMotion(u32, video::Window, usize, MouseState, isize, isize,
                      isize, isize),
     /// (timestamp, window, which, MouseBtn, x, y)
-    MouseButtonDown(usize, video::Window, usize, Mouse, isize, isize),
-    MouseButtonUp(usize, video::Window, usize, Mouse, isize, isize),
+    MouseButtonDown(u32, video::Window, usize, Mouse, isize, isize),
+    MouseButtonUp(u32, video::Window, usize, Mouse, isize, isize),
     /// (timestamp, window, whichId, x, y)
-    MouseWheel(usize, video::Window, usize, isize, isize),
+    MouseWheel(u32, video::Window, usize, isize, isize),
 
     /// (timestamp, whichId, axisIdx, value)
-    JoyAxisMotion(usize, isize, isize, i16),
+    JoyAxisMotion(u32, isize, isize, i16),
     /// (timestamp, whichId, ballIdx, xrel, yrel)
-    JoyBallMotion(usize, isize, isize, i16, i16),
+    JoyBallMotion(u32, isize, isize, i16, i16),
     /// (timestamp, whichId, hatIdx, state)
-    JoyHatMotion(usize, isize, isize, HatState),
+    JoyHatMotion(u32, isize, isize, HatState),
     /// (timestamp, whichId, buttonIdx)
-    JoyButtonDown(usize, isize, isize),
-    JoyButtonUp(usize, isize, isize),
+    JoyButtonDown(u32, isize, isize),
+    JoyButtonUp(u32, isize, isize),
     /// (timestamp, whichId)
-    JoyDeviceAdded(usize, isize),
-    JoyDeviceRemoved(usize, isize),
+    JoyDeviceAdded(u32, isize),
+    JoyDeviceRemoved(u32, isize),
 
     /// (timestamp, whichId, axis, value)
-    ControllerAxisMotion(usize, isize, ControllerAxis, i16),
+    ControllerAxisMotion(u32, isize, ControllerAxis, i16),
     /// (timestamp, whichId, button)
-    ControllerButtonDown(usize, isize, ControllerButton),
-    ControllerButtonUp(usize, isize, ControllerButton),
+    ControllerButtonDown(u32, isize, ControllerButton),
+    ControllerButtonUp(u32, isize, ControllerButton),
     /// (timestamp, whichIdx)
-    ControllerDeviceAdded(usize, isize),
-    ControllerDeviceRemoved(usize, isize),
-    ControllerDeviceRemapped(usize, isize),
+    ControllerDeviceAdded(u32, isize),
+    ControllerDeviceRemoved(u32, isize),
+    ControllerDeviceRemapped(u32, isize),
 
     /// (timestamp, touchId, fingerId, x, y, dx, dy, pressure)
-    FingerDown(usize, i64, i64, f64, f64, f64, f64, f64),
-    FingerUp(usize, i64, i64, f64, f64, f64, f64, f64),
-    FingerMotion(usize, i64, i64, f64, f64, f64, f64, f64),
+    FingerDown(u32, i64, i64, f64, f64, f64, f64, f64),
+    FingerUp(u32, i64, i64, f64, f64, f64, f64, f64),
+    FingerMotion(u32, i64, i64, f64, f64, f64, f64, f64),
 
     /// (timestamp, touchId, gestureId, numFingers, error, x, y)
-    DollarGesture(usize, i64, i64, usize, f64, f64, f64),
-    DollarRecord(usize, i64, i64, usize, f64, f64, f64),
+    DollarGesture(u32, i64, i64, usize, f64, f64, f64),
+    DollarRecord(u32, i64, i64, usize, f64, f64, f64),
     /// (timestamp, touchId, dTheta, dDist, x, y, numFingers)
-    MultiGesture(usize, i64, f64, f64, f64, f64, usize),
+    MultiGesture(u32, i64, f64, f64, f64, f64, usize),
 
     /// (timestamp)
-    ClipboardUpdate(usize),
+    ClipboardUpdate(u32),
 
     /// (timestamp, filename)
-    DropFile(usize, String),
+    DropFile(u32, String),
 
     /// (timestamp, Window, type, code)
-    User(usize, video::Window, usize, isize),
+    User(u32, video::Window, usize, isize),
 }
 
 impl ::std::fmt::Show for Event {
@@ -288,31 +288,31 @@ impl Event {
         unsafe { match event_type {
             EventType::Quit => {
                 let ref event = *raw.quit();
-                Event::Quit(event.timestamp as usize)
+                Event::Quit(event.timestamp)
             }
             EventType::AppTerminating => {
                 let ref event = *raw.common();
-                Event::AppTerminating(event.timestamp as usize)
+                Event::AppTerminating(event.timestamp)
             }
             EventType::AppLowMemory => {
                 let ref event = *raw.common();
-                Event::AppLowMemory(event.timestamp as usize)
+                Event::AppLowMemory(event.timestamp)
             }
             EventType::AppWillEnterBackground => {
                 let ref event = *raw.common();
-                Event::AppWillEnterBackground(event.timestamp as usize)
+                Event::AppWillEnterBackground(event.timestamp)
             }
             EventType::AppDidEnterBackground => {
                 let ref event = *raw.common();
-                Event::AppDidEnterBackground(event.timestamp as usize)
+                Event::AppDidEnterBackground(event.timestamp)
             }
             EventType::AppWillEnterForeground => {
                 let ref event = *raw.common();
-                Event::AppWillEnterForeground(event.timestamp as usize)
+                Event::AppWillEnterForeground(event.timestamp)
             }
             EventType::AppDidEnterForeground => {
                 let ref event = *raw.common();
-                Event::AppDidEnterForeground(event.timestamp as usize)
+                Event::AppDidEnterForeground(event.timestamp)
             }
 
             EventType::Window => {
@@ -324,7 +324,7 @@ impl Event {
                     Ok(window) => window,
                 };
 
-                Event::Window(event.timestamp as usize, window,
+                Event::Window(event.timestamp, window,
                               WindowEventId::from_ll(event.event),
                               event.data1 as isize, event.data2 as isize)
             }
@@ -339,7 +339,7 @@ impl Event {
                     Ok(window) => window,
                 };
 
-                Event::KeyDown(event.timestamp as usize, window,
+                Event::KeyDown(event.timestamp, window,
                                FromPrimitive::from_int(event.keysym.sym as isize)
                                   .unwrap_or(KeyCode::Unknown),
                                 FromPrimitive::from_int(event.keysym.scancode as isize)
@@ -356,7 +356,7 @@ impl Event {
                     Ok(window) => window,
                 };
 
-                Event::KeyUp(event.timestamp as usize, window,
+                Event::KeyUp(event.timestamp, window,
                              FromPrimitive::from_int(event.keysym.sym as isize)
                                .unwrap_or(KeyCode::Unknown),
                              FromPrimitive::from_int(event.keysym.scancode as isize)
@@ -380,7 +380,7 @@ impl Event {
                             .collect::<Vec<u8>>()
                             .as_slice()
                     ).to_owned().into_owned();
-                Event::TextEditing(event.timestamp as usize, window, text,
+                Event::TextEditing(event.timestamp, window, text,
                                    event.start as isize, event.length as isize)
             }
             EventType::TextInput => {
@@ -399,7 +399,7 @@ impl Event {
                             .collect::<Vec<u8>>()
                             .as_slice()
                     ).to_owned().into_owned();
-                Event::TextInput(event.timestamp as usize, window, text)
+                Event::TextInput(event.timestamp, window, text)
             }
 
             EventType::MouseMotion => {
@@ -411,7 +411,7 @@ impl Event {
                     Ok(window) => window,
                 };
 
-                Event::MouseMotion(event.timestamp as usize, window,
+                Event::MouseMotion(event.timestamp, window,
                                    event.which as usize,
                                    mouse::MouseState::from_bits(event.state).unwrap(),
                                    event.x as isize, event.y as isize,
@@ -426,7 +426,7 @@ impl Event {
                     Ok(window) => window,
                 };
 
-                Event::MouseButtonDown(event.timestamp as usize, window,
+                Event::MouseButtonDown(event.timestamp, window,
                                        event.which as usize,
                                        mouse::wrap_mouse(event.button),
                                        event.x as isize, event.y as isize)
@@ -440,7 +440,7 @@ impl Event {
                     Ok(window) => window,
                 };
 
-                Event::MouseButtonUp(event.timestamp as usize, window,
+                Event::MouseButtonUp(event.timestamp, window,
                                      event.which as usize,
                                      mouse::wrap_mouse(event.button),
                                      event.x as isize, event.y as isize)
@@ -454,49 +454,49 @@ impl Event {
                     Ok(window) => window,
                 };
 
-                Event::MouseWheel(event.timestamp as usize, window,
+                Event::MouseWheel(event.timestamp, window,
                                   event.which as usize, event.x as isize,
                                   event.y as isize)
             }
 
             EventType::JoyAxisMotion => {
                 let ref event = *raw.jaxis();
-                Event::JoyAxisMotion(event.timestamp as usize,
+                Event::JoyAxisMotion(event.timestamp,
                                      event.which as isize, event.axis as isize,
                                      event.value)
             }
             EventType::JoyBallMotion => {
                 let ref event = *raw.jball();
-                Event::JoyBallMotion(event.timestamp as usize,
+                Event::JoyBallMotion(event.timestamp,
                                      event.which as isize, event.ball as isize,
                                      event.xrel, event.yrel)
             }
             EventType::JoyHatMotion => {
                 let ref event = *raw.jhat();
-                Event::JoyHatMotion(event.timestamp as usize,
+                Event::JoyHatMotion(event.timestamp,
                                     event.which as isize, event.hat as isize,
                                     joystick::HatState::from_bits(event.value).unwrap())
             }
             EventType::JoyButtonDown => {
                 let ref event = *raw.jbutton();
-                Event::JoyButtonDown(event.timestamp as usize,
+                Event::JoyButtonDown(event.timestamp,
                                      event.which as isize,
                                      event.button as isize)
             }
             EventType::JoyButtonUp => {
                 let ref event = *raw.jbutton();
-                Event::JoyButtonUp(event.timestamp as usize,
+                Event::JoyButtonUp(event.timestamp,
                                    event.which as isize,
                                    event.button as isize)
             }
             EventType::JoyDeviceAdded => {
                 let ref event = *raw.jdevice();
-                Event::JoyDeviceAdded(event.timestamp as usize,
+                Event::JoyDeviceAdded(event.timestamp,
                                       event.which as isize)
             }
             EventType::JoyDeviceRemoved => {
                 let ref event = *raw.jdevice();
-                Event::JoyDeviceRemoved(event.timestamp as usize,
+                Event::JoyDeviceRemoved(event.timestamp,
                                         event.which as isize)
             }
 
@@ -504,7 +504,7 @@ impl Event {
                 let ref event = *raw.caxis();
                 let axis = controller::wrap_controller_axis(event.axis);
 
-                Event::ControllerAxisMotion(event.timestamp as usize,
+                Event::ControllerAxisMotion(event.timestamp,
                                             event.which as isize, axis,
                                             event.value)
             }
@@ -512,49 +512,49 @@ impl Event {
                 let ref event = *raw.cbutton();
                 let button = controller::wrap_controller_button(event.button);
 
-                Event::ControllerButtonDown(event.timestamp as usize,
+                Event::ControllerButtonDown(event.timestamp,
                                             event.which as isize, button)
             }
             EventType::ControllerButtonUp => {
                 let ref event = *raw.cbutton();
                 let button = controller::wrap_controller_button(event.button);
 
-                Event::ControllerButtonUp(event.timestamp as usize,
+                Event::ControllerButtonUp(event.timestamp,
                                           event.which as isize, button)
             }
             EventType::ControllerDeviceAdded => {
                 let ref event = *raw.cdevice();
-                Event::ControllerDeviceAdded(event.timestamp as usize,
+                Event::ControllerDeviceAdded(event.timestamp,
                                              event.which as isize)
             }
             EventType::ControllerDeviceRemoved => {
                 let ref event = *raw.cdevice();
-                Event::ControllerDeviceRemoved(event.timestamp as usize,
+                Event::ControllerDeviceRemoved(event.timestamp,
                                                event.which as isize)
             }
             EventType::ControllerDeviceRemapped => {
                 let ref event = *raw.cdevice();
-                Event::ControllerDeviceRemapped(event.timestamp as usize,
+                Event::ControllerDeviceRemapped(event.timestamp,
                                                 event.which as isize)
             }
 
             EventType::FingerDown => {
                 let ref event = *raw.tfinger();
-                Event::FingerDown(event.timestamp as usize, event.touchId as i64,
+                Event::FingerDown(event.timestamp, event.touchId as i64,
                                   event.fingerId as i64, event.x as f64,
                                   event.y as f64, event.dx as f64,
                                   event.dy as f64, event.pressure as f64)
             }
             EventType::FingerUp => {
                 let ref event = *raw.tfinger();
-                Event::FingerUp(event.timestamp as usize, event.touchId as i64,
+                Event::FingerUp(event.timestamp, event.touchId as i64,
                                 event.fingerId as i64, event.x as f64,
                                 event.y as f64, event.dx as f64,
                                 event.dy as f64, event.pressure as f64)
             }
             EventType::FingerMotion => {
                 let ref event = *raw.tfinger();
-                Event::FingerMotion(event.timestamp as usize,
+                Event::FingerMotion(event.timestamp,
                                     event.touchId as i64, event.fingerId as i64,
                                     event.x as f64, event.y as f64,
                                     event.dx as f64, event.dy as f64,
@@ -562,7 +562,7 @@ impl Event {
             }
             EventType::DollarGesture => {
                 let ref event = *raw.dgesture();
-                Event::DollarGesture(event.timestamp as usize,
+                Event::DollarGesture(event.timestamp,
                                      event.touchId as i64,
                                      event.gestureId as i64,
                                      event.numFingers as usize,
@@ -571,7 +571,7 @@ impl Event {
             }
             EventType::DollarRecord => {
                 let ref event = *raw.dgesture();
-                Event::DollarRecord(event.timestamp as usize,
+                Event::DollarRecord(event.timestamp,
                                     event.touchId as i64,
                                     event.gestureId as i64,
                                     event.numFingers as usize,
@@ -580,7 +580,7 @@ impl Event {
             }
             EventType::MultiGesture => {
                 let ref event = *raw.mgesture();
-                Event::MultiGesture(event.timestamp as usize,
+                Event::MultiGesture(event.timestamp,
                                     event.touchId as i64, event.dTheta as f64,
                                     event.dDist as f64, event.x as f64,
                                     event.y as f64, event.numFingers as usize)
@@ -588,7 +588,7 @@ impl Event {
 
             EventType::ClipboardUpdate => {
                 let ref event = *raw.common();
-                Event::ClipboardUpdate(event.timestamp as usize)
+                Event::ClipboardUpdate(event.timestamp)
             }
             EventType::DropFile => {
                 let ref event = *raw.drop();
@@ -597,7 +597,7 @@ impl Event {
                 let text = String::from_utf8_lossy(buf).to_string();
                 ll::SDL_free(event.file as *const c_void);
 
-                Event::DropFile(event.timestamp as usize, text)
+                Event::DropFile(event.timestamp, text)
             }
 
             EventType::First | EventType::Last => Event::None,
@@ -617,7 +617,7 @@ impl Event {
                     Ok(window) => window,
                 };
 
-                Event::User(event.timestamp as usize, window, raw_type as usize,
+                Event::User(event.timestamp, window, raw_type as usize,
                             event.code as isize)
             }
         }}                      // close unsafe & match

--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -138,7 +138,7 @@ pub enum Event {
     AppDidEnterForeground(u32),
 
     /// (timestamp, window, winEventId, data1, data2)
-    Window(u32, video::Window, WindowEventId, isize, isize),
+    Window(u32, video::Window, WindowEventId, i32, i32),
     // TODO: SysWMEvent
 
     /// (timestamp, window, keycode, scancode, keymod, repeat)
@@ -326,7 +326,7 @@ impl Event {
 
                 Event::Window(event.timestamp, window,
                               WindowEventId::from_ll(event.event),
-                              event.data1 as isize, event.data2 as isize)
+                              event.data1, event.data2)
             }
             // TODO: SysWMEventType
 

--- a/src/sdl2/keyboard.rs
+++ b/src/sdl2/keyboard.rs
@@ -42,11 +42,11 @@ pub fn get_keyboard_state() -> HashMap<ScanCode, bool> {
     let count = 0;
 
     let raw = unsafe { Vec::from_raw_buf(ll::SDL_GetKeyboardState(&count),
-                                          count as uint) };
+                                          count as usize) };
 
     let mut current = 0;
     while current < raw.len() {
-        state.insert(FromPrimitive::from_int(current as int)
+        state.insert(FromPrimitive::from_int(current as isize)
                         .unwrap_or(ScanCode::Unknown),
                      raw[current] == 1);
         current += 1;
@@ -65,14 +65,14 @@ pub fn set_mod_state(flags: Mod) {
 
 pub fn get_key_from_scancode(scancode: ScanCode) -> KeyCode {
     unsafe {
-        FromPrimitive::from_int(ll::SDL_GetKeyFromScancode(scancode as u32) as int)
+        FromPrimitive::from_int(ll::SDL_GetKeyFromScancode(scancode as u32) as isize)
             .unwrap_or(KeyCode::Unknown)
     }
 }
 
 pub fn get_scancode_from_key(key: KeyCode) -> ScanCode {
     unsafe {
-        FromPrimitive::from_int(ll::SDL_GetScancodeFromKey(key as i32) as int)
+        FromPrimitive::from_int(ll::SDL_GetScancodeFromKey(key as i32) as isize)
             .unwrap_or(ScanCode::Unknown)
     }
 }
@@ -87,7 +87,7 @@ pub fn get_scancode_name(scancode: ScanCode) -> String {
 pub fn get_scancode_from_name(name: &str) -> ScanCode {
     unsafe {
         let name = CString::from_slice(name.as_bytes()).as_ptr();
-        FromPrimitive::from_int(ll::SDL_GetScancodeFromName(name) as int)
+        FromPrimitive::from_int(ll::SDL_GetScancodeFromName(name) as isize)
             .unwrap_or(ScanCode::Unknown)
     }
 }
@@ -102,7 +102,7 @@ pub fn get_key_name(key: KeyCode) -> String {
 pub fn get_key_from_name(name: &str) -> KeyCode {
     unsafe {
         let name = CString::from_slice(name.as_bytes()).as_ptr();
-        FromPrimitive::from_int(ll::SDL_GetKeyFromName(name) as int)
+        FromPrimitive::from_int(ll::SDL_GetKeyFromName(name) as isize)
             .unwrap_or(KeyCode::Unknown)
     }
 }

--- a/src/sdl2/keycode.rs
+++ b/src/sdl2/keycode.rs
@@ -241,7 +241,7 @@ pub enum KeyCode {
     Sleep              = 1073742106,
 }
 
-impl<S: hash::Writer> Hash<S> for KeyCode {
+impl<S: hash::Hasher + hash::Writer> Hash<S> for KeyCode {
     #[inline]
     fn hash(&self, state: &mut S) {
         (*self as i32).hash(state);

--- a/src/sdl2/keycode.rs
+++ b/src/sdl2/keycode.rs
@@ -260,7 +260,7 @@ impl ToPrimitive for KeyCode {
     }
 
     #[inline]
-    fn to_int(&self) -> Option<int> {
-        Some(*self as int)
+    fn to_int(&self) -> Option<isize> {
+        Some(*self as isize)
     }
 }

--- a/src/sdl2/macros.rs
+++ b/src/sdl2/macros.rs
@@ -1,5 +1,5 @@
 macro_rules! impl_raw_accessors(
-    ($($t:ty, $raw:ty);+) => (
+    ($(($t:ty, $raw:ty)),+) => (
         $(
         impl $t {
             #[inline]
@@ -10,7 +10,7 @@ macro_rules! impl_raw_accessors(
 );
 
 macro_rules! impl_owned_accessors(
-    ($($t:ty, $owned:ident);+) => (
+    ($(($t:ty, $owned:ident)),+) => (
         $(
         impl $t {
             #[inline]
@@ -21,7 +21,7 @@ macro_rules! impl_owned_accessors(
 );
 
 macro_rules! impl_raw_constructor(
-    ($($t:ty -> $te:ident ($($r:ident:$rt:ty),+));+) => (
+    ($(($t:ty, $te:ident ($($r:ident:$rt:ty),+))),+) => (
         $(
         impl $t {
             #[inline]

--- a/src/sdl2/mouse.rs
+++ b/src/sdl2/mouse.rs
@@ -41,7 +41,7 @@ impl Drop for Cursor {
 }
 
 impl Cursor {
-    pub fn new(data: &[u8], mask: &[u8], width: int, height: int, hot_x: int, hot_y: int) -> SdlResult<Cursor> {
+    pub fn new(data: &[u8], mask: &[u8], width: isize, height: isize, hot_x: isize, hot_y: isize) -> SdlResult<Cursor> {
         unsafe {
             let raw = ll::SDL_CreateCursor(data.as_ptr(),
                                            mask.as_ptr(),
@@ -57,7 +57,7 @@ impl Cursor {
     }
 
     // TODO: figure out how to pass Surface in here correctly
-    pub fn from_surface(surface: &surface::Surface, hot_x: int, hot_y: int) -> SdlResult<Cursor> {
+    pub fn from_surface(surface: &surface::Surface, hot_x: isize, hot_y: isize) -> SdlResult<Cursor> {
         unsafe {
             let raw = ll::SDL_CreateColorCursor(surface.raw(), hot_x as i32,
                                                 hot_y as i32);
@@ -127,21 +127,21 @@ pub fn get_mouse_focus() -> Option<video::Window> {
     }
 }
 
-pub fn get_mouse_state() -> (MouseState, int, int) {
+pub fn get_mouse_state() -> (MouseState, isize, isize) {
     let x = 0;
     let y = 0;
     unsafe {
         let raw = ll::SDL_GetMouseState(&x, &y);
-        return (MouseState::from_bits(raw).unwrap(), x as int, y as int);
+        return (MouseState::from_bits(raw).unwrap(), x as isize, y as isize);
     }
 }
 
-pub fn get_relative_mouse_state() -> (MouseState, int, int) {
+pub fn get_relative_mouse_state() -> (MouseState, isize, isize) {
     let x = 0;
     let y = 0;
     unsafe {
         let raw = ll::SDL_GetRelativeMouseState(&x, &y);
-        return (MouseState::from_bits(raw).unwrap(), x as int, y as int);
+        return (MouseState::from_bits(raw).unwrap(), x as isize, y as isize);
     }
 }
 

--- a/src/sdl2/pixels.rs
+++ b/src/sdl2/pixels.rs
@@ -64,46 +64,46 @@ impl_raw_constructor!((PixelFormat, PixelFormat (raw: *const ll::SDL_PixelFormat
 
 #[derive(Copy, Clone, PartialEq, Show, FromPrimitive)]
 pub enum PixelFormatFlag {
-    Unknown = ll::SDL_PIXELFORMAT_UNKNOWN as int,
-    Index1LSB = ll::SDL_PIXELFORMAT_INDEX1LSB as int,
-    Index1MSB = ll::SDL_PIXELFORMAT_INDEX1MSB as int,
-    Index4LSB = ll::SDL_PIXELFORMAT_INDEX4LSB as int,
-    Index4MSB = ll::SDL_PIXELFORMAT_INDEX4MSB as int,
-    Index8 = ll::SDL_PIXELFORMAT_INDEX8 as int,
-    RGB332 = ll::SDL_PIXELFORMAT_RGB332 as int,
-    RGB444 = ll::SDL_PIXELFORMAT_RGB444 as int,
-    RGB555 = ll::SDL_PIXELFORMAT_RGB555 as int,
-    BGR555 = ll::SDL_PIXELFORMAT_BGR555 as int,
-    ARGB4444 = ll::SDL_PIXELFORMAT_ARGB4444 as int,
-    RGBA4444 = ll::SDL_PIXELFORMAT_RGBA4444 as int,
-    ABGR4444 = ll::SDL_PIXELFORMAT_ABGR4444 as int,
-    BGRA4444 = ll::SDL_PIXELFORMAT_BGRA4444 as int,
-    ARGB1555 = ll::SDL_PIXELFORMAT_ARGB1555 as int,
-    RGBA5551 = ll::SDL_PIXELFORMAT_RGBA5551 as int,
-    ABGR1555 = ll::SDL_PIXELFORMAT_ABGR1555 as int,
-    BGRA5551 = ll::SDL_PIXELFORMAT_BGRA5551 as int,
-    RGB565 = ll::SDL_PIXELFORMAT_RGB565 as int,
-    BGR565 = ll::SDL_PIXELFORMAT_BGR565 as int,
-    RGB24 = ll::SDL_PIXELFORMAT_RGB24 as int,
-    BGR24 = ll::SDL_PIXELFORMAT_BGR24 as int,
-    RGB888 = ll::SDL_PIXELFORMAT_RGB888 as int,
-    RGBX8888 = ll::SDL_PIXELFORMAT_RGBX8888 as int,
-    BGR888 = ll::SDL_PIXELFORMAT_BGR888 as int,
-    BGRX8888 = ll::SDL_PIXELFORMAT_BGRX8888 as int,
-    ARGB8888 = ll::SDL_PIXELFORMAT_ARGB8888 as int,
-    RGBA8888 = ll::SDL_PIXELFORMAT_RGBA8888 as int,
-    ABGR8888 = ll::SDL_PIXELFORMAT_ABGR8888 as int,
-    BGRA8888 = ll::SDL_PIXELFORMAT_BGRA8888 as int,
-    ARGB2101010 = ll::SDL_PIXELFORMAT_ARGB2101010 as int,
-    YV12 = ll::SDL_PIXELFORMAT_YV12 as int,
-    IYUV = ll::SDL_PIXELFORMAT_IYUV as int,
-    YUY2 = ll::SDL_PIXELFORMAT_YUY2 as int,
-    UYVY = ll::SDL_PIXELFORMAT_UYVY as int,
-    YVYU = ll::SDL_PIXELFORMAT_YVYU as int
+    Unknown = ll::SDL_PIXELFORMAT_UNKNOWN as isize,
+    Index1LSB = ll::SDL_PIXELFORMAT_INDEX1LSB as isize,
+    Index1MSB = ll::SDL_PIXELFORMAT_INDEX1MSB as isize,
+    Index4LSB = ll::SDL_PIXELFORMAT_INDEX4LSB as isize,
+    Index4MSB = ll::SDL_PIXELFORMAT_INDEX4MSB as isize,
+    Index8 = ll::SDL_PIXELFORMAT_INDEX8 as isize,
+    RGB332 = ll::SDL_PIXELFORMAT_RGB332 as isize,
+    RGB444 = ll::SDL_PIXELFORMAT_RGB444 as isize,
+    RGB555 = ll::SDL_PIXELFORMAT_RGB555 as isize,
+    BGR555 = ll::SDL_PIXELFORMAT_BGR555 as isize,
+    ARGB4444 = ll::SDL_PIXELFORMAT_ARGB4444 as isize,
+    RGBA4444 = ll::SDL_PIXELFORMAT_RGBA4444 as isize,
+    ABGR4444 = ll::SDL_PIXELFORMAT_ABGR4444 as isize,
+    BGRA4444 = ll::SDL_PIXELFORMAT_BGRA4444 as isize,
+    ARGB1555 = ll::SDL_PIXELFORMAT_ARGB1555 as isize,
+    RGBA5551 = ll::SDL_PIXELFORMAT_RGBA5551 as isize,
+    ABGR1555 = ll::SDL_PIXELFORMAT_ABGR1555 as isize,
+    BGRA5551 = ll::SDL_PIXELFORMAT_BGRA5551 as isize,
+    RGB565 = ll::SDL_PIXELFORMAT_RGB565 as isize,
+    BGR565 = ll::SDL_PIXELFORMAT_BGR565 as isize,
+    RGB24 = ll::SDL_PIXELFORMAT_RGB24 as isize,
+    BGR24 = ll::SDL_PIXELFORMAT_BGR24 as isize,
+    RGB888 = ll::SDL_PIXELFORMAT_RGB888 as isize,
+    RGBX8888 = ll::SDL_PIXELFORMAT_RGBX8888 as isize,
+    BGR888 = ll::SDL_PIXELFORMAT_BGR888 as isize,
+    BGRX8888 = ll::SDL_PIXELFORMAT_BGRX8888 as isize,
+    ARGB8888 = ll::SDL_PIXELFORMAT_ARGB8888 as isize,
+    RGBA8888 = ll::SDL_PIXELFORMAT_RGBA8888 as isize,
+    ABGR8888 = ll::SDL_PIXELFORMAT_ABGR8888 as isize,
+    BGRA8888 = ll::SDL_PIXELFORMAT_BGRA8888 as isize,
+    ARGB2101010 = ll::SDL_PIXELFORMAT_ARGB2101010 as isize,
+    YV12 = ll::SDL_PIXELFORMAT_YV12 as isize,
+    IYUV = ll::SDL_PIXELFORMAT_IYUV as isize,
+    YUY2 = ll::SDL_PIXELFORMAT_YUY2 as isize,
+    UYVY = ll::SDL_PIXELFORMAT_UYVY as isize,
+    YVYU = ll::SDL_PIXELFORMAT_YVYU as isize
 }
 
 impl PixelFormatFlag {
-    pub fn byte_size_of_pixels(&self, num_of_pixels: uint) -> uint {
+    pub fn byte_size_of_pixels(&self, num_of_pixels: usize) -> usize {
         match *self {
             PixelFormatFlag::RGB332
                 => num_of_pixels * 1,
@@ -140,7 +140,7 @@ impl PixelFormatFlag {
         }
     }
 
-    pub fn byte_size_per_pixel(&self) -> uint {
+    pub fn byte_size_per_pixel(&self) -> usize {
         match *self {
             PixelFormatFlag::RGB332
                 => 1,

--- a/src/sdl2/pixels.rs
+++ b/src/sdl2/pixels.rs
@@ -7,7 +7,7 @@ pub struct Palette {
     raw: *const ll::SDL_Palette
 }
 
-impl_raw_accessors!(Palette, *const ll::SDL_Palette);
+impl_raw_accessors!((Palette, *const ll::SDL_Palette));
 
 #[derive(PartialEq, Clone, Copy)]
 pub enum Color {
@@ -59,8 +59,8 @@ pub struct PixelFormat {
     raw: *const ll::SDL_PixelFormat
 }
 
-impl_raw_accessors!(PixelFormat, *const ll::SDL_PixelFormat);
-impl_raw_constructor!(PixelFormat -> PixelFormat (raw: *const ll::SDL_PixelFormat));
+impl_raw_accessors!((PixelFormat, *const ll::SDL_PixelFormat));
+impl_raw_constructor!((PixelFormat, PixelFormat (raw: *const ll::SDL_PixelFormat)));
 
 #[derive(Copy, Clone, PartialEq, Show, FromPrimitive)]
 pub enum PixelFormatFlag {
@@ -136,7 +136,7 @@ impl PixelFormatFlag {
             PixelFormatFlag::Unknown | PixelFormatFlag::Index1LSB |
             PixelFormatFlag::Index1MSB | PixelFormatFlag::Index4LSB |
             PixelFormatFlag::Index4MSB
-                => panic!("not supported format: {}", *self),
+                => panic!("not supported format: {:?}", *self),
         }
     }
 
@@ -172,7 +172,7 @@ impl PixelFormatFlag {
             PixelFormatFlag::Unknown | PixelFormatFlag::Index1LSB |
             PixelFormatFlag::Index1MSB | PixelFormatFlag::Index4LSB |
             PixelFormatFlag::Index4MSB
-                => panic!("not supported format: {}", *self),
+                => panic!("not supported format: {:?}", *self),
         }
     }
 }

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -21,14 +21,14 @@ pub use sys::render as ll;
 #[derive(Copy, Clone)]
 pub enum RenderDriverIndex {
     Auto,
-    Index(int)
+    Index(isize)
 }
 
 #[derive(Copy, Clone, PartialEq, FromPrimitive)]
 pub enum TextureAccess {
-    Static = ll::SDL_TEXTUREACCESS_STATIC as int,
-    Streaming = ll::SDL_TEXTUREACCESS_STREAMING as int,
-    Target = ll::SDL_TEXTUREACCESS_TARGET as int
+    Static = ll::SDL_TEXTUREACCESS_STATIC as isize,
+    Streaming = ll::SDL_TEXTUREACCESS_STREAMING as isize,
+    Target = ll::SDL_TEXTUREACCESS_TARGET as isize
 }
 
 bitflags! {
@@ -45,23 +45,23 @@ pub struct RendererInfo {
     pub name: String,
     pub flags: RendererFlags,
     pub texture_formats: Vec<pixels::PixelFormatFlag>,
-    pub max_texture_width: int,
-    pub max_texture_height: int
+    pub max_texture_width: isize,
+    pub max_texture_height: isize
 }
 
 #[derive(Copy, Clone, PartialEq, FromPrimitive)]
 pub enum BlendMode {
-    None = ll::SDL_BLENDMODE_NONE as int,
-    Blend = ll::SDL_BLENDMODE_BLEND as int,
-    Add = ll::SDL_BLENDMODE_ADD as int,
-    Mod = ll::SDL_BLENDMODE_MOD as int
+    None = ll::SDL_BLENDMODE_NONE as isize,
+    Blend = ll::SDL_BLENDMODE_BLEND as isize,
+    Add = ll::SDL_BLENDMODE_ADD as isize,
+    Mod = ll::SDL_BLENDMODE_MOD as isize
 }
 
 #[derive(Copy, Clone, PartialEq)]
 pub enum RendererFlip {
-    None = ll::SDL_FLIP_NONE as int,
-    Horizontal = ll::SDL_FLIP_HORIZONTAL as int,
-    Vertical = ll::SDL_FLIP_VERTICAL as int,
+    None = ll::SDL_FLIP_NONE as isize,
+    Horizontal = ll::SDL_FLIP_HORIZONTAL as isize,
+    Vertical = ll::SDL_FLIP_VERTICAL as isize,
 }
 
 impl RendererInfo {
@@ -69,7 +69,7 @@ impl RendererInfo {
         let actual_flags = RendererFlags::from_bits(info.flags).unwrap();
 
         unsafe {
-            let texture_formats: Vec<pixels::PixelFormatFlag> = info.texture_formats[0..(info.num_texture_formats as uint)].iter().map(|&format| {
+            let texture_formats: Vec<pixels::PixelFormatFlag> = info.texture_formats[0..(info.num_texture_formats as usize)].iter().map(|&format| {
                 FromPrimitive::from_i64(format as i64).unwrap()
             }).collect();
 
@@ -77,8 +77,8 @@ impl RendererInfo {
                 name: String::from_utf8_lossy(c_str_to_bytes(&info.name)).to_string(),
                 flags: actual_flags,
                 texture_formats: texture_formats,
-                max_texture_width: info.max_texture_width as int,
-                max_texture_height: info.max_texture_height as int
+                max_texture_width: info.max_texture_width as isize,
+                max_texture_height: info.max_texture_height as isize
             }
         }
     }
@@ -125,7 +125,7 @@ impl Renderer {
         }
     }
 
-    pub fn new_with_window(width: int, height: int, window_flags: video::WindowFlags) -> SdlResult<Renderer> {
+    pub fn new_with_window(width: isize, height: isize, window_flags: video::WindowFlags) -> SdlResult<Renderer> {
         let raw_window: *const video::ll::SDL_Window = ptr::null();
         let raw_renderer: *const ll::SDL_Renderer = ptr::null();
         let result = unsafe { ll::SDL_CreateWindowAndRenderer(width as c_int, height as c_int, window_flags.bits(), &raw_window, &raw_renderer) == 0};
@@ -205,20 +205,20 @@ impl Renderer {
         unsafe { ll::SDL_RenderPresent(self.raw) }
     }
 
-    pub fn get_output_size(&self) -> SdlResult<(int, int)> {
+    pub fn get_output_size(&self) -> SdlResult<(isize, isize)> {
         let width: c_int = 0;
         let height: c_int = 0;
 
         let result = unsafe { ll::SDL_GetRendererOutputSize(self.raw, &width, &height) == 0 };
 
         if result {
-            Ok((width as int, height as int))
+            Ok((width as isize, height as isize))
         } else {
             Err(get_error())
         }
     }
 
-    pub fn create_texture(&self, format: pixels::PixelFormatFlag, access: TextureAccess, width: int, height: int) -> SdlResult<Texture> {
+    pub fn create_texture(&self, format: pixels::PixelFormatFlag, access: TextureAccess, width: isize, height: isize) -> SdlResult<Texture> {
         let result = unsafe { ll::SDL_CreateTexture(self.raw, format as uint32_t, access as c_int, width as c_int, height as c_int) };
         if result == ptr::null() {
             Err(get_error())
@@ -267,21 +267,21 @@ impl Renderer {
         }
     }
 
-    pub fn set_logical_size(&self, width: int, height: int) -> SdlResult<()> {
+    pub fn set_logical_size(&self, width: isize, height: isize) -> SdlResult<()> {
         let ret = unsafe { ll::SDL_RenderSetLogicalSize(self.raw, width as c_int, height as c_int) };
 
         if ret == 0 { Ok(()) }
         else { Err(get_error()) }
     }
 
-    pub fn get_logical_size(&self) -> (int, int) {
+    pub fn get_logical_size(&self) -> (isize, isize) {
 
         let width: c_int = 0;
         let height: c_int = 0;
 
         unsafe { ll::SDL_RenderGetLogicalSize(self.raw, &width, &height) };
 
-        (width as int, height as int)
+        (width as isize, height as isize)
     }
 
     pub fn set_viewport(&self, rect: Option<Rect>) -> SdlResult<()> {
@@ -460,10 +460,10 @@ impl Renderer {
     pub fn read_pixels(&self, rect: Option<Rect>, format: pixels::PixelFormatFlag) -> SdlResult<Vec<u8>> {
         unsafe {
             let (actual_rect, w, h) = match rect {
-                Some(ref rect) => (rect as *const _, rect.w as uint, rect.h as uint),
+                Some(ref rect) => (rect as *const _, rect.w as usize, rect.h as usize),
                 None => {
                     let (w, h) = try!(self.get_output_size());
-                    (ptr::null(), w as uint, h as uint)
+                    (ptr::null(), w as usize, h as usize)
                 }
             };
             
@@ -492,8 +492,8 @@ impl Renderer {
 pub struct TextureQuery {
     pub format: pixels::PixelFormatFlag,
     pub access: TextureAccess,
-    pub width: int,
-    pub height: int
+    pub width: isize,
+    pub height: isize
 }
 
 #[derive(PartialEq)] #[allow(raw_pointer_derive)]
@@ -525,8 +525,8 @@ impl Texture {
             Ok(TextureQuery {
                format: FromPrimitive::from_i64(format as i64).unwrap(),
                access: FromPrimitive::from_i64(access as i64).unwrap(),
-               width: width as int,
-               height: height as int
+               width: width as isize,
+               height: height as isize
             })
         } else {
             Err(get_error())
@@ -588,7 +588,7 @@ impl Texture {
         }
     }
 
-    pub fn update(&self, rect: Option<Rect>, pixel_data: &[u8], pitch: int) -> SdlResult<()> {
+    pub fn update(&self, rect: Option<Rect>, pixel_data: &[u8], pitch: isize) -> SdlResult<()> {
         let ret = unsafe {
             let actual_rect = match rect {
                 Some(ref rect) => rect as *const _,
@@ -608,7 +608,7 @@ impl Texture {
             let q = try!(self.query());
             let pixels : *const c_void = ptr::null();
             let pitch = 0i32;
-            let size = q.format.byte_size_of_pixels((q.width * q.height) as uint);
+            let size = q.format.byte_size_of_pixels((q.width * q.height) as usize);
         
             let actual_rect = match rect {
                 Some(ref rect) => rect as *const _,
@@ -669,16 +669,16 @@ impl Texture {
 }
 
 
-pub fn get_num_render_drivers() -> SdlResult<int> {
+pub fn get_num_render_drivers() -> SdlResult<isize> {
     let result = unsafe { ll::SDL_GetNumRenderDrivers() };
     if result > 0 {
-        Ok(result as int)
+        Ok(result as isize)
     } else {
         Err(get_error())
     }
 }
 
-pub fn get_render_driver_info(index: int) -> SdlResult<RendererInfo> {
+pub fn get_render_driver_info(index: isize) -> SdlResult<RendererInfo> {
     let out = ll::SDL_RendererInfo {
         name: ptr::null(),
         flags: 0,

--- a/src/sdl2/rwops.rs
+++ b/src/sdl2/rwops.rs
@@ -36,9 +36,9 @@ impl RWops {
         else { Ok(RWops{raw: raw, close_on_drop: false}) }
     }
 
-    pub fn len(&self) -> uint {
+    pub fn len(&self) -> usize {
         unsafe {
-            ((*self.raw).size)(self.raw) as uint
+            ((*self.raw).size)(self.raw) as usize
         }
     }
 }
@@ -56,7 +56,7 @@ impl Drop for RWops {
 }
 
 impl Reader for RWops {
-    fn read(&mut self, buf: &mut [u8]) -> IoResult<uint> {
+    fn read(&mut self, buf: &mut [u8]) -> IoResult<usize> {
         let out_len = buf.len() as size_t;
         // FIXME: it's better to use as_mut_ptr().
         // number of objects read, or 0 at error or end of file.
@@ -66,7 +66,7 @@ impl Reader for RWops {
         if ret == 0 {
             Err(io::standard_error(io::EndOfFile))
         } else {
-            Ok(ret as uint)
+            Ok(ret as usize)
         }
     }
 }

--- a/src/sdl2/rwops.rs
+++ b/src/sdl2/rwops.rs
@@ -13,8 +13,8 @@ pub struct RWops {
     close_on_drop: bool
 }
 
-impl_raw_accessors!(RWops, *const ll::SDL_RWops);
-impl_owned_accessors!(RWops, close_on_drop);
+impl_raw_accessors!((RWops, *const ll::SDL_RWops));
+impl_owned_accessors!((RWops, close_on_drop));
 
 /// A structure that provides an abstract interface to stream I/O.
 impl RWops {

--- a/src/sdl2/scancode.rs
+++ b/src/sdl2/scancode.rs
@@ -266,7 +266,7 @@ impl ToPrimitive for ScanCode {
     }
 
     #[inline]
-    fn to_int(&self) -> Option<int> {
-        Some(*self as int)
+    fn to_int(&self) -> Option<isize> {
+        Some(*self as isize)
     }
 }

--- a/src/sdl2/scancode.rs
+++ b/src/sdl2/scancode.rs
@@ -247,7 +247,7 @@ pub enum ScanCode {
     Num                = 512,
 }
 
-impl<S: hash::Writer> Hash<S> for ScanCode {
+impl<S: hash::Hasher + hash::Writer> Hash<S> for ScanCode {
     #[inline]
     fn hash(&self, state: &mut S) {
         (*self as i32).hash(state);

--- a/src/sdl2/sdl.rs
+++ b/src/sdl2/sdl.rs
@@ -18,11 +18,11 @@ bitflags! {
 
 #[derive(Copy, Clone, PartialEq)]
 pub enum Error {
-    NoMemError = ll::SDL_ENOMEM as int,
-    ReadError = ll::SDL_EFREAD as int,
-    WriteError = ll::SDL_EFWRITE as int,
-    SeekError = ll::SDL_EFSEEK as int,
-    UnsupportedError = ll::SDL_UNSUPPORTED as int
+    NoMemError = ll::SDL_ENOMEM as isize,
+    ReadError = ll::SDL_EFREAD as isize,
+    WriteError = ll::SDL_EFWRITE as isize,
+    SeekError = ll::SDL_EFSEEK as isize,
+    UnsupportedError = ll::SDL_UNSUPPORTED as isize
 }
 
 pub type SdlResult<T> = Result<T, String>;

--- a/src/sdl2/surface.rs
+++ b/src/sdl2/surface.rs
@@ -37,9 +37,9 @@ impl Drop for Surface {
     }
 }
 
-impl_raw_accessors!(Surface, *const ll::SDL_Surface);
-impl_owned_accessors!(Surface, owned);
-impl_raw_constructor!(Surface -> Surface (raw: *const ll::SDL_Surface, owned: bool));
+impl_raw_accessors!((Surface, *const ll::SDL_Surface));
+impl_owned_accessors!((Surface, owned));
+impl_raw_constructor!((Surface, Surface (raw: *const ll::SDL_Surface, owned: bool)));
 
 impl Surface {
     pub fn new(surface_flags: SurfaceFlag, width: int, height: int, bpp: int,

--- a/src/sdl2/surface.rs
+++ b/src/sdl2/surface.rs
@@ -42,7 +42,7 @@ impl_owned_accessors!((Surface, owned));
 impl_raw_constructor!((Surface, Surface (raw: *const ll::SDL_Surface, owned: bool)));
 
 impl Surface {
-    pub fn new(surface_flags: SurfaceFlag, width: int, height: int, bpp: int,
+    pub fn new(surface_flags: SurfaceFlag, width: isize, height: isize, bpp: isize,
                rmask: u32, gmask: u32, bmask: u32, amask: u32) -> SdlResult<Surface> {
         unsafe {
             let raw = ll::SDL_CreateRGBSurface(surface_flags.bits(), width as c_int, height as c_int, bpp as c_int,
@@ -56,7 +56,7 @@ impl Surface {
         }
     }
 
-    pub fn from_data(data: &mut [u8], width: int, height: int, bpp: int, pitch: int,
+    pub fn from_data(data: &mut [u8], width: isize, height: isize, bpp: isize, pitch: isize,
                      rmask: u32, gmask: u32, bmask: u32, amask: u32) -> SdlResult<Surface> {
 
         unsafe {
@@ -72,19 +72,19 @@ impl Surface {
         }
     }
 
-    pub fn get_width(&self) -> int {
-        unsafe { (*self.raw).w as int }
+    pub fn get_width(&self) -> isize {
+        unsafe { (*self.raw).w as isize }
     }
 
-    pub fn get_height(&self) -> int {
-        unsafe { (*self.raw).h as int }
+    pub fn get_height(&self) -> isize {
+        unsafe { (*self.raw).h as isize }
     }
 
-    pub fn get_pitch(&self) -> int {
-        unsafe { (*self.raw).pitch as int }
+    pub fn get_pitch(&self) -> isize {
+        unsafe { (*self.raw).pitch as isize }
     }
 
-    pub fn get_size(&self) -> (int, int) {
+    pub fn get_size(&self) -> (isize, isize) {
         (self.get_width(), self.get_height())
     }
 
@@ -113,7 +113,7 @@ impl Surface {
             if ll::SDL_LockSurface(self.raw) != 0 { panic!("could not lock surface"); }
 
             let raw_pixels = (*self.raw).pixels as *mut _;
-            let len = (*self.raw).pitch as uint * ((*self.raw).h as uint);
+            let len = (*self.raw).pitch as usize * ((*self.raw).h as usize);
             let pixels = ::std::slice::from_raw_mut_buf(&raw_pixels, len);
             let rv = f(pixels);
             ll::SDL_UnlockSurface(self.raw);
@@ -271,7 +271,7 @@ impl Surface {
 
     pub fn set_blend_mode(&mut self, mode: BlendMode) -> SdlResult<()> {
         let result = unsafe {
-            ll::SDL_SetSurfaceBlendMode(self.raw, FromPrimitive::from_int(mode as int).unwrap())
+            ll::SDL_SetSurfaceBlendMode(self.raw, FromPrimitive::from_int(mode as isize).unwrap())
         };
 
         match result {
@@ -287,7 +287,7 @@ impl Surface {
         };
 
         match result {
-            0 => Ok(FromPrimitive::from_int(mode as int).unwrap()),
+            0 => Ok(FromPrimitive::from_int(mode as isize).unwrap()),
             _ => Err(get_error())
         }
     }

--- a/src/sdl2/timer.rs
+++ b/src/sdl2/timer.rs
@@ -2,8 +2,8 @@ use libc::{uint32_t, c_void};
 
 pub use sys::timer as ll;
 
-pub fn get_ticks() -> uint {
-    unsafe { ll::SDL_GetTicks() as uint }
+pub fn get_ticks() -> usize {
+    unsafe { ll::SDL_GetTicks() as usize }
 }
 
 pub fn get_performance_counter() -> u64 {
@@ -14,14 +14,14 @@ pub fn get_performance_frequency() -> u64 {
     unsafe { ll::SDL_GetPerformanceFrequency() }
 }
 
-pub fn delay(ms: uint) {
+pub fn delay(ms: usize) {
     unsafe { ll::SDL_Delay(ms as u32) }
 }
 
 pub type TimerCallback = extern "C" fn (interval: uint32_t, param: *const c_void) -> u32;
 
 pub struct Timer {
-    delay: uint,
+    delay: usize,
     raw: ll::SDL_TimerID,
     callback: TimerCallback,
     param: *const c_void,
@@ -29,7 +29,7 @@ pub struct Timer {
 }
 
 impl Timer {
-    pub fn new(delay: uint, callback: TimerCallback, param: *const c_void, remove_on_drop: bool) -> Timer {
+    pub fn new(delay: usize, callback: TimerCallback, param: *const c_void, remove_on_drop: bool) -> Timer {
         Timer { delay: delay, raw: 0, callback: callback, param: param, remove_on_drop: remove_on_drop }
     }
 

--- a/src/sdl2/touch.rs
+++ b/src/sdl2/touch.rs
@@ -5,19 +5,19 @@ pub use sys::touch as ll;
 pub type Finger = ll::Finger;
 pub type TouchDevice = ll::TouchDevice;
 
-pub fn get_num_touch_devices() -> int {
-    unsafe { ll::SDL_GetNumTouchDevices() as int }
+pub fn get_num_touch_devices() -> isize {
+    unsafe { ll::SDL_GetNumTouchDevices() as isize }
 }
 
-pub fn get_touch_device(index: int) -> TouchDevice {
+pub fn get_touch_device(index: isize) -> TouchDevice {
     unsafe { ll::SDL_GetTouchDevice(index as i32) }
 }
 
-pub fn get_num_touch_fingers(touch: TouchDevice) -> int {
-    unsafe { ll::SDL_GetNumTouchFingers(touch) as int }
+pub fn get_num_touch_fingers(touch: TouchDevice) -> isize {
+    unsafe { ll::SDL_GetNumTouchFingers(touch) as isize }
 }
 
-pub fn get_touch_finger(touch: TouchDevice, index: int) -> Option<Finger> {
+pub fn get_touch_finger(touch: TouchDevice, index: isize) -> Option<Finger> {
     let raw = unsafe { ll::SDL_GetTouchFinger(touch, index as i32) };
 
     if raw == ptr::null() {

--- a/src/sdl2/version.rs
+++ b/src/sdl2/version.rs
@@ -11,11 +11,11 @@ pub use sys::version as ll;
 #[derive(PartialEq, Copy, Clone)]
 pub struct Version {
     /// major version
-    pub major: int,
+    pub major: isize,
     /// minor version
-    pub minor: int,
+    pub minor: isize,
     /// update version (patchlevel)
-    pub patch: int,
+    pub patch: isize,
 }
 
 impl Version {
@@ -23,7 +23,7 @@ impl Version {
     pub fn from_ll(sv: *const ll::SDL_version) -> Version {
         unsafe {
             let ref v = *sv;
-            Version{ major: v.major as int, minor: v.minor as int, patch: v.patch as int }
+            Version{ major: v.major as isize, minor: v.minor as isize, patch: v.patch as isize }
         }
     }
 }
@@ -52,8 +52,8 @@ pub fn get_revision() -> String {
 }
 
 /// Get the revision number of SDL that is linked against your program.
-pub fn get_revision_number() -> int {
+pub fn get_revision_number() -> isize {
     unsafe {
-        ll::SDL_GetRevisionNumber() as int
+        ll::SDL_GetRevisionNumber() as isize
     }
 }

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -164,17 +164,17 @@ pub struct Window {
 }
 
 impl_raw_accessors!(
-    GLContext, ll::SDL_GLContext;
-    Window, *const ll::SDL_Window
+    (GLContext, ll::SDL_GLContext),
+    (Window, *const ll::SDL_Window)
 );
 
 impl_owned_accessors!(
-    GLContext, owned;
-    Window, owned
+    (GLContext, owned),
+    (Window, owned)
 );
 
 impl_raw_constructor!(
-    Window -> Window (raw: *const ll::SDL_Window, owned: bool)
+    (Window, Window (raw: *const ll::SDL_Window, owned: bool))
 );
 
 impl Drop for Window {

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -63,14 +63,14 @@ fn empty_sdl_display_mode() -> ll::SDL_DisplayMode {
 #[derive(Clone, PartialEq)]
 pub struct DisplayMode {
     pub format: u32,
-    pub w: int,
-    pub h: int,
-    pub refresh_rate: int
+    pub w: isize,
+    pub h: isize,
+    pub refresh_rate: isize
 }
 
 impl DisplayMode {
 
-    pub fn new(format: u32, w: int, h: int, refresh_rate: int) -> DisplayMode {
+    pub fn new(format: u32, w: isize, h: isize, refresh_rate: isize) -> DisplayMode {
         DisplayMode {
             format: format,
             w: w,
@@ -82,9 +82,9 @@ impl DisplayMode {
     pub fn from_ll(raw: &ll::SDL_DisplayMode) -> DisplayMode {
         DisplayMode::new(
             raw.format as u32,
-            raw.w as int,
-            raw.h as int,
-            raw.refresh_rate as int
+            raw.w as isize,
+            raw.h as isize,
+            raw.refresh_rate as isize
         )
     }
 
@@ -129,7 +129,7 @@ pub enum FullscreenType {
 pub enum WindowPos {
     PosUndefined,
     PosCentered,
-    Positioned(int)
+    Positioned(isize)
 }
 
 fn unwrap_windowpos (pos: WindowPos) -> ll::SDL_WindowPos {
@@ -188,7 +188,7 @@ impl Drop for Window {
 }
 
 impl Window {
-    pub fn new(title: &str, x: WindowPos, y: WindowPos, width: int, height: int, window_flags: WindowFlags) -> SdlResult<Window> {
+    pub fn new(title: &str, x: WindowPos, y: WindowPos, width: isize, height: isize, window_flags: WindowFlags) -> SdlResult<Window> {
         unsafe {
             let buff = CString::from_slice(title.as_bytes()).as_ptr();
             let raw = ll::SDL_CreateWindow(
@@ -217,12 +217,12 @@ impl Window {
         }
     }
 
-    pub fn get_display_index(&self) -> SdlResult<int> {
+    pub fn get_display_index(&self) -> SdlResult<isize> {
         let result = unsafe { ll::SDL_GetWindowDisplayIndex(self.raw) };
         if result < 0 {
             return Err(get_error())
         } else {
-            Ok(result as int)
+            Ok(result as isize)
         }
     }
 
@@ -293,51 +293,51 @@ impl Window {
         unsafe { ll::SDL_SetWindowPosition(self.raw, unwrap_windowpos(x), unwrap_windowpos(y)) }
     }
 
-    pub fn get_position(&self) -> (int, int) {
+    pub fn get_position(&self) -> (isize, isize) {
         let x: c_int = 0;
         let y: c_int = 0;
         unsafe { ll::SDL_GetWindowPosition(self.raw, &x, &y) };
-        (x as int, y as int)
+        (x as isize, y as isize)
     }
 
-    pub fn set_size(&self, w: int, h: int) {
+    pub fn set_size(&self, w: isize, h: isize) {
         unsafe { ll::SDL_SetWindowSize(self.raw, w as c_int, h as c_int) }
     }
 
-    pub fn get_size(&self) -> (int, int) {
+    pub fn get_size(&self) -> (isize, isize) {
         let w: c_int = 0;
         let h: c_int = 0;
         unsafe { ll::SDL_GetWindowSize(self.raw, &w, &h) };
-        (w as int, h as int)
+        (w as isize, h as isize)
     }
 
-    pub fn get_drawable_size(&self) -> (int, int) {
+    pub fn get_drawable_size(&self) -> (isize, isize) {
         let w: c_int = 0;
         let h: c_int = 0;
         unsafe { ll::SDL_GL_GetDrawableSize(self.raw, &w, &h) };
-        (w as int, h as int)
+        (w as isize, h as isize)
     }
 
-    pub fn set_minimum_size(&self, w: int, h: int) {
+    pub fn set_minimum_size(&self, w: isize, h: isize) {
         unsafe { ll::SDL_SetWindowMinimumSize(self.raw, w as c_int, h as c_int) }
     }
 
-    pub fn get_minimum_size(&self) -> (int, int) {
+    pub fn get_minimum_size(&self) -> (isize, isize) {
         let w: c_int = 0;
         let h: c_int = 0;
         unsafe { ll::SDL_GetWindowMinimumSize(self.raw, &w, &h) };
-        (w as int, h as int)
+        (w as isize, h as isize)
     }
 
-    pub fn set_maximum_size(&self, w: int, h: int) {
+    pub fn set_maximum_size(&self, w: isize, h: isize) {
         unsafe { ll::SDL_SetWindowMaximumSize(self.raw, w as c_int, h as c_int) }
     }
 
-    pub fn get_maximum_size(&self) -> (int, int) {
+    pub fn get_maximum_size(&self) -> (isize, isize) {
         let w: c_int = 0;
         let h: c_int = 0;
         unsafe { ll::SDL_GetWindowMaximumSize(self.raw, &w, &h) };
-        (w as int, h as int)
+        (w as isize, h as isize)
     }
 
     pub fn set_bordered(&self, bordered: bool) {
@@ -454,16 +454,16 @@ impl Window {
     }
 }
 
-pub fn get_num_video_drivers() -> SdlResult<int> {
+pub fn get_num_video_drivers() -> SdlResult<isize> {
     let result = unsafe { ll::SDL_GetNumVideoDrivers() };
     if result < 0 {
         Err(get_error())
     } else {
-        Ok(result as int)
+        Ok(result as isize)
     }
 }
 
-pub fn get_video_driver(id: int) -> String {
+pub fn get_video_driver(id: isize) -> String {
     unsafe {
         let buf = ll::SDL_GetVideoDriver(id as c_int);
         String::from_utf8_lossy(c_str_to_bytes(&buf)).to_string()
@@ -486,23 +486,23 @@ pub fn get_current_video_driver() -> String {
     }
 }
 
-pub fn get_num_video_displays() -> SdlResult<int> {
+pub fn get_num_video_displays() -> SdlResult<isize> {
     let result = unsafe { ll::SDL_GetNumVideoDisplays() };
     if result < 0 {
         Err(get_error())
     } else {
-        Ok(result as int)
+        Ok(result as isize)
     }
 }
 
-pub fn get_display_name(display_index: int) -> String {
+pub fn get_display_name(display_index: isize) -> String {
     unsafe {
         let display = ll::SDL_GetDisplayName(display_index as c_int);
         String::from_utf8_lossy(c_str_to_bytes(&display)).to_string()
     }
 }
 
-pub fn get_display_bounds(display_index: int) -> SdlResult<Rect> {
+pub fn get_display_bounds(display_index: isize) -> SdlResult<Rect> {
     let out: Rect = Rect::new(0, 0, 0, 0);
     let result = unsafe { ll::SDL_GetDisplayBounds(display_index as c_int, &out) == 0 };
 
@@ -513,16 +513,16 @@ pub fn get_display_bounds(display_index: int) -> SdlResult<Rect> {
     }
 }
 
-pub fn get_num_display_modes(display_index: int) -> SdlResult<int> {
+pub fn get_num_display_modes(display_index: isize) -> SdlResult<isize> {
     let result = unsafe { ll::SDL_GetNumDisplayModes(display_index as c_int) };
     if result < 0 {
         Err(get_error())
     } else {
-        Ok(result as int)
+        Ok(result as isize)
     }
 }
 
-pub fn get_display_mode(display_index: int, mode_index: int) -> SdlResult<DisplayMode> {
+pub fn get_display_mode(display_index: isize, mode_index: isize) -> SdlResult<DisplayMode> {
     let dm = empty_sdl_display_mode();
     let result = unsafe { ll::SDL_GetDisplayMode(display_index as c_int, mode_index as c_int, &dm) == 0};
 
@@ -533,7 +533,7 @@ pub fn get_display_mode(display_index: int, mode_index: int) -> SdlResult<Displa
     }
 }
 
-pub fn get_desktop_display_mode(display_index: int) -> SdlResult<DisplayMode> {
+pub fn get_desktop_display_mode(display_index: isize) -> SdlResult<DisplayMode> {
     let dm = empty_sdl_display_mode();
     let result = unsafe { ll::SDL_GetDesktopDisplayMode(display_index as c_int, &dm) == 0};
 
@@ -544,7 +544,7 @@ pub fn get_desktop_display_mode(display_index: int) -> SdlResult<DisplayMode> {
     }
 }
 
-pub fn get_current_display_mode(display_index: int) -> SdlResult<DisplayMode> {
+pub fn get_current_display_mode(display_index: isize) -> SdlResult<DisplayMode> {
     let dm = empty_sdl_display_mode();
     let result = unsafe { ll::SDL_GetCurrentDisplayMode(display_index as c_int, &dm) == 0};
 
@@ -555,7 +555,7 @@ pub fn get_current_display_mode(display_index: int) -> SdlResult<DisplayMode> {
     }
 }
 
-pub fn get_closest_display_mode(display_index: int, mode: &DisplayMode) -> SdlResult<DisplayMode> {
+pub fn get_closest_display_mode(display_index: isize, mode: &DisplayMode) -> SdlResult<DisplayMode> {
     let input = mode.to_ll();
     let out = empty_sdl_display_mode();
 
@@ -608,16 +608,16 @@ pub fn gl_extension_supported(extension: &str) -> bool {
     unsafe { ll::SDL_GL_ExtensionSupported(buff) == 1 }
 }
 
-pub fn gl_set_attribute(attr: GLAttr, value: int) -> bool {
+pub fn gl_set_attribute(attr: GLAttr, value: isize) -> bool {
     unsafe { ll::SDL_GL_SetAttribute(FromPrimitive::from_u64(attr as u64).unwrap(), value as c_int) == 0 }
 }
 
-pub fn gl_get_attribute(attr: GLAttr) -> SdlResult<int> {
+pub fn gl_get_attribute(attr: GLAttr) -> SdlResult<isize> {
     let out: c_int = 0;
 
     let result = unsafe { ll::SDL_GL_GetAttribute(FromPrimitive::from_u64(attr as u64).unwrap(), &out) } == 0;
     if result {
-        Ok(out as int)
+        Ok(out as isize)
     } else {
         Err(get_error())
     }
@@ -641,10 +641,10 @@ pub fn gl_get_current_context() -> SdlResult<GLContext> {
     }
 }
 
-pub fn gl_set_swap_interval(interval: int) -> bool {
+pub fn gl_set_swap_interval(interval: isize) -> bool {
     unsafe { ll::SDL_GL_SetSwapInterval(interval as c_int) == 0 }
 }
 
-pub fn gl_get_swap_interval() -> int {
-    unsafe { ll::SDL_GL_GetSwapInterval() as int }
+pub fn gl_get_swap_interval() -> isize {
+    unsafe { ll::SDL_GL_GetSwapInterval() as isize }
 }


### PR DESCRIPTION
After the recent int / uint debacle and rename to isize and usize, I was wondering why their use is so prevalent in rust-sdl2. As far as I can tell they should not be used as a general purpose integer type in Rust.

This pull request changes the integer types used in events to match the definitions found in SDL_event.h. There is much less casting involved after this change. This will likely break a lot of code, but the recent int -> isize transition also breaks the same code, so I felt this would be a good opportunity for this change.

I also noticed that touch and gesture events use f64 where SDL2 uses f32. This implies greater accuracy than SDL2 provides, so I changed those back to f32, but I'm not sure if this is the right way to go -- those commits can be easily dropped if needed.

I assume you will want to pull jpernst's recent 1.0 alpha fixes, so I based this branch on top of those commits.