### PR TITLE
Remove owned fields in favor of `Unowned<T>` struct?

### DIFF
--- a/src/sdl2/lib.rs
+++ b/src/sdl2/lib.rs
@@ -10,7 +10,7 @@ extern crate bitflags;
 extern crate "sdl2-sys" as sys;
 
 pub use sdl::*;
-pub use unowned::Unowned;
+pub use unowned::{Unowned, UnownedMut};
 
 pub mod keycode;
 pub mod scancode;

--- a/src/sdl2/lib.rs
+++ b/src/sdl2/lib.rs
@@ -10,6 +10,7 @@ extern crate bitflags;
 extern crate "sdl2-sys" as sys;
 
 pub use sdl::*;
+pub use unowned::Unowned;
 
 pub mod keycode;
 pub mod scancode;
@@ -37,3 +38,5 @@ pub mod sdl;
 pub mod audio;
 pub mod version;
 pub mod messagebox;
+
+mod unowned;

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -43,6 +43,7 @@ use surface::Surface;
 use pixels;
 use get_error;
 use SdlResult;
+use Unowned;
 use std::mem;
 use std::ptr;
 use std::raw;
@@ -257,7 +258,7 @@ impl Renderer {
         if result == ptr::null() {
             Err(get_error())
         } else {
-            Ok(Texture { raw: result, owned: true, _marker: ContravariantLifetime } )
+            Ok(Texture { raw: result, _marker: ContravariantLifetime } )
         }
     }
 
@@ -284,7 +285,7 @@ impl Renderer {
         if result == ptr::null() {
             Err(get_error())
         } else {
-            Ok(Texture { raw: result, owned: true, _marker: ContravariantLifetime } )
+            Ok(Texture { raw: result, _marker: ContravariantLifetime } )
         }
     }
 }
@@ -705,7 +706,7 @@ impl RenderTarget {
     }
 
     /// Creates a new texture and sets it as the render target.
