### PR TITLE
Add documentation to render, other minor fixes

### DIFF
--- a/examples/renderer-texture.rs
+++ b/examples/renderer-texture.rs
@@ -35,10 +35,9 @@ pub fn main() {
     }).unwrap();
 
     let mut drawer = renderer.drawer();
-    // drawer.set_draw_color(Color::RGB(255, 0, 0));
     drawer.clear();
-    drawer.copy(&mut texture, None, Some(Rect::new(100, 100, 256, 256)));
-    drawer.copy_ex(&mut texture, None, Some(Rect::new(450, 100, 256, 256)), 30.0, None, (false, false));
+    drawer.copy(&texture, None, Some(Rect::new(100, 100, 256, 256)));
+    drawer.copy_ex(&texture, None, Some(Rect::new(450, 100, 256, 256)), 30.0, None, (false, false));
     drawer.present();
 
     loop {

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -1,3 +1,41 @@
+//! Official C documentation: https://wiki.libsdl.org/CategoryRender
+//! # Introduction
+//!
+//! This module contains functions for 2D accelerated rendering.
+//!
+//! This API supports the following features:
+//!
+//! * single pixel points
+//! * single pixel lines
+//! * filled rectangles
+//! * texture images
+//! * All of these may be drawn in opaque, blended, or additive modes.
+//!
+//! The texture images can have an additional color tint or alpha modulation
+//! applied to them, and may also be stretched with linear interpolation,
+//! rotated or flipped/mirrored.
+//!
+//! For advanced functionality like particle effects or actual 3D you should use
+//! SDL's OpenGL/Direct3D support or one of the many available 3D engines.
+//!
+//! This API is not designed to be used from multiple threads, see
+//! [this bug](http://bugzilla.libsdl.org/show_bug.cgi?id=1995) for details.
+//!
+//! # Rust differences
+//!
+//! The Rust version of the render API deviates slightly from the original,
+//! in order to be more idiomatic with Rust and to adhere to its notion of
+//! memory safety.
+//!
+//! All `Texture` types are restricted to live for only as long as
+//! the parent `Renderer`.
+//! Consequentially, this means that `Renderer` never mutates and that all
+//! drawing functionality is put behind interior mutability using
+//! `RefCell<RenderDrawer>`.
+//!
+//! None of the draw methods in `RenderDrawer` are expected to fail.
+//! If they do, a panic is raised and the program is aborted.
+
 use video;
 use video::Window;
 use surface;

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -423,18 +423,18 @@ impl RenderDrawer {
     }
 
     /// Sets the drawing scale for rendering on the current target.
-    pub fn set_scale(&mut self, scale_x: f64, scale_y: f64) {
-        let ret = unsafe { ll::SDL_RenderSetScale(self.raw, scale_x as c_float, scale_y as c_float) };
+    pub fn set_scale(&mut self, scale_x: f32, scale_y: f32) {
+        let ret = unsafe { ll::SDL_RenderSetScale(self.raw, scale_x, scale_y) };
         // Should only fail on an invalid renderer
         if ret != 0 { panic!(get_error()) }
     }
 
     /// Gets the drawing scale for the current target.
-    pub fn get_scale(&self) -> (f64, f64) {
-        let scale_x: c_float = 0.0;
-        let scale_y: c_float = 0.0;
+    pub fn get_scale(&self) -> (f32, f32) {
+        let scale_x = 0.0;
+        let scale_y = 0.0;
         unsafe { ll::SDL_RenderGetScale(self.raw, &scale_x, &scale_y) };
-        (scale_x as f64, scale_y as f64)
+        (scale_x, scale_y)
     }
 
     /// Draws a point on the current rendering target.

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -225,11 +225,16 @@ impl Renderer {
     /// belong to the Renderer.
     ///
     /// # Examples
-    /// ```
-    /// let mut drawer = renderer.drawer();
-    /// drawer.clear();
-    /// drawer.draw_rect(&Rect::new(50, 50, 150, 175));
-    /// drawer.present();
+    /// ```no_run
+    /// use sdl2::render::Renderer;
+    /// use sdl2::rect::Rect;
+    ///
+    /// fn test_draw(renderer: &Renderer) {
+    ///     let mut drawer = renderer.drawer();
+    ///     drawer.clear();
+    ///     drawer.draw_rect(&Rect::new(50, 50, 150, 175));
+    ///     drawer.present();
+    /// }
     /// ```
     pub fn drawer(&self) -> RefMut<RenderDrawer> {
         match self.drawer.try_borrow_mut() {

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -430,7 +430,7 @@ impl RenderDrawer {
         }
     }
 
-    pub fn copy(&mut self, texture: &mut Texture, src: Option<Rect>, dst: Option<Rect>) {
+    pub fn copy(&mut self, texture: &Texture, src: Option<Rect>, dst: Option<Rect>) {
         let ret = unsafe {
             ll::SDL_RenderCopy(
                 self.raw,
@@ -451,7 +451,7 @@ impl RenderDrawer {
         }
     }
 
-    pub fn copy_ex(&mut self, texture: &mut Texture, src: Option<Rect>, dst: Option<Rect>, angle: f64, center: Option<Point>, (flip_horizontal, flip_vertical): (bool, bool)) {
+    pub fn copy_ex(&mut self, texture: &Texture, src: Option<Rect>, dst: Option<Rect>, angle: f64, center: Option<Point>, (flip_horizontal, flip_vertical): (bool, bool)) {
         let flip = match (flip_horizontal, flip_vertical) {
             (false, false) => ll::SDL_FLIP_NONE,
             (true, false) => ll::SDL_FLIP_HORIZONTAL,


### PR DESCRIPTION
Most of the documentation is pretty much cut-and-paste from https://wiki.libsdl.org/CategoryRender.
Other Rust-specific documentation was added where it was needed.

Other fixes unnoticed from last time:
* copy() and copy_ex() should take a `&Texture`; the texture is never modified by these methods.
* `f64` was changed to `f32`, as SDL uses floats and not doubles
* `SdlResult<>` was removed from some texture methods in favor of panics. These are getters and setters that can only fail if the texture is invalid, which should basically never happen.