### PR TITLE
Audio thread safety, improve AudioCVT

### DIFF
--- a/sdl2-sys/src/audio.rs
+++ b/sdl2-sys/src/audio.rs
@@ -44,7 +44,8 @@ pub type SDL_AudioFilter =
     ::std::option::Option<extern "C" fn
                               (arg1: *const SDL_AudioCVT,
                                arg2: SDL_AudioFormat)>;
-#[allow(dead_code, missing_copy_implementations)]
+#[allow(dead_code, missing_copy_implementations, raw_pointer_derive)]
+#[derive(Copy)]
 #[repr(C)]
 pub struct SDL_AudioCVT {
     pub needed: c_int,

--- a/src/sdl2/audio.rs
+++ b/src/sdl2/audio.rs
@@ -390,6 +390,8 @@ pub struct AudioDeviceLockGuard<'a, CB: 'a> {
     device: &'a mut AudioDevice<CB>
 }
 
+impl<'a, CB: 'a> !Send for AudioDeviceLockGuard<'a, CB> {}
+
 impl<'a, CB: 'a> Deref for AudioDeviceLockGuard<'a, CB> {
     type Target = CB;
     fn deref(&self) -> &CB { &self.device.userdata.callback }

--- a/src/sdl2/audio.rs
+++ b/src/sdl2/audio.rs
@@ -141,7 +141,7 @@ impl Drop for AudioSpecWAV {
     }
 }
 
-pub trait AudioCallback<T> {
+pub trait AudioCallback<T>: Send {
     fn callback(&mut self, &mut [T]);
 }
 

--- a/src/sdl2/audio.rs
+++ b/src/sdl2/audio.rs
@@ -476,7 +476,7 @@ impl AudioCVT {
     /// converted data.
     pub fn get_capacity(&self, src_len: usize) -> usize {
         use std::num::Int;
-        src_len.checked_mul(self.raw.len_mult as usize).expect("Interger overflow")
+        src_len.checked_mul(self.raw.len_mult as usize).expect("Integer overflow")
     }
 }
 

--- a/src/sdl2/lib.rs
+++ b/src/sdl2/lib.rs
@@ -1,7 +1,7 @@
 #![crate_name = "sdl2"]
 #![crate_type = "lib"]
 
-#![feature(slicing_syntax, unsafe_destructor)]
+#![feature(slicing_syntax, unsafe_destructor, optin_builtin_traits)]
 
 extern crate libc;
 extern crate collections;


### PR DESCRIPTION
The `AudioCallback` trait must implement [`Send`](http://doc.rust-lang.org/std/marker/trait.Send.html).
`Send` declares that the audio callback data is safe to be sent across other threads (i.e. the audio callback thread).

As a result, types that can only be used on a single thread, such as `Rc<T>`, raw pointers and even our own `Renderer`, cannot be sent.

As long as the struct implementing `AudioCallback` does not include any non-Sendable fields, user code should compile without explicitly having to declare `Send`. Notice the audio-whitenoise example didn't change at all.

The only drawback is that `Send` imposes a `'static` lifetime. That means no (non-static) references are allowed to be stored in the audio callback. However, the restriction should (hopefully) be lifted soon with https://github.com/rust-lang/rfcs/pull/458.

---
Changes to `AudioCVT` are fairly simple. Because I'm getting lazy and don't want to write more things, you can just read the commit messages if you want more details. :D