### PR TITLE
Allow specifying the "samples" field in AudioSpec desired.

### DIFF
--- a/examples/audio-whitenoise.rs
+++ b/examples/audio-whitenoise.rs
@@ -23,6 +23,7 @@ fn main() {
     let desired_spec = AudioSpecDesired {
         freq: 44100,
         channels: 1,
+        samples: 0,
         callback: MyCallback { volume: 0.5 }
     };
 

--- a/src/sdl2/audio.rs
+++ b/src/sdl2/audio.rs
@@ -207,11 +207,12 @@ extern "C" fn audio_callback_marshall<T: AudioFormatNum<T>, CB: AudioCallback<T>
 pub struct AudioSpecDesired<T: AudioFormatNum<T>, CB: AudioCallback<T>> {
     pub freq: i32,
     pub channels: u8,
+    pub samples: u16,
     pub callback: CB
 }
 
 impl<T: AudioFormatNum<T>, CB: AudioCallback<T>> AudioSpecDesired<T, CB> {
-    fn convert_to_ll(freq: i32, channels: u8, userdata: &mut AudioCallbackUserdata<CB>) -> ll::SDL_AudioSpec {
+    fn convert_to_ll(freq: i32, channels: u8, samples: u16, userdata: &mut AudioCallbackUserdata<CB>) -> ll::SDL_AudioSpec {
         use std::mem::transmute;
 
         let format_num: T = AudioFormatNum::zero();
@@ -222,7 +223,7 @@ impl<T: AudioFormatNum<T>, CB: AudioCallback<T>> AudioSpecDesired<T, CB> {
                 format: format_num.get_audio_format(),
                 channels: channels,
                 silence: 0,
-                samples: 0,
+                samples: samples,
                 padding: 0,
                 size: 0,
                 callback: Some(audio_callback_marshall::<T, CB>
@@ -249,7 +250,7 @@ impl<T: AudioFormatNum<T>, CB: AudioCallback<T>> AudioSpecDesired<T, CB> {
         use libc::c_char;
 
         let mut userdata = AudioSpecDesired::callback_to_userdata(self.callback);
-        let desired = AudioSpecDesired::convert_to_ll(self.freq, self.channels, &mut *userdata);
+        let desired = AudioSpecDesired::convert_to_ll(self.freq, self.channels, self.samples, &mut *userdata);
 
         let mut obtained = unsafe { uninitialized::<ll::SDL_AudioSpec>() };
         unsafe {


### PR DESCRIPTION
Fixes issue #286 

This will break all current uses of AudioSpec. People who don't care
about this value can just set it to 0. Otherwise it must be a power of
2 (per the SDL docs).