### PR TITLE
Add pkgconfig feature to sdl2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,8 @@ path       = "src/sdl2/lib.rs"
 
 path = "sdl2-sys"
 version = "0.0.16"
+
+[features]
+
+default = []
+use-pkgconfig = [ "sdl2-sys/use-pkgconfig" ]


### PR DESCRIPTION
This allows a package with sdl2 as its dependency to build with pkgconfig by selecting the feature use-pkgconfig of sdl2.
At this moment you cannot select features of dependencies, so otherwise the feature would be useless unless building sdl2 directly.