### PR TITLE
Don't reexport sdl2-sys modules

### DIFF
--- a/src/sdl2/audio.rs
+++ b/src/sdl2/audio.rs
@@ -9,7 +9,7 @@ use get_error;
 use rwops::RWops;
 use SdlResult;
 
-pub use sys::audio as ll;
+use sys::audio as ll;
 
 pub type AudioFormat = ll::SDL_AudioFormat;
 

--- a/src/sdl2/clipboard.rs
+++ b/src/sdl2/clipboard.rs
@@ -2,7 +2,7 @@ use std::ffi::{c_str_to_bytes, CString};
 use SdlResult;
 use get_error;
 
-pub use sys::clipboard as ll;
+use sys::clipboard as ll;
 
 pub fn set_clipboard_text(text: &String) -> SdlResult<()> {
     unsafe {

--- a/src/sdl2/controller.rs
+++ b/src/sdl2/controller.rs
@@ -1,6 +1,6 @@
 use libc::c_int;
 
-pub use sys::controller as ll;
+use sys::controller as ll;
 
 #[derive(Copy, Clone, PartialEq)]
 #[repr(i32)]

--- a/src/sdl2/cpuinfo.rs
+++ b/src/sdl2/cpuinfo.rs
@@ -1,4 +1,4 @@
-pub use sys::cpuinfo as ll;
+use sys::cpuinfo as ll;
 
 pub const CACHELINESIZE: u8 = 128;
 

--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -15,7 +15,7 @@ use joystick;
 use joystick::HatState;
 use keyboard;
 use keyboard::Mod;
-use keyboard::ll::SDL_Keymod;
+use sys::keyboard::SDL_Keymod;
 use keycode::KeyCode;
 use mouse;
 use mouse::{Mouse, MouseState};
@@ -24,7 +24,7 @@ use video;
 use get_error;
 use SdlResult;
 
-pub use sys::event as ll;
+use sys::event as ll;
 
 /// Types of events that can be delivered.
 #[derive(Copy, Clone, FromPrimitive)]

--- a/src/sdl2/filesystem.rs
+++ b/src/sdl2/filesystem.rs
@@ -2,7 +2,7 @@ use std::ffi::{c_str_to_bytes, CString};
 use SdlResult;
 use get_error;
 
-pub use sys::filesystem as ll;
+use sys::filesystem as ll;
 
 pub fn get_base_path() -> SdlResult<String> {
     let result = unsafe {

--- a/src/sdl2/gesture.rs
+++ b/src/sdl2/gesture.rs
@@ -1,1 +1,1 @@
-pub use sys::gesture as ll;
+use sys::gesture as ll;

--- a/src/sdl2/haptic.rs
+++ b/src/sdl2/haptic.rs
@@ -1,2 +1,2 @@
 //! Haptic Functions
-pub use sys::haptic as ll;
+use sys::haptic as ll;

--- a/src/sdl2/joystick.rs
+++ b/src/sdl2/joystick.rs
@@ -1,4 +1,4 @@
-pub use sys::joystick as ll;
+use sys::joystick as ll;
 
 bitflags! {
     flags HatState: u8 {

--- a/src/sdl2/keyboard.rs
+++ b/src/sdl2/keyboard.rs
@@ -8,7 +8,7 @@ use rect::Rect;
 use scancode::ScanCode;
 use video::Window;
 
-pub use sys::keyboard as ll;
+use sys::keyboard as ll;
 
 bitflags! {
     flags Mod: u32 {

--- a/src/sdl2/messagebox.rs
+++ b/src/sdl2/messagebox.rs
@@ -5,7 +5,7 @@ use video::Window;
 use get_error;
 use SdlResult;
 
-pub use sys::messagebox as ll;
+use sys::messagebox as ll;
 
 bitflags! {
     flags MessageBoxFlag: u32 {

--- a/src/sdl2/mouse.rs
+++ b/src/sdl2/mouse.rs
@@ -5,7 +5,7 @@ use SdlResult;
 use surface;
 use video;
 
-pub use sys::mouse as ll;
+use sys::mouse as ll;
 
 #[derive(Copy, Clone, PartialEq)]
 #[repr(u32)]

--- a/src/sdl2/pixels.rs
+++ b/src/sdl2/pixels.rs
@@ -1,6 +1,6 @@
 extern crate rand;
 
-pub use sys::pixels as ll;
+use sys::pixels as ll;
 
 #[derive(PartialEq)] #[allow(raw_pointer_derive, missing_copy_implementations)]
 pub struct Palette {

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -16,7 +16,7 @@ use std::num::FromPrimitive;
 use std::vec::Vec;
 use std::borrow::ToOwned;
 
-pub use sys::render as ll;
+use sys::render as ll;
 
 #[derive(Copy, Clone)]
 pub enum RenderDriverIndex {
@@ -126,7 +126,9 @@ impl Renderer {
     }
 
     pub fn new_with_window(width: i32, height: i32, window_flags: video::WindowFlags) -> SdlResult<Renderer> {
-        let raw_window: *const video::ll::SDL_Window = ptr::null();
+        use sys::video::SDL_Window;
+
+        let raw_window: *const SDL_Window = ptr::null();
         let raw_renderer: *const ll::SDL_Renderer = ptr::null();
         let result = unsafe { ll::SDL_CreateWindowAndRenderer(width as c_int, height as c_int, window_flags.bits(), &raw_window, &raw_renderer) == 0};
         if result {

--- a/src/sdl2/rwops.rs
+++ b/src/sdl2/rwops.rs
@@ -5,7 +5,7 @@ use libc::{c_void, c_int, size_t};
 use get_error;
 use SdlResult;
 
-pub use sys::rwops as ll;
+use sys::rwops as ll;
 
 #[derive(PartialEq)] #[allow(raw_pointer_derive)]
 pub struct RWops {

--- a/src/sdl2/surface.rs
+++ b/src/sdl2/surface.rs
@@ -9,7 +9,7 @@ use pixels;
 use render::BlendMode;
 use rwops;
 
-pub use sys::surface as ll;
+use sys::surface as ll;
 
 bitflags! {
     flags SurfaceFlag: u32 {

--- a/src/sdl2/timer.rs
+++ b/src/sdl2/timer.rs
@@ -1,6 +1,6 @@
 use libc::{uint32_t, c_void};
 
-pub use sys::timer as ll;
+use sys::timer as ll;
 
 pub fn get_ticks() -> u32 {
     unsafe { ll::SDL_GetTicks() }

--- a/src/sdl2/touch.rs
+++ b/src/sdl2/touch.rs
@@ -1,6 +1,6 @@
 use std::ptr;
 
-pub use sys::touch as ll;
+use sys::touch as ll;
 
 pub type Finger = ll::Finger;
 pub type TouchDevice = ll::TouchDevice;

--- a/src/sdl2/version.rs
+++ b/src/sdl2/version.rs
@@ -5,7 +5,7 @@ Querying SDL Version
 use std::ffi::c_str_to_bytes;
 use std::fmt;
 
-pub use sys::version as ll;
+use sys::version as ll;
 
 /// A structure that contains information about the version of SDL in use.
 #[derive(PartialEq, Copy, Clone)]

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -11,7 +11,7 @@ use std::num::FromPrimitive;
 
 use get_error;
 
-pub use sys::video as ll;
+use sys::video as ll;
 
 #[derive(Copy, Clone, PartialEq)]
 pub enum GLAttr {


### PR DESCRIPTION
Just a bit of cleanup.
`ll` was showing up on the Rustdocs, which means users can use it directly. Probably best to encourage people to use `sdl2_sys` for raw bindings instead. :]