### PR TITLE
Make the render submodule safer

### DIFF
--- a/examples/renderer-texture.rs
+++ b/examples/renderer-texture.rs
@@ -2,7 +2,8 @@ extern crate sdl2;
 
 use sdl2::video::{Window, WindowPos, OPENGL};
 use sdl2::render::{RenderDriverIndex, ACCELERATED, Renderer};
-use sdl2::pixels::Color;
+use sdl2::pixels::PixelFormatEnum;
+use sdl2::rect::Rect;
 use sdl2::event::poll_event;
 use sdl2::event::Event::{Quit, KeyDown};
 use sdl2::keycode::KeyCode;
@@ -10,7 +11,7 @@ use sdl2::keycode::KeyCode;
 pub fn main() {
     sdl2::init(sdl2::INIT_VIDEO);
 
-    let window = match Window::new("rust-sdl2 demo: Video", WindowPos::PosCentered, WindowPos::PosCentered, 800, 600, OPENGL) {
+    let window = match Window::new("rust-sdl2 demo: Renderer + Texture", WindowPos::PosCentered, WindowPos::PosCentered, 800, 600, OPENGL) {
         Ok(window) => window,
         Err(err) => panic!("failed to create window: {}", err)
     };
@@ -20,9 +21,24 @@ pub fn main() {
         Err(err) => panic!("failed to create renderer: {}", err)
     };
 
+    let mut texture = renderer.create_texture_streaming(PixelFormatEnum::RGB24, (256, 256)).unwrap();
+    // Create a red-green gradient
+    texture.with_lock(None, |buffer: &mut [u8], pitch: usize| {
+        for y in (0us..256) {
+            for x in (0us..256) {
+                let offset = y*pitch + x*3;
+                buffer[offset + 0] = x as u8;
+                buffer[offset + 1] = y as u8;
+                buffer[offset + 2] = 0;
+            }
+        }
+    }).unwrap();
+
     let mut drawer = renderer.drawer();
-    drawer.set_draw_color(Color::RGB(255, 0, 0));
+    // drawer.set_draw_color(Color::RGB(255, 0, 0));
     drawer.clear();
+    drawer.copy(&mut texture, None, Some(Rect::new(100, 100, 256, 256)));
+    drawer.copy_ex(&mut texture, None, Some(Rect::new(450, 100, 256, 256)), 30.0, None, (false, false));
     drawer.present();
 
     loop {

--- a/sdl2-sys/src/pixels.rs
+++ b/sdl2-sys/src/pixels.rs
@@ -22,7 +22,7 @@ pub struct SDL_Palette {
 #[allow(non_snake_case, missing_copy_implementations)]
 #[repr(C)]
 pub struct SDL_PixelFormat {
-    pub format: SDL_PixelFormatFlag,
+    pub format: SDL_PixelFormatEnum,
     pub palette: *const SDL_Palette,
     pub BitsPerPixel: uint8_t,
     pub BytesPerPixel: uint8_t,
@@ -43,43 +43,43 @@ pub struct SDL_PixelFormat {
     pub next: *const SDL_PixelFormat
 }
 
-pub type SDL_PixelFormatFlag = uint32_t;
-pub const SDL_PIXELFORMAT_UNKNOWN: SDL_PixelFormatFlag = 0x0;
-pub const SDL_PIXELFORMAT_INDEX1LSB: SDL_PixelFormatFlag = 0x11100100;
-pub const SDL_PIXELFORMAT_INDEX1MSB: SDL_PixelFormatFlag = 0x11200100;
-pub const SDL_PIXELFORMAT_INDEX4LSB: SDL_PixelFormatFlag = 0x12100400;
-pub const SDL_PIXELFORMAT_INDEX4MSB: SDL_PixelFormatFlag = 0x12200400;
-pub const SDL_PIXELFORMAT_INDEX8: SDL_PixelFormatFlag = 0x13000801;
-pub const SDL_PIXELFORMAT_RGB332: SDL_PixelFormatFlag = 0x14110801;
-pub const SDL_PIXELFORMAT_RGB444: SDL_PixelFormatFlag = 0x15120c02;
-pub const SDL_PIXELFORMAT_RGB555: SDL_PixelFormatFlag = 0x15130f02;
-pub const SDL_PIXELFORMAT_BGR555: SDL_PixelFormatFlag = 0x15530f02;
-pub const SDL_PIXELFORMAT_ARGB4444: SDL_PixelFormatFlag = 0x15321002;
-pub const SDL_PIXELFORMAT_RGBA4444: SDL_PixelFormatFlag = 0x15421002;
-pub const SDL_PIXELFORMAT_ABGR4444: SDL_PixelFormatFlag = 0x15721002;
-pub const SDL_PIXELFORMAT_BGRA4444: SDL_PixelFormatFlag = 0x15821002;
-pub const SDL_PIXELFORMAT_ARGB1555: SDL_PixelFormatFlag = 0x15331002;
-pub const SDL_PIXELFORMAT_RGBA5551: SDL_PixelFormatFlag = 0x15441002;
-pub const SDL_PIXELFORMAT_ABGR1555: SDL_PixelFormatFlag = 0x15731002;
-pub const SDL_PIXELFORMAT_BGRA5551: SDL_PixelFormatFlag = 0x15841002;
-pub const SDL_PIXELFORMAT_RGB565: SDL_PixelFormatFlag = 0x15151002;
-pub const SDL_PIXELFORMAT_BGR565: SDL_PixelFormatFlag = 0x15551002;
-pub const SDL_PIXELFORMAT_RGB24: SDL_PixelFormatFlag = 0x17101803;
-pub const SDL_PIXELFORMAT_BGR24: SDL_PixelFormatFlag = 0x17401803;
-pub const SDL_PIXELFORMAT_RGB888: SDL_PixelFormatFlag = 0x16161804;
-pub const SDL_PIXELFORMAT_RGBX8888: SDL_PixelFormatFlag = 0x16261804;
-pub const SDL_PIXELFORMAT_BGR888: SDL_PixelFormatFlag = 0x16561804;
-pub const SDL_PIXELFORMAT_BGRX8888: SDL_PixelFormatFlag = 0x16661804;
-pub const SDL_PIXELFORMAT_ARGB8888: SDL_PixelFormatFlag = 0x16362004;
-pub const SDL_PIXELFORMAT_RGBA8888: SDL_PixelFormatFlag = 0x16462004;
-pub const SDL_PIXELFORMAT_ABGR8888: SDL_PixelFormatFlag = 0x16762004;
-pub const SDL_PIXELFORMAT_BGRA8888: SDL_PixelFormatFlag = 0x16862004;
-pub const SDL_PIXELFORMAT_ARGB2101010: SDL_PixelFormatFlag = 0x16372004;
-pub const SDL_PIXELFORMAT_YV12: SDL_PixelFormatFlag = 0x32315659;
-pub const SDL_PIXELFORMAT_IYUV: SDL_PixelFormatFlag = 0x56555949;
-pub const SDL_PIXELFORMAT_YUY2: SDL_PixelFormatFlag = 0x32595559;
-pub const SDL_PIXELFORMAT_UYVY: SDL_PixelFormatFlag = 0x59565955;
-pub const SDL_PIXELFORMAT_YVYU: SDL_PixelFormatFlag = 0x55595659;
+pub type SDL_PixelFormatEnum = uint32_t;
+pub const SDL_PIXELFORMAT_UNKNOWN: SDL_PixelFormatEnum = 0x0;
+pub const SDL_PIXELFORMAT_INDEX1LSB: SDL_PixelFormatEnum = 0x11100100;
+pub const SDL_PIXELFORMAT_INDEX1MSB: SDL_PixelFormatEnum = 0x11200100;
+pub const SDL_PIXELFORMAT_INDEX4LSB: SDL_PixelFormatEnum = 0x12100400;
+pub const SDL_PIXELFORMAT_INDEX4MSB: SDL_PixelFormatEnum = 0x12200400;
+pub const SDL_PIXELFORMAT_INDEX8: SDL_PixelFormatEnum = 0x13000801;
+pub const SDL_PIXELFORMAT_RGB332: SDL_PixelFormatEnum = 0x14110801;
+pub const SDL_PIXELFORMAT_RGB444: SDL_PixelFormatEnum = 0x15120c02;
+pub const SDL_PIXELFORMAT_RGB555: SDL_PixelFormatEnum = 0x15130f02;
+pub const SDL_PIXELFORMAT_BGR555: SDL_PixelFormatEnum = 0x15530f02;
+pub const SDL_PIXELFORMAT_ARGB4444: SDL_PixelFormatEnum = 0x15321002;
+pub const SDL_PIXELFORMAT_RGBA4444: SDL_PixelFormatEnum = 0x15421002;
+pub const SDL_PIXELFORMAT_ABGR4444: SDL_PixelFormatEnum = 0x15721002;
+pub const SDL_PIXELFORMAT_BGRA4444: SDL_PixelFormatEnum = 0x15821002;
+pub const SDL_PIXELFORMAT_ARGB1555: SDL_PixelFormatEnum = 0x15331002;
+pub const SDL_PIXELFORMAT_RGBA5551: SDL_PixelFormatEnum = 0x15441002;
+pub const SDL_PIXELFORMAT_ABGR1555: SDL_PixelFormatEnum = 0x15731002;
+pub const SDL_PIXELFORMAT_BGRA5551: SDL_PixelFormatEnum = 0x15841002;
+pub const SDL_PIXELFORMAT_RGB565: SDL_PixelFormatEnum = 0x15151002;
+pub const SDL_PIXELFORMAT_BGR565: SDL_PixelFormatEnum = 0x15551002;
+pub const SDL_PIXELFORMAT_RGB24: SDL_PixelFormatEnum = 0x17101803;
+pub const SDL_PIXELFORMAT_BGR24: SDL_PixelFormatEnum = 0x17401803;
+pub const SDL_PIXELFORMAT_RGB888: SDL_PixelFormatEnum = 0x16161804;
+pub const SDL_PIXELFORMAT_RGBX8888: SDL_PixelFormatEnum = 0x16261804;
+pub const SDL_PIXELFORMAT_BGR888: SDL_PixelFormatEnum = 0x16561804;
+pub const SDL_PIXELFORMAT_BGRX8888: SDL_PixelFormatEnum = 0x16661804;
+pub const SDL_PIXELFORMAT_ARGB8888: SDL_PixelFormatEnum = 0x16362004;
+pub const SDL_PIXELFORMAT_RGBA8888: SDL_PixelFormatEnum = 0x16462004;
+pub const SDL_PIXELFORMAT_ABGR8888: SDL_PixelFormatEnum = 0x16762004;
+pub const SDL_PIXELFORMAT_BGRA8888: SDL_PixelFormatEnum = 0x16862004;
+pub const SDL_PIXELFORMAT_ARGB2101010: SDL_PixelFormatEnum = 0x16372004;
+pub const SDL_PIXELFORMAT_YV12: SDL_PixelFormatEnum = 0x32315659;
+pub const SDL_PIXELFORMAT_IYUV: SDL_PixelFormatEnum = 0x56555949;
+pub const SDL_PIXELFORMAT_YUY2: SDL_PixelFormatEnum = 0x32595559;
+pub const SDL_PIXELFORMAT_UYVY: SDL_PixelFormatEnum = 0x59565955;
+pub const SDL_PIXELFORMAT_YVYU: SDL_PixelFormatEnum = 0x55595659;
 
 extern "C" {
     pub fn SDL_GetRGB(pixel: uint32_t, format: *const SDL_PixelFormat, r: *const uint8_t, g: *const uint8_t, b: *const uint8_t);

--- a/src/sdl2/pixels.rs
+++ b/src/sdl2/pixels.rs
@@ -63,7 +63,7 @@ impl_raw_accessors!((PixelFormat, *const ll::SDL_PixelFormat));
 impl_raw_constructor!((PixelFormat, PixelFormat (raw: *const ll::SDL_PixelFormat)));
 
 #[derive(Copy, Clone, PartialEq, Show, FromPrimitive)]
-pub enum PixelFormatFlag {
+pub enum PixelFormatEnum {
     Unknown = ll::SDL_PIXELFORMAT_UNKNOWN as isize,
     Index1LSB = ll::SDL_PIXELFORMAT_INDEX1LSB as isize,
     Index1MSB = ll::SDL_PIXELFORMAT_INDEX1MSB as isize,
@@ -102,76 +102,76 @@ pub enum PixelFormatFlag {
     YVYU = ll::SDL_PIXELFORMAT_YVYU as isize
 }
 
-impl PixelFormatFlag {
+impl PixelFormatEnum {
     pub fn byte_size_of_pixels(&self, num_of_pixels: usize) -> usize {
         match *self {
-            PixelFormatFlag::RGB332
+            PixelFormatEnum::RGB332
                 => num_of_pixels * 1,
-            PixelFormatFlag::RGB444 | PixelFormatFlag::RGB555 |
-            PixelFormatFlag::BGR555 | PixelFormatFlag::ARGB4444 |
-            PixelFormatFlag::RGBA4444 | PixelFormatFlag::ABGR4444 |
-            PixelFormatFlag::BGRA4444 | PixelFormatFlag::ARGB1555 |
-            PixelFormatFlag::RGBA5551 | PixelFormatFlag::ABGR1555 |
-            PixelFormatFlag::BGRA5551 | PixelFormatFlag::RGB565 |
-            PixelFormatFlag::BGR565
+            PixelFormatEnum::RGB444 | PixelFormatEnum::RGB555 |
+            PixelFormatEnum::BGR555 | PixelFormatEnum::ARGB4444 |
+            PixelFormatEnum::RGBA4444 | PixelFormatEnum::ABGR4444 |
+            PixelFormatEnum::BGRA4444 | PixelFormatEnum::ARGB1555 |
+            PixelFormatEnum::RGBA5551 | PixelFormatEnum::ABGR1555 |
+            PixelFormatEnum::BGRA5551 | PixelFormatEnum::RGB565 |
+            PixelFormatEnum::BGR565
                 => num_of_pixels * 2,
-            PixelFormatFlag::RGB24 | PixelFormatFlag::BGR24
+            PixelFormatEnum::RGB24 | PixelFormatEnum::BGR24
                 => num_of_pixels * 3,
-            PixelFormatFlag::RGB888 | PixelFormatFlag::RGBX8888 |
-            PixelFormatFlag::BGR888 | PixelFormatFlag::BGRX8888 |
-            PixelFormatFlag::ARGB8888 | PixelFormatFlag::RGBA8888 |
-            PixelFormatFlag::ABGR8888 | PixelFormatFlag::BGRA8888 |
-            PixelFormatFlag::ARGB2101010
+            PixelFormatEnum::RGB888 | PixelFormatEnum::RGBX8888 |
+            PixelFormatEnum::BGR888 | PixelFormatEnum::BGRX8888 |
+            PixelFormatEnum::ARGB8888 | PixelFormatEnum::RGBA8888 |
+            PixelFormatEnum::ABGR8888 | PixelFormatEnum::BGRA8888 |
+            PixelFormatEnum::ARGB2101010
                 => num_of_pixels * 4,
             // YUV formats
             // FIXME: rounding error here?
-            PixelFormatFlag::YV12 | PixelFormatFlag::IYUV
+            PixelFormatEnum::YV12 | PixelFormatEnum::IYUV
                 => num_of_pixels / 2 * 3,
-            PixelFormatFlag::YUY2 | PixelFormatFlag::UYVY |
-            PixelFormatFlag::YVYU
+            PixelFormatEnum::YUY2 | PixelFormatEnum::UYVY |
+            PixelFormatEnum::YVYU
                 => num_of_pixels * 2,
             // Unsupported formats
-            PixelFormatFlag::Index8
+            PixelFormatEnum::Index8
                 => num_of_pixels * 1,
-            PixelFormatFlag::Unknown | PixelFormatFlag::Index1LSB |
-            PixelFormatFlag::Index1MSB | PixelFormatFlag::Index4LSB |
-            PixelFormatFlag::Index4MSB
+            PixelFormatEnum::Unknown | PixelFormatEnum::Index1LSB |
+            PixelFormatEnum::Index1MSB | PixelFormatEnum::Index4LSB |
+            PixelFormatEnum::Index4MSB
                 => panic!("not supported format: {:?}", *self),
         }
     }
 
     pub fn byte_size_per_pixel(&self) -> usize {
         match *self {
-            PixelFormatFlag::RGB332
+            PixelFormatEnum::RGB332
                 => 1,
-            PixelFormatFlag::RGB444 | PixelFormatFlag::RGB555 |
-            PixelFormatFlag::BGR555 | PixelFormatFlag::ARGB4444 |
-            PixelFormatFlag::RGBA4444 | PixelFormatFlag::ABGR4444 |
-            PixelFormatFlag::BGRA4444 | PixelFormatFlag::ARGB1555 |
-            PixelFormatFlag::RGBA5551 | PixelFormatFlag::ABGR1555 |
-            PixelFormatFlag::BGRA5551 | PixelFormatFlag::RGB565 |
-            PixelFormatFlag::BGR565
+            PixelFormatEnum::RGB444 | PixelFormatEnum::RGB555 |
+            PixelFormatEnum::BGR555 | PixelFormatEnum::ARGB4444 |
+            PixelFormatEnum::RGBA4444 | PixelFormatEnum::ABGR4444 |
+            PixelFormatEnum::BGRA4444 | PixelFormatEnum::ARGB1555 |
+            PixelFormatEnum::RGBA5551 | PixelFormatEnum::ABGR1555 |
+            PixelFormatEnum::BGRA5551 | PixelFormatEnum::RGB565 |
+            PixelFormatEnum::BGR565
                 => 2,
-            PixelFormatFlag::RGB24 | PixelFormatFlag::BGR24
+            PixelFormatEnum::RGB24 | PixelFormatEnum::BGR24
                 => 3,
-            PixelFormatFlag::RGB888 | PixelFormatFlag::RGBX8888 |
-            PixelFormatFlag::BGR888 | PixelFormatFlag::BGRX8888 |
-            PixelFormatFlag::ARGB8888 | PixelFormatFlag::RGBA8888 |
-            PixelFormatFlag::ABGR8888 | PixelFormatFlag::BGRA8888 |
-            PixelFormatFlag::ARGB2101010
+            PixelFormatEnum::RGB888 | PixelFormatEnum::RGBX8888 |
+            PixelFormatEnum::BGR888 | PixelFormatEnum::BGRX8888 |
+            PixelFormatEnum::ARGB8888 | PixelFormatEnum::RGBA8888 |
+            PixelFormatEnum::ABGR8888 | PixelFormatEnum::BGRA8888 |
+            PixelFormatEnum::ARGB2101010
                 => 4,
             // YUV formats
-            PixelFormatFlag::YV12 | PixelFormatFlag::IYUV
+            PixelFormatEnum::YV12 | PixelFormatEnum::IYUV
                 => 2,
-            PixelFormatFlag::YUY2 | PixelFormatFlag::UYVY |
-            PixelFormatFlag::YVYU
+            PixelFormatEnum::YUY2 | PixelFormatEnum::UYVY |
+            PixelFormatEnum::YVYU
                 => 2,
             // Unsupported formats
-            PixelFormatFlag::Index8
+            PixelFormatEnum::Index8
                 => 1,
-            PixelFormatFlag::Unknown | PixelFormatFlag::Index1LSB |
-            PixelFormatFlag::Index1MSB | PixelFormatFlag::Index4LSB |
-            PixelFormatFlag::Index4MSB
+            PixelFormatEnum::Unknown | PixelFormatEnum::Index1LSB |
+            PixelFormatEnum::Index1MSB | PixelFormatEnum::Index4LSB |
+            PixelFormatEnum::Index4MSB
                 => panic!("not supported format: {:?}", *self),
         }
     }

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -149,6 +149,14 @@ impl Renderer {
         }
     }
 
+    pub fn get_info(&self) -> RendererInfo {
+        unsafe {
+            let renderer_info_raw: ll::SDL_RendererInfo = mem::uninitialized();
+            ll::SDL_GetRendererInfo(self.raw, &renderer_info_raw);
+            RendererInfo::from_ll(&renderer_info_raw)
+        }
+    }
+
     #[inline]
     pub fn get_parent(&self) -> &RendererParent { self.parent.as_ref().unwrap() }
 

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -158,13 +158,29 @@ impl Renderer {
         mem::replace(&mut self.parent, None).unwrap()
     }
 
-    pub fn create_texture(&self, format: pixels::PixelFormatFlag, access: TextureAccess, width: i32, height: i32) -> SdlResult<Texture> {
+    pub fn create_texture(&self, format: pixels::PixelFormatFlag, access: TextureAccess, size: (i32, i32)) -> SdlResult<Texture> {
+        let (width, height) = size;
         let result = unsafe { ll::SDL_CreateTexture(self.raw, format as uint32_t, access as c_int, width as c_int, height as c_int) };
         if result == ptr::null() {
             Err(get_error())
         } else {
             Ok(Texture { raw: result, owned: true, _marker: ContravariantLifetime } )
         }
+    }
+
+    /// Shorthand for `create_texture(format, TextureAccess::Static, size)`
+    pub fn create_texture_static(&self, format: pixels::PixelFormatFlag, size: (i32, i32)) -> SdlResult<Texture> {
+        self.create_texture(format, TextureAccess::Static, size)
+    }
+
+    /// Shorthand for `create_texture(format, TextureAccess::Streaming, size)`
+    pub fn create_texture_streaming(&self, format: pixels::PixelFormatFlag, size: (i32, i32)) -> SdlResult<Texture> {
+        self.create_texture(format, TextureAccess::Streaming, size)
+    }
+
+    /// Shorthand for `create_texture(format, TextureAccess::Target, size)` 
+    pub fn create_texture_target(&self, format: pixels::PixelFormatFlag, size: (i32, i32)) -> SdlResult<Texture> {
+        self.create_texture(format, TextureAccess::Target, size)
     }
 
     pub fn create_texture_from_surface(&self, surface: &surface::Surface) -> SdlResult<Texture> {

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -152,8 +152,12 @@ impl Renderer {
     pub fn get_info(&self) -> RendererInfo {
         unsafe {
             let renderer_info_raw: ll::SDL_RendererInfo = mem::uninitialized();
-            ll::SDL_GetRendererInfo(self.raw, &renderer_info_raw);
-            RendererInfo::from_ll(&renderer_info_raw)
+            if ll::SDL_GetRendererInfo(self.raw, &renderer_info_raw) != 0 {
+                // Should only fail on an invalid renderer
+                panic!();
+            } else {
+                RendererInfo::from_ll(&renderer_info_raw)
+            }
         }
     }
 

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -206,7 +206,7 @@ impl RenderDrawer {
         else { None }
     }
 
-    pub fn set_draw_color(&self, color: pixels::Color) -> SdlResult<()> {
+    pub fn set_draw_color(&mut self, color: pixels::Color) -> SdlResult<()> {
         let ret = match color {
             pixels::Color::RGB(r, g, b) => {
                 unsafe { ll::SDL_SetRenderDrawColor(self.raw, r, g, b, 255) }
@@ -232,7 +232,7 @@ impl RenderDrawer {
         }
     }
 
-    pub fn set_blend_mode(&self, blend: BlendMode) -> SdlResult<()> {
+    pub fn set_blend_mode(&mut self, blend: BlendMode) -> SdlResult<()> {
         let ret = unsafe { ll::SDL_SetRenderDrawBlendMode(self.raw, FromPrimitive::from_i64(blend as i64).unwrap()) };
 
         if ret == 0 { Ok(()) }
@@ -249,13 +249,13 @@ impl RenderDrawer {
         }
     }
 
-    pub fn clear(&self) -> SdlResult<()> {
+    pub fn clear(&mut self) -> SdlResult<()> {
         let ret = unsafe { ll::SDL_RenderClear(self.raw) };
         if ret == 0 { Ok(()) }
         else { Err(get_error()) }
     }
 
-    pub fn present(&self) {
+    pub fn present(&mut self) {
         unsafe { ll::SDL_RenderPresent(self.raw) }
     }
 
@@ -272,7 +272,7 @@ impl RenderDrawer {
         }
     }
 
-    pub fn set_logical_size(&self, width: i32, height: i32) -> SdlResult<()> {
+    pub fn set_logical_size(&mut self, width: i32, height: i32) -> SdlResult<()> {
         let ret = unsafe { ll::SDL_RenderSetLogicalSize(self.raw, width as c_int, height as c_int) };
 
         if ret == 0 { Ok(()) }
@@ -289,7 +289,7 @@ impl RenderDrawer {
         (width as i32, height as i32)
     }
 
-    pub fn set_viewport(&self, rect: Option<Rect>) -> SdlResult<()> {
+    pub fn set_viewport(&mut self, rect: Option<Rect>) -> SdlResult<()> {
         let ptr = match rect {
             Some(ref rect) => rect as *const _,
             None => ptr::null()
@@ -311,7 +311,7 @@ impl RenderDrawer {
         rect
     }
 
-    pub fn set_clip_rect(&self, rect: Option<Rect>) -> SdlResult<()> {
+    pub fn set_clip_rect(&mut self, rect: Option<Rect>) -> SdlResult<()> {
         let ret = unsafe {
             ll::SDL_RenderSetClipRect(
                 self.raw,
@@ -337,7 +337,7 @@ impl RenderDrawer {
         rect
     }
 
-    pub fn set_scale(&self, scale_x: f64, scale_y: f64) -> SdlResult<()> {
+    pub fn set_scale(&mut self, scale_x: f64, scale_y: f64) -> SdlResult<()> {
         let ret = unsafe { ll::SDL_RenderSetScale(self.raw, scale_x as c_float, scale_y as c_float) };
 
         if ret == 0 { Ok(()) }
@@ -351,14 +351,14 @@ impl RenderDrawer {
         (scale_x as f64, scale_y as f64)
     }
 
-    pub fn draw_point(&self, point: Point) -> SdlResult<()> {
+    pub fn draw_point(&mut self, point: Point) -> SdlResult<()> {
         let ret = unsafe { ll::SDL_RenderDrawPoint(self.raw, point.x, point.y) };
 
         if ret == 0 { Ok(()) }
         else { Err(get_error()) }
     }
 
-    pub fn draw_points(&self, points: &[Point]) -> SdlResult<()> {
+    pub fn draw_points(&mut self, points: &[Point]) -> SdlResult<()> {
         let ret = unsafe {
             ll::SDL_RenderDrawPoints(self.raw, points.as_ptr(), points.len() as c_int)
         };
@@ -367,14 +367,14 @@ impl RenderDrawer {
         else { Err(get_error()) }
     }
 
-    pub fn draw_line(&self, start: Point, end: Point) -> SdlResult<()> {
+    pub fn draw_line(&mut self, start: Point, end: Point) -> SdlResult<()> {
         let ret = unsafe { ll::SDL_RenderDrawLine(self.raw, start.x, start.y, end.x, end.y) };
 
         if ret == 0 { Ok(()) }
         else { Err(get_error()) }
     }
 
-    pub fn draw_lines(&self, points: &[Point]) -> SdlResult<()> {
+    pub fn draw_lines(&mut self, points: &[Point]) -> SdlResult<()> {
         let ret = unsafe {
             ll::SDL_RenderDrawLines(self.raw, points.as_ptr(), points.len() as c_int)
         };
@@ -383,14 +383,14 @@ impl RenderDrawer {
         else { Err(get_error()) }
     }
 
-    pub fn draw_rect(&self, rect: &Rect) -> SdlResult<()> {
+    pub fn draw_rect(&mut self, rect: &Rect) -> SdlResult<()> {
         let ret = unsafe { ll::SDL_RenderDrawRect(self.raw, rect) };
 
         if ret == 0 { Ok(()) }
         else { Err(get_error()) }
     }
 
-    pub fn draw_rects(&self, rects: &[Rect]) -> SdlResult<()> {
+    pub fn draw_rects(&mut self, rects: &[Rect]) -> SdlResult<()> {
         let ret = unsafe {
             ll::SDL_RenderDrawRects(self.raw, rects.as_ptr(), rects.len() as c_int)
         };
@@ -399,14 +399,14 @@ impl RenderDrawer {
         else { Err(get_error()) }
     }
 
-    pub fn fill_rect(&self, rect: &Rect) -> SdlResult<()> {
+    pub fn fill_rect(&mut self, rect: &Rect) -> SdlResult<()> {
         let ret = unsafe { ll::SDL_RenderFillRect(self.raw, rect) };
 
         if ret == 0 { Ok(()) }
         else { Err(get_error()) }
     }
 
-    pub fn fill_rects(&self, rects: &[Rect]) -> SdlResult<()> {
+    pub fn fill_rects(&mut self, rects: &[Rect]) -> SdlResult<()> {
         let ret = unsafe {
             ll::SDL_RenderFillRects(self.raw, rects.as_ptr(), rects.len() as c_int)
         };
@@ -415,7 +415,7 @@ impl RenderDrawer {
         else { Err(get_error()) }
     }
 
-    pub fn copy(&self, texture: &mut Texture, src: Option<Rect>, dst: Option<Rect>) -> SdlResult<()> {
+    pub fn copy(&mut self, texture: &mut Texture, src: Option<Rect>, dst: Option<Rect>) -> SdlResult<()> {
         let ret = unsafe {
             ll::SDL_RenderCopy(
                 self.raw,
@@ -435,7 +435,7 @@ impl RenderDrawer {
         else { Err(get_error()) }
     }
 
-    pub fn copy_ex(&self, texture: &mut Texture, src: Option<Rect>, dst: Option<Rect>, angle: f64, center: Option<Point>, (flip_horizontal, flip_vertical): (bool, bool)) -> SdlResult<()> {
+    pub fn copy_ex(&mut self, texture: &mut Texture, src: Option<Rect>, dst: Option<Rect>, angle: f64, center: Option<Point>, (flip_horizontal, flip_vertical): (bool, bool)) -> SdlResult<()> {
         let flip = match (flip_horizontal, flip_vertical) {
             (false, false) => ll::SDL_FLIP_NONE,
             (true, false) => ll::SDL_FLIP_HORIZONTAL,

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -248,7 +248,10 @@ impl Renderer {
 
     pub fn render_target(&self) -> Option<RefMut<RenderTarget>> {
         if self.render_target_supported() {
-            Some(self.render_target.borrow_mut())
+            match self.render_target.try_borrow_mut() {
+                Some(render_target) => Some(render_target),
+                None => panic!("Render target already borrowed")
+            }
         } else {
             None
         }

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -46,7 +46,7 @@ bitflags! {
 pub struct RendererInfo {
     pub name: String,
     pub flags: RendererFlags,
-    pub texture_formats: Vec<pixels::PixelFormatFlag>,
+    pub texture_formats: Vec<pixels::PixelFormatEnum>,
     pub max_texture_width: i32,
     pub max_texture_height: i32
 }
@@ -64,7 +64,7 @@ impl RendererInfo {
         let actual_flags = RendererFlags::from_bits(info.flags).unwrap();
 
         unsafe {
-            let texture_formats: Vec<pixels::PixelFormatFlag> = info.texture_formats[0..(info.num_texture_formats as usize)].iter().map(|&format| {
+            let texture_formats: Vec<pixels::PixelFormatEnum> = info.texture_formats[0..(info.num_texture_formats as usize)].iter().map(|&format| {
                 FromPrimitive::from_i64(format as i64).unwrap()
             }).collect();
 
@@ -158,7 +158,7 @@ impl Renderer {
         mem::replace(&mut self.parent, None).unwrap()
     }
 
-    pub fn create_texture(&self, format: pixels::PixelFormatFlag, access: TextureAccess, size: (i32, i32)) -> SdlResult<Texture> {
+    pub fn create_texture(&self, format: pixels::PixelFormatEnum, access: TextureAccess, size: (i32, i32)) -> SdlResult<Texture> {
         let (width, height) = size;
         let result = unsafe { ll::SDL_CreateTexture(self.raw, format as uint32_t, access as c_int, width as c_int, height as c_int) };
         if result == ptr::null() {
@@ -169,17 +169,17 @@ impl Renderer {
     }
 
     /// Shorthand for `create_texture(format, TextureAccess::Static, size)`
-    pub fn create_texture_static(&self, format: pixels::PixelFormatFlag, size: (i32, i32)) -> SdlResult<Texture> {
+    pub fn create_texture_static(&self, format: pixels::PixelFormatEnum, size: (i32, i32)) -> SdlResult<Texture> {
         self.create_texture(format, TextureAccess::Static, size)
     }
 
     /// Shorthand for `create_texture(format, TextureAccess::Streaming, size)`
-    pub fn create_texture_streaming(&self, format: pixels::PixelFormatFlag, size: (i32, i32)) -> SdlResult<Texture> {
+    pub fn create_texture_streaming(&self, format: pixels::PixelFormatEnum, size: (i32, i32)) -> SdlResult<Texture> {
         self.create_texture(format, TextureAccess::Streaming, size)
     }
 
     /// Shorthand for `create_texture(format, TextureAccess::Target, size)`
-    pub fn create_texture_target(&self, format: pixels::PixelFormatFlag, size: (i32, i32)) -> SdlResult<Texture> {
+    pub fn create_texture_target(&self, format: pixels::PixelFormatEnum, size: (i32, i32)) -> SdlResult<Texture> {
         self.create_texture(format, TextureAccess::Target, size)
     }
 
@@ -473,7 +473,7 @@ impl RenderDrawer {
         }
     }
 
-    pub fn read_pixels(&self, rect: Option<Rect>, format: pixels::PixelFormatFlag) -> SdlResult<Vec<u8>> {
+    pub fn read_pixels(&self, rect: Option<Rect>, format: pixels::PixelFormatEnum) -> SdlResult<Vec<u8>> {
         unsafe {
             let (actual_rect, w, h) = match rect {
                 Some(ref rect) => (rect as *const _, rect.w as usize, rect.h as usize),
@@ -532,7 +532,7 @@ impl RenderTarget {
     }
 
     /// Creates a new texture and sets it as the render target.
-    pub fn create_and_set(&mut self, format: pixels::PixelFormatFlag, width: i32, height: i32) -> SdlResult<Texture> {
+    pub fn create_and_set(&mut self, format: pixels::PixelFormatEnum, width: i32, height: i32) -> SdlResult<Texture> {
         let new_texture_raw = unsafe {
             let access = ll::SDL_TEXTUREACCESS_TARGET;
             ll::SDL_CreateTexture(self.raw, format as uint32_t, access as c_int, width as c_int, height as c_int)
@@ -574,7 +574,7 @@ impl RenderTarget {
 
 #[derive(Copy, Clone)]
 pub struct TextureQuery {
-    pub format: pixels::PixelFormatFlag,
+    pub format: pixels::PixelFormatEnum,
     pub access: TextureAccess,
     pub width: i32,
     pub height: i32

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -511,8 +511,8 @@ pub struct TextureQuery {
 
 #[derive(PartialEq)] #[allow(raw_pointer_derive)]
 pub struct Texture {
-    pub raw: *const ll::SDL_Texture,
-    pub owned: bool
+    raw: *const ll::SDL_Texture,
+    owned: bool
 }
 
 impl Drop for Texture {

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -509,6 +509,30 @@ impl RenderTarget {
         }
     }
 
+    /// Creates a new texture and sets it as the render target.
+    pub fn create_and_set(&mut self, format: pixels::PixelFormatFlag, width: i32, height: i32) -> SdlResult<Texture> {
+        let new_texture_raw = unsafe {
+            let access = ll::SDL_TEXTUREACCESS_TARGET;
+            ll::SDL_CreateTexture(self.raw, format as uint32_t, access as c_int, width as c_int, height as c_int)
+        };
+
+        if new_texture_raw == ptr::null() {
+            Err(get_error())
+        } else {
+            unsafe {
+                if ll::SDL_SetRenderTarget(self.raw, new_texture_raw) == 0 {
+                    Ok(Texture {
+                        raw: new_texture_raw,
+                        owned: false,
+                        _marker: ContravariantLifetime
+                    })
+                } else {
+                    Err(get_error())
+                }
+            }
+        }
+    }
+
     /// Gets the current render target.
     /// Returns None if the default render target is set.
     pub fn get(&mut self) -> Option<Texture> {

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -91,22 +91,15 @@ pub enum RendererParent {
     Window(Window)
 }
 
-#[allow(raw_pointer_derive)]
 pub struct Renderer {
     raw: *const ll::SDL_Renderer,
     parent: Option<RendererParent>,
-    render_target: RefCell<RenderTarget>,
-    owned: bool
+    render_target: RefCell<RenderTarget>
 }
 
-#[unsafe_destructor]
 impl Drop for Renderer {
     fn drop(&mut self) {
-        if self.owned {
-            unsafe {
-                ll::SDL_DestroyRenderer(self.raw);
-            }
-        }
+        unsafe { ll::SDL_DestroyRenderer(self.raw) };
     }
 }
 
@@ -127,8 +120,7 @@ impl Renderer {
             Ok(Renderer {
                 raw: raw,
                 parent: Some(RendererParent::Window(window)),
-                render_target: RefCell::new(RenderTarget { raw: raw }),
-                owned: true
+                render_target: RefCell::new(RenderTarget { raw: raw })
             })
         }
     }
@@ -144,8 +136,7 @@ impl Renderer {
             Ok(Renderer {
                 raw: raw_renderer,
                 parent: Some(RendererParent::Window(window)),
-                render_target: RefCell::new(RenderTarget { raw: raw_renderer }),
-                owned: true
+                render_target: RefCell::new(RenderTarget { raw: raw_renderer })
             })
         } else {
             Err(get_error())
@@ -158,8 +149,7 @@ impl Renderer {
             Ok(Renderer {
                 raw: raw_renderer,
                 parent: Some(RendererParent::Surface(surface)),
-                render_target: RefCell::new(RenderTarget { raw: raw_renderer }),
-                owned: true
+                render_target: RefCell::new(RenderTarget { raw: raw_renderer })
             })
         } else {
             Err(get_error())

--- a/src/sdl2/surface.rs
+++ b/src/sdl2/surface.rs
@@ -317,7 +317,7 @@ impl Surface {
         }
     }
 
-    pub fn convert_format(&self, format: pixels::PixelFormatFlag) -> SdlResult<Surface> {
+    pub fn convert_format(&self, format: pixels::PixelFormatEnum) -> SdlResult<Surface> {
         let surface_ptr = unsafe { ll::SDL_ConvertSurfaceFormat(self.raw, format as uint32_t, 0u32) };
 
         if surface_ptr == ptr::null() {

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -255,7 +255,7 @@ impl Window {
         }
     }
 
-    pub fn get_window_pixel_format(&self) -> pixels::PixelFormatFlag {
+    pub fn get_window_pixel_format(&self) -> pixels::PixelFormatEnum {
         unsafe{ FromPrimitive::from_u64(ll::SDL_GetWindowPixelFormat(self.raw) as u64).unwrap() }
     }
 


### PR DESCRIPTION
Whew, that was a lot of work. Sorry for the large PR. :]

Sooo, most of this is contained within render.rs. All that really changed was: added a Texture lifetime, added `&mut self` to various methods, `RefCell`'d the draw methods, and implemented other ergonomic changes.
This is one of those times where Rust's borrow checker can be overly zealous/too restrictive (`RefCell`), but it generally works in our favor. To my knowledge, no crashes or aliasing problems should be possible.

An example using textures was added: `renderer-texture.rs`

Closes #293