### PR TITLE
Fix conflict with #288 and #290

### DIFF
--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -197,7 +197,7 @@ impl Renderer {
     }
 
     pub fn get_blend_mode(&self) -> SdlResult<BlendMode> {
-        let blend: c_uint = 0;
+        let blend = 0;
         let result = unsafe { ll::SDL_GetRenderDrawBlendMode(self.raw, &blend) == 0 };
         if result {
             Ok(FromPrimitive::from_i64(blend as i64).unwrap())
@@ -590,7 +590,7 @@ impl Texture {
     }
 
     pub fn get_blend_mode(&self) -> SdlResult<BlendMode> {
-        let blend: c_uint = 0;
+        let blend = 0;
         let result = unsafe { ll::SDL_GetTextureBlendMode(self.raw, &blend) == 0 };
         if result {
             Ok(FromPrimitive::from_i64(blend as i64).unwrap())


### PR DESCRIPTION
Oops, it appears the two pull requests #288 and #290 changed details about the blend mode that weren't compatible with each other.
This is just a quick fix to that. :)