### PR TITLE
Mark raw() and owned() accessors as unsafe, remove unnecessary accessors

### DIFF
--- a/src/sdl2/audio.rs
+++ b/src/sdl2/audio.rs
@@ -411,9 +411,6 @@ pub struct AudioCVT {
     owned: bool,
 }
 
-impl_raw_accessors!( (AudioCVT, *mut ll::SDL_AudioCVT) );
-impl_owned_accessors!( (AudioCVT, owned) );
-
 impl Drop for AudioCVT {
     fn drop(&mut self) {
         if self.owned {
@@ -425,7 +422,7 @@ impl Drop for AudioCVT {
 impl AudioCVT {
     pub fn new(src_format: ll::SDL_AudioFormat, src_channels: u8, src_rate: i32,
                dst_format: ll::SDL_AudioFormat, dst_channels: u8, dst_rate: i32) -> SdlResult<AudioCVT> {
-        
+
         use std::mem;
         unsafe {
             let c_cvt_p = libc::malloc(mem::size_of::<ll::SDL_AudioCVT>() as size_t) as *mut ll::SDL_AudioCVT;

--- a/src/sdl2/macros.rs
+++ b/src/sdl2/macros.rs
@@ -3,7 +3,7 @@ macro_rules! impl_raw_accessors(
         $(
         impl $t {
             #[inline]
-            pub fn raw(&self) -> $raw { self.raw }
+            pub unsafe fn raw(&self) -> $raw { self.raw }
         }
         )+
     )
@@ -14,7 +14,7 @@ macro_rules! impl_owned_accessors(
         $(
         impl $t {
             #[inline]
-            pub fn $owned(&self) -> bool { self.$owned }
+            pub unsafe fn $owned(&self) -> bool { self.$owned }
         }
         )+
     )

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -163,12 +163,6 @@ impl Renderer {
         mem::replace(&mut self.parent, None).unwrap()
     }
 
-    #[inline]
-    pub fn raw(&self) -> *const ll::SDL_Renderer { self.raw }
-
-    #[inline]
-    pub fn owned(&self) -> bool { self.owned }
-
     pub fn set_draw_color(&self, color: pixels::Color) -> SdlResult<()> {
         let ret = match color {
             pixels::Color::RGB(r, g, b) => {
@@ -309,12 +303,12 @@ impl Renderer {
     pub fn set_clip_rect(&self, rect: Option<Rect>) -> SdlResult<()> {
         let ret = unsafe {
             ll::SDL_RenderSetClipRect(
-                self.raw, 
+                self.raw,
                 match rect {
                     Some(ref rect) => rect as *const _,
                     None => ptr::null()
                 }
-            ) 
+            )
         };
 
         if ret == 0 { Ok(()) }
@@ -466,7 +460,7 @@ impl Renderer {
                     (ptr::null(), w as usize, h as usize)
                 }
             };
-            
+
             let pitch = w * format.byte_size_per_pixel(); // calculated pitch
             let size = format.byte_size_of_pixels(w * h);
             let mut pixels = Vec::with_capacity(size);
@@ -609,7 +603,7 @@ impl Texture {
             let pixels : *const c_void = ptr::null();
             let pitch = 0i32;
             let size = q.format.byte_size_of_pixels((q.width * q.height) as usize);
-        
+
             let actual_rect = match rect {
                 Some(ref rect) => rect as *const _,
                 None => ptr::null()


### PR DESCRIPTION
The `impl_raw_accessors!` and `impl_owned_accessors!` macros generate methods that expose raw ffi pointers (`raw()`) and its ownership state (`owned()`) to the public.
These methods are only used for ffi interop, and their use should be discouraged unless absolutely necessary (with an unsafe block).
We certainly don't want to encourage casual use of these functions from user code; raw pointers and ffi interop are inherently unsafe.

`AudioCVT` and `Renderer` also don't require these methods (rust-sdl2 compiles without them), so they were removed.