### PR TITLE
Audit isize

### DIFF
--- a/sdl2-sys/src/render.rs
+++ b/sdl2-sys/src/render.rs
@@ -52,7 +52,7 @@ pub struct SDL_Renderer;
 pub struct SDL_Texture;
 
 //SDL_blendmode.h
-pub type SDL_BlendMode = c_uint;
+pub type SDL_BlendMode = c_int;
 pub const SDL_BLENDMODE_NONE : SDL_BlendMode = 0x00000000;
 pub const SDL_BLENDMODE_BLEND : SDL_BlendMode = 0x00000001;
 pub const SDL_BLENDMODE_ADD : SDL_BlendMode = 0x00000002;

--- a/src/sdl2/audio.rs
+++ b/src/sdl2/audio.rs
@@ -40,22 +40,22 @@ pub enum AudioStatus {
     Paused  = ll::SDL_AUDIO_PAUSED  as isize,
 }
 
-pub fn get_num_audio_drivers() -> isize {
-    unsafe { ll::SDL_GetNumAudioDrivers() as isize }
+pub fn get_num_audio_drivers() -> i32 {
+    unsafe { ll::SDL_GetNumAudioDrivers() as i32 }
 }
 
-pub fn get_audio_driver(index: isize) -> String {
+pub fn get_audio_driver(index: i32) -> String {
     unsafe {
         let driver = ll::SDL_GetAudioDriver(index as c_int);
         String::from_utf8_lossy(c_str_to_bytes(&driver)).to_string()
     }
 }
 
-pub fn get_num_audio_devices(iscapture: isize) -> isize {
-    unsafe { ll::SDL_GetNumAudioDevices(iscapture as c_int) as isize }
+pub fn get_num_audio_devices(iscapture: i32) -> i32 {
+    unsafe { ll::SDL_GetNumAudioDevices(iscapture as c_int) as i32 }
 }
 
-pub fn get_audio_device_name(index: isize, iscapture: isize) -> String {
+pub fn get_audio_device_name(index: i32, iscapture: i32) -> String {
     unsafe {
         let dev_name = ll::SDL_GetAudioDeviceName(index as c_int, iscapture as c_int);
         String::from_utf8_lossy(c_str_to_bytes(&dev_name)).to_string()
@@ -345,7 +345,7 @@ impl<CB> AudioDevice<CB> {
     pub fn get_status(&self) -> AudioStatus {
         unsafe {
             let status = ll::SDL_GetAudioDeviceStatus(self.device_id.id());
-            FromPrimitive::from_int(status as isize).unwrap()
+            FromPrimitive::from_i32(status as i32).unwrap()
         }
     }
 

--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -648,7 +648,7 @@ pub fn wait_event() -> SdlResult<Event> {
 }
 
 /// Wait until the specified timeout (in milliseconds) for the next available event.
-pub fn wait_event_timeout(timeout: isize) -> SdlResult<Event> {
+pub fn wait_event_timeout(timeout: i32) -> SdlResult<Event> {
     let raw = null_event();
     let success = unsafe { ll::SDL_WaitEventTimeout(&raw, timeout as c_int) ==
                            1 as c_int };
@@ -700,12 +700,12 @@ pub fn get_event_state(_type: EventType) -> bool {
 }
 
 /// allocate a set of user-defined events, and return the beginning event number for that set of events
-pub fn register_events(num: isize) -> Option<usize> {
-    let ret = unsafe { ll::SDL_RegisterEvents(num as c_int) };
+pub fn register_events(num_events: i32) -> Option<u32> {
+    let ret = unsafe { ll::SDL_RegisterEvents(num_events as c_int) };
     if ret == (-1 as uint32_t) {
         None
     } else {
-        Some(ret as usize)
+        Some(ret as u32)
     }
 }
 

--- a/src/sdl2/mouse.rs
+++ b/src/sdl2/mouse.rs
@@ -41,7 +41,7 @@ impl Drop for Cursor {
 }
 
 impl Cursor {
-    pub fn new(data: &[u8], mask: &[u8], width: isize, height: isize, hot_x: isize, hot_y: isize) -> SdlResult<Cursor> {
+    pub fn new(data: &[u8], mask: &[u8], width: i32, height: i32, hot_x: i32, hot_y: i32) -> SdlResult<Cursor> {
         unsafe {
             let raw = ll::SDL_CreateCursor(data.as_ptr(),
                                            mask.as_ptr(),
@@ -57,10 +57,9 @@ impl Cursor {
     }
 
     // TODO: figure out how to pass Surface in here correctly
-    pub fn from_surface(surface: &surface::Surface, hot_x: isize, hot_y: isize) -> SdlResult<Cursor> {
+    pub fn from_surface(surface: &surface::Surface, hot_x: i32, hot_y: i32) -> SdlResult<Cursor> {
         unsafe {
-            let raw = ll::SDL_CreateColorCursor(surface.raw(), hot_x as i32,
-                                                hot_y as i32);
+            let raw = ll::SDL_CreateColorCursor(surface.raw(), hot_x, hot_y);
 
             if raw == ptr::null() {
                 Err(get_error())
@@ -127,21 +126,21 @@ pub fn get_mouse_focus() -> Option<video::Window> {
     }
 }
 
-pub fn get_mouse_state() -> (MouseState, isize, isize) {
+pub fn get_mouse_state() -> (MouseState, i32, i32) {
     let x = 0;
     let y = 0;
     unsafe {
         let raw = ll::SDL_GetMouseState(&x, &y);
-        return (MouseState::from_bits(raw).unwrap(), x as isize, y as isize);
+        return (MouseState::from_bits(raw).unwrap(), x as i32, y as i32);
     }
 }
 
-pub fn get_relative_mouse_state() -> (MouseState, isize, isize) {
+pub fn get_relative_mouse_state() -> (MouseState, i32, i32) {
     let x = 0;
     let y = 0;
     unsafe {
         let raw = ll::SDL_GetRelativeMouseState(&x, &y);
-        return (MouseState::from_bits(raw).unwrap(), x as isize, y as isize);
+        return (MouseState::from_bits(raw).unwrap(), x as i32, y as i32);
     }
 }
 

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -21,7 +21,7 @@ pub use sys::render as ll;
 #[derive(Copy, Clone)]
 pub enum RenderDriverIndex {
     Auto,
-    Index(isize)
+    Index(i32)
 }
 
 #[derive(Copy, Clone, PartialEq, FromPrimitive)]
@@ -45,8 +45,8 @@ pub struct RendererInfo {
     pub name: String,
     pub flags: RendererFlags,
     pub texture_formats: Vec<pixels::PixelFormatFlag>,
-    pub max_texture_width: isize,
-    pub max_texture_height: isize
+    pub max_texture_width: i32,
+    pub max_texture_height: i32
 }
 
 #[derive(Copy, Clone, PartialEq, FromPrimitive)]
@@ -77,8 +77,8 @@ impl RendererInfo {
                 name: String::from_utf8_lossy(c_str_to_bytes(&info.name)).to_string(),
                 flags: actual_flags,
                 texture_formats: texture_formats,
-                max_texture_width: info.max_texture_width as isize,
-                max_texture_height: info.max_texture_height as isize
+                max_texture_width: info.max_texture_width as i32,
+                max_texture_height: info.max_texture_height as i32
             }
         }
     }
@@ -125,7 +125,7 @@ impl Renderer {
         }
     }
 
-    pub fn new_with_window(width: isize, height: isize, window_flags: video::WindowFlags) -> SdlResult<Renderer> {
+    pub fn new_with_window(width: i32, height: i32, window_flags: video::WindowFlags) -> SdlResult<Renderer> {
         let raw_window: *const video::ll::SDL_Window = ptr::null();
         let raw_renderer: *const ll::SDL_Renderer = ptr::null();
         let result = unsafe { ll::SDL_CreateWindowAndRenderer(width as c_int, height as c_int, window_flags.bits(), &raw_window, &raw_renderer) == 0};
@@ -205,20 +205,20 @@ impl Renderer {
         unsafe { ll::SDL_RenderPresent(self.raw) }
     }
 
-    pub fn get_output_size(&self) -> SdlResult<(isize, isize)> {
+    pub fn get_output_size(&self) -> SdlResult<(i32, i32)> {
         let width: c_int = 0;
         let height: c_int = 0;
 
         let result = unsafe { ll::SDL_GetRendererOutputSize(self.raw, &width, &height) == 0 };
 
         if result {
-            Ok((width as isize, height as isize))
+            Ok((width as i32, height as i32))
         } else {
             Err(get_error())
         }
     }
 
-    pub fn create_texture(&self, format: pixels::PixelFormatFlag, access: TextureAccess, width: isize, height: isize) -> SdlResult<Texture> {
+    pub fn create_texture(&self, format: pixels::PixelFormatFlag, access: TextureAccess, width: i32, height: i32) -> SdlResult<Texture> {
         let result = unsafe { ll::SDL_CreateTexture(self.raw, format as uint32_t, access as c_int, width as c_int, height as c_int) };
         if result == ptr::null() {
             Err(get_error())
@@ -267,21 +267,21 @@ impl Renderer {
         }
     }
 
-    pub fn set_logical_size(&self, width: isize, height: isize) -> SdlResult<()> {
+    pub fn set_logical_size(&self, width: i32, height: i32) -> SdlResult<()> {
         let ret = unsafe { ll::SDL_RenderSetLogicalSize(self.raw, width as c_int, height as c_int) };
 
         if ret == 0 { Ok(()) }
         else { Err(get_error()) }
     }
 
-    pub fn get_logical_size(&self) -> (isize, isize) {
+    pub fn get_logical_size(&self) -> (i32, i32) {
 
         let width: c_int = 0;
         let height: c_int = 0;
 
         unsafe { ll::SDL_RenderGetLogicalSize(self.raw, &width, &height) };
 
-        (width as isize, height as isize)
+        (width as i32, height as i32)
     }
 
     pub fn set_viewport(&self, rect: Option<Rect>) -> SdlResult<()> {
@@ -492,8 +492,8 @@ impl Renderer {
 pub struct TextureQuery {
     pub format: pixels::PixelFormatFlag,
     pub access: TextureAccess,
-    pub width: isize,
-    pub height: isize
+    pub width: i32,
+    pub height: i32
 }
 
 #[derive(PartialEq)] #[allow(raw_pointer_derive)]
@@ -525,8 +525,8 @@ impl Texture {
             Ok(TextureQuery {
                format: FromPrimitive::from_i64(format as i64).unwrap(),
                access: FromPrimitive::from_i64(access as i64).unwrap(),
-               width: width as isize,
-               height: height as isize
+               width: width as i32,
+               height: height as i32
             })
         } else {
             Err(get_error())
@@ -588,7 +588,7 @@ impl Texture {
         }
     }
 
-    pub fn update(&self, rect: Option<Rect>, pixel_data: &[u8], pitch: isize) -> SdlResult<()> {
+    pub fn update(&self, rect: Option<Rect>, pixel_data: &[u8], pitch: i32) -> SdlResult<()> {
         let ret = unsafe {
             let actual_rect = match rect {
                 Some(ref rect) => rect as *const _,
@@ -669,16 +669,16 @@ impl Texture {
 }
 
 
-pub fn get_num_render_drivers() -> SdlResult<isize> {
+pub fn get_num_render_drivers() -> SdlResult<i32> {
     let result = unsafe { ll::SDL_GetNumRenderDrivers() };
     if result > 0 {
-        Ok(result as isize)
+        Ok(result as i32)
     } else {
         Err(get_error())
     }
 }
 
-pub fn get_render_driver_info(index: isize) -> SdlResult<RendererInfo> {
+pub fn get_render_driver_info(index: i32) -> SdlResult<RendererInfo> {
     let out = ll::SDL_RendererInfo {
         name: ptr::null(),
         flags: 0,

--- a/src/sdl2/surface.rs
+++ b/src/sdl2/surface.rs
@@ -42,7 +42,7 @@ impl_owned_accessors!((Surface, owned));
 impl_raw_constructor!((Surface, Surface (raw: *const ll::SDL_Surface, owned: bool)));
 
 impl Surface {
-    pub fn new(surface_flags: SurfaceFlag, width: isize, height: isize, bpp: isize,
+    pub fn new(surface_flags: SurfaceFlag, width: i32, height: i32, bpp: i32,
                rmask: u32, gmask: u32, bmask: u32, amask: u32) -> SdlResult<Surface> {
         unsafe {
             let raw = ll::SDL_CreateRGBSurface(surface_flags.bits(), width as c_int, height as c_int, bpp as c_int,
@@ -56,7 +56,7 @@ impl Surface {
         }
     }
 
-    pub fn from_data(data: &mut [u8], width: isize, height: isize, bpp: isize, pitch: isize,
+    pub fn from_data(data: &mut [u8], width: i32, height: i32, bpp: i32, pitch: i32,
                      rmask: u32, gmask: u32, bmask: u32, amask: u32) -> SdlResult<Surface> {
 
         unsafe {
@@ -72,19 +72,19 @@ impl Surface {
         }
     }
 
-    pub fn get_width(&self) -> isize {
-        unsafe { (*self.raw).w as isize }
+    pub fn get_width(&self) -> i32 {
+        unsafe { (*self.raw).w as i32 }
     }
 
-    pub fn get_height(&self) -> isize {
-        unsafe { (*self.raw).h as isize }
+    pub fn get_height(&self) -> i32 {
+        unsafe { (*self.raw).h as i32 }
     }
 
-    pub fn get_pitch(&self) -> isize {
-        unsafe { (*self.raw).pitch as isize }
+    pub fn get_pitch(&self) -> i32 {
+        unsafe { (*self.raw).pitch as i32 }
     }
 
-    pub fn get_size(&self) -> (isize, isize) {
+    pub fn get_size(&self) -> (i32, i32) {
         (self.get_width(), self.get_height())
     }
 
@@ -271,7 +271,7 @@ impl Surface {
 
     pub fn set_blend_mode(&mut self, mode: BlendMode) -> SdlResult<()> {
         let result = unsafe {
-            ll::SDL_SetSurfaceBlendMode(self.raw, FromPrimitive::from_int(mode as isize).unwrap())
+            ll::SDL_SetSurfaceBlendMode(self.raw, mode as c_int)
         };
 
         match result {
@@ -281,13 +281,13 @@ impl Surface {
     }
 
     pub fn get_blend_mode(&self) -> SdlResult<BlendMode> {
-        let mode: ll::SDL_BlendMode = FromPrimitive::from_int(0).unwrap();
+        let mode: ll::SDL_BlendMode = 0;
         let result = unsafe {
             ll::SDL_GetSurfaceBlendMode(self.raw, &mode)
         };
 
         match result {
-            0 => Ok(FromPrimitive::from_int(mode as isize).unwrap()),
+            0 => Ok(FromPrimitive::from_i32(mode as i32).unwrap()),
             _ => Err(get_error())
         }
     }

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -63,14 +63,14 @@ fn empty_sdl_display_mode() -> ll::SDL_DisplayMode {
 #[derive(Clone, PartialEq)]
 pub struct DisplayMode {
     pub format: u32,
-    pub w: isize,
-    pub h: isize,
-    pub refresh_rate: isize
+    pub w: i32,
+    pub h: i32,
+    pub refresh_rate: i32
 }
 
 impl DisplayMode {
 
-    pub fn new(format: u32, w: isize, h: isize, refresh_rate: isize) -> DisplayMode {
+    pub fn new(format: u32, w: i32, h: i32, refresh_rate: i32) -> DisplayMode {
         DisplayMode {
             format: format,
             w: w,
@@ -82,9 +82,9 @@ impl DisplayMode {
     pub fn from_ll(raw: &ll::SDL_DisplayMode) -> DisplayMode {
         DisplayMode::new(
             raw.format as u32,
-            raw.w as isize,
-            raw.h as isize,
-            raw.refresh_rate as isize
+            raw.w as i32,
+            raw.h as i32,
+            raw.refresh_rate as i32
         )
     }
 
@@ -129,7 +129,7 @@ pub enum FullscreenType {
 pub enum WindowPos {
     PosUndefined,
     PosCentered,
-    Positioned(isize)
+    Positioned(i32)
 }
 
 fn unwrap_windowpos (pos: WindowPos) -> ll::SDL_WindowPos {
@@ -188,7 +188,7 @@ impl Drop for Window {
 }
 
 impl Window {
-    pub fn new(title: &str, x: WindowPos, y: WindowPos, width: isize, height: isize, window_flags: WindowFlags) -> SdlResult<Window> {
+    pub fn new(title: &str, x: WindowPos, y: WindowPos, width: i32, height: i32, window_flags: WindowFlags) -> SdlResult<Window> {
         unsafe {
             let buff = CString::from_slice(title.as_bytes()).as_ptr();
             let raw = ll::SDL_CreateWindow(
@@ -217,12 +217,12 @@ impl Window {
         }
     }
 
-    pub fn get_display_index(&self) -> SdlResult<isize> {
+    pub fn get_display_index(&self) -> SdlResult<i32> {
         let result = unsafe { ll::SDL_GetWindowDisplayIndex(self.raw) };
         if result < 0 {
             return Err(get_error())
         } else {
-            Ok(result as isize)
+            Ok(result as i32)
         }
     }
 
@@ -293,51 +293,51 @@ impl Window {
         unsafe { ll::SDL_SetWindowPosition(self.raw, unwrap_windowpos(x), unwrap_windowpos(y)) }
     }
 
-    pub fn get_position(&self) -> (isize, isize) {
+    pub fn get_position(&self) -> (i32, i32) {
         let x: c_int = 0;
         let y: c_int = 0;
         unsafe { ll::SDL_GetWindowPosition(self.raw, &x, &y) };
-        (x as isize, y as isize)
+        (x as i32, y as i32)
     }
 
-    pub fn set_size(&self, w: isize, h: isize) {
+    pub fn set_size(&self, w: i32, h: i32) {
         unsafe { ll::SDL_SetWindowSize(self.raw, w as c_int, h as c_int) }
     }
 
-    pub fn get_size(&self) -> (isize, isize) {
+    pub fn get_size(&self) -> (i32, i32) {
         let w: c_int = 0;
         let h: c_int = 0;
         unsafe { ll::SDL_GetWindowSize(self.raw, &w, &h) };
-        (w as isize, h as isize)
+        (w as i32, h as i32)
     }
 
-    pub fn get_drawable_size(&self) -> (isize, isize) {
+    pub fn get_drawable_size(&self) -> (i32, i32) {
         let w: c_int = 0;
         let h: c_int = 0;
         unsafe { ll::SDL_GL_GetDrawableSize(self.raw, &w, &h) };
-        (w as isize, h as isize)
+        (w as i32, h as i32)
     }
 
-    pub fn set_minimum_size(&self, w: isize, h: isize) {
+    pub fn set_minimum_size(&self, w: i32, h: i32) {
         unsafe { ll::SDL_SetWindowMinimumSize(self.raw, w as c_int, h as c_int) }
     }
 
-    pub fn get_minimum_size(&self) -> (isize, isize) {
+    pub fn get_minimum_size(&self) -> (i32, i32) {
         let w: c_int = 0;
         let h: c_int = 0;
         unsafe { ll::SDL_GetWindowMinimumSize(self.raw, &w, &h) };
-        (w as isize, h as isize)
+        (w as i32, h as i32)
     }
 
-    pub fn set_maximum_size(&self, w: isize, h: isize) {
+    pub fn set_maximum_size(&self, w: i32, h: i32) {
         unsafe { ll::SDL_SetWindowMaximumSize(self.raw, w as c_int, h as c_int) }
     }
 
-    pub fn get_maximum_size(&self) -> (isize, isize) {
+    pub fn get_maximum_size(&self) -> (i32, i32) {
         let w: c_int = 0;
         let h: c_int = 0;
         unsafe { ll::SDL_GetWindowMaximumSize(self.raw, &w, &h) };
-        (w as isize, h as isize)
+        (w as i32, h as i32)
     }
 
     pub fn set_bordered(&self, bordered: bool) {
@@ -454,16 +454,16 @@ impl Window {
     }
 }
 
-pub fn get_num_video_drivers() -> SdlResult<isize> {
+pub fn get_num_video_drivers() -> SdlResult<i32> {
     let result = unsafe { ll::SDL_GetNumVideoDrivers() };
     if result < 0 {
         Err(get_error())
     } else {
-        Ok(result as isize)
+        Ok(result as i32)
     }
 }
 
-pub fn get_video_driver(id: isize) -> String {
+pub fn get_video_driver(id: i32) -> String {
     unsafe {
         let buf = ll::SDL_GetVideoDriver(id as c_int);
         String::from_utf8_lossy(c_str_to_bytes(&buf)).to_string()
@@ -486,23 +486,23 @@ pub fn get_current_video_driver() -> String {
     }
 }
 
-pub fn get_num_video_displays() -> SdlResult<isize> {
+pub fn get_num_video_displays() -> SdlResult<i32> {
     let result = unsafe { ll::SDL_GetNumVideoDisplays() };
     if result < 0 {
         Err(get_error())
     } else {
-        Ok(result as isize)
+        Ok(result as i32)
     }
 }
 
-pub fn get_display_name(display_index: isize) -> String {
+pub fn get_display_name(display_index: i32) -> String {
     unsafe {
         let display = ll::SDL_GetDisplayName(display_index as c_int);
         String::from_utf8_lossy(c_str_to_bytes(&display)).to_string()
     }
 }
 
-pub fn get_display_bounds(display_index: isize) -> SdlResult<Rect> {
+pub fn get_display_bounds(display_index: i32) -> SdlResult<Rect> {
     let out: Rect = Rect::new(0, 0, 0, 0);
     let result = unsafe { ll::SDL_GetDisplayBounds(display_index as c_int, &out) == 0 };
 
@@ -513,16 +513,16 @@ pub fn get_display_bounds(display_index: isize) -> SdlResult<Rect> {
     }
 }
 
-pub fn get_num_display_modes(display_index: isize) -> SdlResult<isize> {
+pub fn get_num_display_modes(display_index: i32) -> SdlResult<i32> {
     let result = unsafe { ll::SDL_GetNumDisplayModes(display_index as c_int) };
     if result < 0 {
         Err(get_error())
     } else {
-        Ok(result as isize)
+        Ok(result as i32)
     }
 }
 
-pub fn get_display_mode(display_index: isize, mode_index: isize) -> SdlResult<DisplayMode> {
+pub fn get_display_mode(display_index: i32, mode_index: i32) -> SdlResult<DisplayMode> {
     let dm = empty_sdl_display_mode();
     let result = unsafe { ll::SDL_GetDisplayMode(display_index as c_int, mode_index as c_int, &dm) == 0};
 
@@ -533,7 +533,7 @@ pub fn get_display_mode(display_index: isize, mode_index: isize) -> SdlResult<Di
     }
 }
 
-pub fn get_desktop_display_mode(display_index: isize) -> SdlResult<DisplayMode> {
+pub fn get_desktop_display_mode(display_index: i32) -> SdlResult<DisplayMode> {
     let dm = empty_sdl_display_mode();
     let result = unsafe { ll::SDL_GetDesktopDisplayMode(display_index as c_int, &dm) == 0};
 
@@ -544,7 +544,7 @@ pub fn get_desktop_display_mode(display_index: isize) -> SdlResult<DisplayMode> 
     }
 }
 
-pub fn get_current_display_mode(display_index: isize) -> SdlResult<DisplayMode> {
+pub fn get_current_display_mode(display_index: i32) -> SdlResult<DisplayMode> {
     let dm = empty_sdl_display_mode();
     let result = unsafe { ll::SDL_GetCurrentDisplayMode(display_index as c_int, &dm) == 0};
 
@@ -555,7 +555,7 @@ pub fn get_current_display_mode(display_index: isize) -> SdlResult<DisplayMode> 
     }
 }
 
-pub fn get_closest_display_mode(display_index: isize, mode: &DisplayMode) -> SdlResult<DisplayMode> {
+pub fn get_closest_display_mode(display_index: i32, mode: &DisplayMode) -> SdlResult<DisplayMode> {
     let input = mode.to_ll();
     let out = empty_sdl_display_mode();
 
@@ -608,16 +608,16 @@ pub fn gl_extension_supported(extension: &str) -> bool {
     unsafe { ll::SDL_GL_ExtensionSupported(buff) == 1 }
 }
 
-pub fn gl_set_attribute(attr: GLAttr, value: isize) -> bool {
+pub fn gl_set_attribute(attr: GLAttr, value: i32) -> bool {
     unsafe { ll::SDL_GL_SetAttribute(FromPrimitive::from_u64(attr as u64).unwrap(), value as c_int) == 0 }
 }
 
-pub fn gl_get_attribute(attr: GLAttr) -> SdlResult<isize> {
+pub fn gl_get_attribute(attr: GLAttr) -> SdlResult<i32> {
     let out: c_int = 0;
 
     let result = unsafe { ll::SDL_GL_GetAttribute(FromPrimitive::from_u64(attr as u64).unwrap(), &out) } == 0;
     if result {
-        Ok(out as isize)
+        Ok(out as i32)
     } else {
         Err(get_error())
     }
@@ -641,10 +641,10 @@ pub fn gl_get_current_context() -> SdlResult<GLContext> {
     }
 }
 
-pub fn gl_set_swap_interval(interval: isize) -> bool {
+pub fn gl_set_swap_interval(interval: i32) -> bool {
     unsafe { ll::SDL_GL_SetSwapInterval(interval as c_int) == 0 }
 }
 
-pub fn gl_get_swap_interval() -> isize {
-    unsafe { ll::SDL_GL_GetSwapInterval() as isize }
+pub fn gl_get_swap_interval() -> i32 {
+    unsafe { ll::SDL_GL_GetSwapInterval() as i32 }
 }


### PR DESCRIPTION
These commits should fix the improper usage of isize throughout most of src/sdl. A few improper usages of usize that appeared around the isize instances are fixed as well. keyboard.rs needs to be looked at still, and the casting between i32 and c_int may not really be needed, but may be good for explicitness.