### PR TITLE
Fix panic when mouse is moved while buttons with id > 5 are pressed

### DIFF
--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -411,7 +411,7 @@ impl Event {
                 };
 
                 Event::MouseMotion(event.timestamp, window, event.which,
-                                   mouse::MouseState::from_bits(event.state).unwrap(),
+                                   mouse::MouseState::from_bits_truncate(event.state),
                                    event.x, event.y,
                                    event.xrel, event.yrel)
             }

--- a/src/sdl2/mouse.rs
+++ b/src/sdl2/mouse.rs
@@ -132,7 +132,7 @@ pub fn get_mouse_state() -> (MouseState, isize, isize) {
     let y = 0;
     unsafe {
         let raw = ll::SDL_GetMouseState(&x, &y);
-        return (MouseState::from_bits(raw).unwrap(), x as isize, y as isize);
+        return (MouseState::from_bits_truncate(raw), x as isize, y as isize);
     }
 }
 
@@ -141,7 +141,7 @@ pub fn get_relative_mouse_state() -> (MouseState, isize, isize) {
     let y = 0;
     unsafe {
         let raw = ll::SDL_GetRelativeMouseState(&x, &y);
-        return (MouseState::from_bits(raw).unwrap(), x as isize, y as isize);
+        return (MouseState::from_bits_truncate(raw), x as isize, y as isize);
     }
 }
 


### PR DESCRIPTION
SDL lib handles mouse buttons state as a bitmask where each bit
corresponds to a currently pressed button. Constants that map bits
to buttons are defined in C headers, but there are defines only
for the first 5 buttons (left, middle, right, X1, X2). SDL may still
set bits for buttons with num > 5 if they are present and pressed.
Current code runs from_bits(..).unwrap() on them and panics. This patch
replaces the code with from_bits_truncate() that ignores unknown bits.