-    pub fn create_and_set(&mut self, format: pixels::PixelFormatEnum, width: i32, height: i32) -> SdlResult<Texture> {
+    pub fn create_and_set(&mut self, format: pixels::PixelFormatEnum, width: i32, height: i32) -> SdlResult<Unowned<Texture>> {
         let new_texture_raw = unsafe {
             let access = ll::SDL_TEXTUREACCESS_TARGET;
             ll::SDL_CreateTexture(self.raw, format as uint32_t, access as c_int, width as c_int, height as c_int)
@@ -716,11 +717,10 @@ impl RenderTarget {
         } else {
             unsafe {
                 if ll::SDL_SetRenderTarget(self.raw, new_texture_raw) == 0 {
-                    Ok(Texture {
+                    Ok(Unowned::new(Texture {
                         raw: new_texture_raw,
-                        owned: false,
                         _marker: ContravariantLifetime
-                    })
+                    }))
                 } else {
                     Err(get_error())
                 }
@@ -730,17 +730,18 @@ impl RenderTarget {
 
     /// Gets the current render target.
     /// Returns None if the default render target is set.
-    pub fn get(&mut self) -> Option<Texture> {
+    pub fn get(&mut self) -> Option<Unowned<Texture>> {
         let texture_raw = unsafe {  ll::SDL_GetRenderTarget(self.raw) };
 
         if texture_raw == ptr::null() {
             None
         } else {
-            Some(Texture {
-                raw: texture_raw,
-                owned: false,
-                _marker: ContravariantLifetime
-            })
+            unsafe {
+                Some(Unowned::new(Texture {
+                    raw: texture_raw,
+                    _marker: ContravariantLifetime
+                }))
+            }
         }
     }
 }
@@ -760,7 +761,6 @@ pub struct TextureQuery {
 #[derive(PartialEq)] #[allow(raw_pointer_derive)]
 pub struct Texture<'renderer> {
     raw: *const ll::SDL_Texture,
-    owned: bool,
     /// Textures cannot live longer than the Renderer it was born from: 'a
     /// All SDL textures contain an internal reference to a Renderer
     _marker: ContravariantLifetime<'renderer>
@@ -769,11 +769,7 @@ pub struct Texture<'renderer> {
 #[unsafe_destructor]
 impl<'renderer> Drop for Texture<'renderer> {
     fn drop(&mut self) {
-        if self.owned {
-            unsafe {
-                ll::SDL_DestroyTexture(self.raw);
-            }
-        }
+        unsafe { ll::SDL_DestroyTexture(self.raw) };
     }
 }
 

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -43,7 +43,7 @@ use surface::Surface;
 use pixels;
 use get_error;
 use SdlResult;
-use Unowned;
+use {Unowned, UnownedMut};
 use std::mem;
 use std::ptr;
 use std::raw;
@@ -706,7 +706,7 @@ impl RenderTarget {
     }
 
     /// Creates a new texture and sets it as the render target.
-    pub fn create_and_set(&mut self, format: pixels::PixelFormatEnum, width: i32, height: i32) -> SdlResult<Unowned<Texture>> {
+    pub fn create_and_set(&mut self, format: pixels::PixelFormatEnum, width: i32, height: i32) -> SdlResult<UnownedMut<Texture>> {
         let new_texture_raw = unsafe {
             let access = ll::SDL_TEXTUREACCESS_TARGET;
             ll::SDL_CreateTexture(self.raw, format as uint32_t, access as c_int, width as c_int, height as c_int)
@@ -717,7 +717,7 @@ impl RenderTarget {
         } else {
             unsafe {
                 if ll::SDL_SetRenderTarget(self.raw, new_texture_raw) == 0 {
-                    Ok(Unowned::new(Texture {
+                    Ok(UnownedMut::new(Texture {
                         raw: new_texture_raw,
                         _marker: ContravariantLifetime
                     }))
@@ -730,7 +730,7 @@ impl RenderTarget {
 
     /// Gets the current render target.
     /// Returns None if the default render target is set.
-    pub fn get(&mut self) -> Option<Unowned<Texture>> {
+    pub fn get(&self) -> Option<Unowned<Texture>> {
         let texture_raw = unsafe {  ll::SDL_GetRenderTarget(self.raw) };
 
         if texture_raw == ptr::null() {
@@ -738,6 +738,23 @@ impl RenderTarget {
         } else {
             unsafe {
                 Some(Unowned::new(Texture {
+                    raw: texture_raw,
+                    _marker: ContravariantLifetime
+                }))
+            }
+        }
+    }
+
+    /// Gets the current render target.
+    /// Returns None if the default render target is set.
+    pub fn get_mut(&mut self) -> Option<UnownedMut<Texture>> {
+        let texture_raw = unsafe {  ll::SDL_GetRenderTarget(self.raw) };
+
+        if texture_raw == ptr::null() {
+            None
+        } else {
+            unsafe {
+                Some(UnownedMut::new(Texture {
                     raw: texture_raw,
                     _marker: ContravariantLifetime
                 }))

--- a/src/sdl2/unowned.rs
+++ b/src/sdl2/unowned.rs
@@ -2,7 +2,7 @@ use std::marker::ContravariantLifetime;
 use std::mem;
 use std::ops::{Deref, DerefMut};
 
-/// An unowned value.
+/// An unowned shared value.
 ///
 /// This type is used by rust-sdl2 when obtaining a handle owned by a parent
 /// resource.
@@ -30,15 +30,49 @@ impl<'a, T> Deref for Unowned<'a, T> {
     fn deref(&self) -> &T { self.value.as_ref().unwrap() }
 }
 
-impl<'a, T> DerefMut for Unowned<'a, T> {
-    fn deref_mut(&mut self) -> &mut T { self.value.as_mut().unwrap() }
-}
-
 impl<'a, T> Unowned<'a, T> {
     pub unsafe fn new<'l>(value: T) -> Unowned<'l, T> {
         Unowned {
             value: Some(value),
-            _marker: ContravariantLifetime::<'l>
+            _marker: ContravariantLifetime
+        }
+    }
+}
+
+/// An unowned mutable value.
+///
+/// This type is used by rust-sdl2 when obtaining a handle owned by a parent
+/// resource.
+///
+/// This does not free the underlying value when dropped.
+/// Instead, `std::mem::forget()` is called on the value when dropped.
+pub struct UnownedMut<'a, T> {
+    value: Option<T>,
+    _marker: ContravariantLifetime<'a>
+}
+
+#[unsafe_destructor]
+impl<'a, T> Drop for UnownedMut<'a, T> {
+    fn drop(&mut self) {
+        unsafe { mem::forget(mem::replace(&mut self.value, None)) };
+    }
+}
+
+impl<'a, T> Deref for UnownedMut<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &T { self.value.as_ref().unwrap() }
+}
+
+impl<'a, T> DerefMut for UnownedMut<'a, T> {
+    fn deref_mut(&mut self) -> &mut T { self.value.as_mut().unwrap() }
+}
+
+impl<'a, T> UnownedMut<'a, T> {
+    pub unsafe fn new<'l>(value: T) -> UnownedMut<'l, T> {
+        UnownedMut {
+            value: Some(value),
+            _marker: ContravariantLifetime
         }
     }
 }

--- a/src/sdl2/unowned.rs
+++ b/src/sdl2/unowned.rs
@@ -1,0 +1,39 @@
+use std::mem;
+use std::ops::{Deref, DerefMut};
+
+/// An unowned value.
+///
+/// This type is used by rust-sdl2 when obtaining a handle owned by a parent
+/// resource.
+///
+/// This does not free the underlying value when dropped.
+/// Instead, `std::mem::forget()` is called on the value when dropped.
+pub struct Unowned<T> {
+    /// The reason `Option` is used is because `std::mem::forget` consumes
+    /// a value. The only way to obtain the value from drop() is to swap this
+    /// field with a non-dropping variant such as None.
+    value: Option<T>
+}
+
+#[unsafe_destructor]
+impl<T> Drop for Unowned<T> {
+    fn drop(&mut self) {
+        unsafe { mem::forget(mem::replace(&mut self.value, None)) };
+    }
+}
+
+impl<T> Deref for Unowned<T> {
+    type Target = T;
+
+    fn deref(&self) -> &T { self.value.as_ref().unwrap() }
+}
+
+impl<T> DerefMut for Unowned<T> {
+    fn deref_mut(&mut self) -> &mut T { self.value.as_mut().unwrap() }
+}
+
+impl<T> Unowned<T> {
+    pub unsafe fn new(value: T) -> Unowned<T> {
+        Unowned { value: Some(value) }
+    }
+}


### PR DESCRIPTION
I'd like some input on the idea of introducing an `Unowned<T>` struct. `Unowned<T>` would act as an alternative to the `owned: bool` fields that exist in various SDL types. This PR offers just a taste of what I'm proposing in the long run.

## The old way

The following SDL types currently implement an `owned: bool` field:
* AudioCVT (removed in #312)
* Cursor
* GLContext
* RWops
* Surface
* Texture (removed in this PR)
* Window
* Timer

Each of the above types implement `Drop` which will free the underlying value, **IFF** `self.owned` is set to true. Basically, **destruction is conditional**.

This makes sense for when these types are "borrowed" from a parent resource (i.e. obtain a `Surface` owned by `Window` with `get_surface()`). Because the parent owns them, the value should not be freed when it falls out of scope. It works.

In practice, I find it confusing. In the Rustdocs, when reading over the `Window` type, I'll see:
```rust
pub fn get_surface(&self) -> SdlResult<Surface>
```
To a newcomer, it looks like `get_surface()` is allocating a _brand new surface_ for us. But as we know, this is not the case.

## `Unowned<T>`
Compare it to:
```rust
pub fn get_surface(&mut self) -> SdlResult<Unowned<Surface>>
```
It's slightly less ambiguous; we now know that we're no longer obtaining an "ordinary" surface.

`Unowned<T>` works by using `std::mem::forget()` on the underlying value when dropped. It forces the value to never be freed in the way it usually is. It also implements `Deref` and `DerefMut`, so we can continue to access `Surface`'s methods seamlessly.

Understandably though, I could see how this might still be confusing.

## Ideally...
But, _the best syntax_ would look like this. Unfortunately, it seems unattainable without resorting to transmuting and DSTs.
```rust
pub fn get_surface(&self) -> SdlResult<&Surface>
```
The reference sigil makes it super obvious that the surface belongs to the window. No ambiguity here.

But... if a type like `Surface` were made into a DST (which I'm unsure how to even do), it could not be used as a regular value with a defined size. No more declaring owned types on the stack. DSTs seem out of the question.

---
Over the long run, I'd like to see an elimination of all `owned: bool` fields in favor of using `Unowned<T>` where it's needed.

So, what you do think of this? Is it rubbish/unclear? Maybe `Unowned` could be renamed to something clearer?