### PR TITLE
Correct integer types

### DIFF
--- a/src/sdl2/cpuinfo.rs
+++ b/src/sdl2/cpuinfo.rs
@@ -1,13 +1,13 @@
 pub use sys::cpuinfo as ll;
 
-pub const CACHELINESIZE: isize = 128;
+pub const CACHELINESIZE: u8 = 128;
 
-pub fn get_cpu_count() -> isize {
-    unsafe { ll::SDL_GetCPUCount() as isize }
+pub fn get_cpu_count() -> i32 {
+    unsafe { ll::SDL_GetCPUCount() }
 }
 
-pub fn get_cpu_cache_line_size() -> isize {
-    unsafe { ll::SDL_GetCPUCacheLineSize() as isize}
+pub fn get_cpu_cache_line_size() -> i32 {
+    unsafe { ll::SDL_GetCPUCacheLineSize() }
 }
 
 pub fn has_rdtsc() -> bool {
@@ -50,6 +50,6 @@ pub fn has_avx() -> bool {
     unsafe { ll::SDL_HasAVX() == 1 }
 }
 
-pub fn get_system_ram() -> isize {
-    unsafe { ll::SDL_GetSystemRAM() as isize }
+pub fn get_system_ram() -> i32 {
+    unsafe { ll::SDL_GetSystemRAM() }
 }

--- a/src/sdl2/timer.rs
+++ b/src/sdl2/timer.rs
@@ -2,8 +2,8 @@ use libc::{uint32_t, c_void};
 
 pub use sys::timer as ll;
 
-pub fn get_ticks() -> usize {
-    unsafe { ll::SDL_GetTicks() as usize }
+pub fn get_ticks() -> u32 {
+    unsafe { ll::SDL_GetTicks() }
 }
 
 pub fn get_performance_counter() -> u64 {
@@ -14,8 +14,8 @@ pub fn get_performance_frequency() -> u64 {
     unsafe { ll::SDL_GetPerformanceFrequency() }
 }
 
-pub fn delay(ms: usize) {
-    unsafe { ll::SDL_Delay(ms as u32) }
+pub fn delay(ms: u32) {
+    unsafe { ll::SDL_Delay(ms) }
 }
 
 pub type TimerCallback = extern "C" fn (interval: uint32_t, param: *const c_void) -> u32;

--- a/src/sdl2/touch.rs
+++ b/src/sdl2/touch.rs
@@ -5,20 +5,20 @@ pub use sys::touch as ll;
 pub type Finger = ll::Finger;
 pub type TouchDevice = ll::TouchDevice;
 
-pub fn get_num_touch_devices() -> isize {
-    unsafe { ll::SDL_GetNumTouchDevices() as isize }
+pub fn get_num_touch_devices() -> i32 {
+    unsafe { ll::SDL_GetNumTouchDevices() }
 }
 
-pub fn get_touch_device(index: isize) -> TouchDevice {
-    unsafe { ll::SDL_GetTouchDevice(index as i32) }
+pub fn get_touch_device(index: i32) -> TouchDevice {
+    unsafe { ll::SDL_GetTouchDevice(index) }
 }
 
-pub fn get_num_touch_fingers(touch: TouchDevice) -> isize {
-    unsafe { ll::SDL_GetNumTouchFingers(touch) as isize }
+pub fn get_num_touch_fingers(touch: TouchDevice) -> i32 {
+    unsafe { ll::SDL_GetNumTouchFingers(touch) }
 }
 
-pub fn get_touch_finger(touch: TouchDevice, index: isize) -> Option<Finger> {
-    let raw = unsafe { ll::SDL_GetTouchFinger(touch, index as i32) };
+pub fn get_touch_finger(touch: TouchDevice, index: i32) -> Option<Finger> {
+    let raw = unsafe { ll::SDL_GetTouchFinger(touch, index) };
 
     if raw == ptr::null() {
         None

--- a/src/sdl2/version.rs
+++ b/src/sdl2/version.rs
@@ -11,11 +11,11 @@ pub use sys::version as ll;
 #[derive(PartialEq, Copy, Clone)]
 pub struct Version {
     /// major version
-    pub major: isize,
+    pub major: u8,
     /// minor version
-    pub minor: isize,
+    pub minor: u8,
     /// update version (patchlevel)
-    pub patch: isize,
+    pub patch: u8,
 }
 
 impl Version {
@@ -23,7 +23,7 @@ impl Version {
     pub fn from_ll(sv: *const ll::SDL_version) -> Version {
         unsafe {
             let ref v = *sv;
-            Version{ major: v.major as isize, minor: v.minor as isize, patch: v.patch as isize }
+            Version{ major: v.major, minor: v.minor, patch: v.patch }
         }
     }
 }
@@ -52,8 +52,8 @@ pub fn get_revision() -> String {
 }
 
 /// Get the revision number of SDL that is linked against your program.
-pub fn get_revision_number() -> isize {
+pub fn get_revision_number() -> i32 {
     unsafe {
-        ll::SDL_GetRevisionNumber() as isize
+        ll::SDL_GetRevisionNumber()
     }
 }


### PR DESCRIPTION
Clean up a few more files using `isize` and `usize` in error.

This came up in #283. These were low-hanging fruit, there is still more to be done before #283 is fixed.
