### PR TITLE
Fix All Compile Warnings

### DIFF
--- a/examples/audio-whitenoise.rs
+++ b/examples/audio-whitenoise.rs
@@ -1,3 +1,5 @@
+#![feature(rand)]
+
 extern crate sdl2;
 
 use sdl2::audio::{AudioCallback, AudioSpecDesired};

--- a/examples/game_controller.rs
+++ b/examples/game_controller.rs
@@ -1,3 +1,5 @@
+#![feature(io, std_misc, core)]
+
 extern crate sdl2;
 
 use sdl2::{joystick, controller};

--- a/sdl2-sys/build.rs
+++ b/sdl2-sys/build.rs
@@ -1,3 +1,5 @@
+#![feature(os)]
+
 extern crate "pkg-config" as pkg_config;
 
 fn main() {

--- a/sdl2-sys/src/lib.rs
+++ b/sdl2-sys/src/lib.rs
@@ -1,5 +1,7 @@
 #![allow(non_camel_case_types)]
 
+#![feature(core, libc)]
+
 extern crate libc;
 
 pub mod scancode;

--- a/sdl2-sys/src/rect.rs
+++ b/sdl2-sys/src/rect.rs
@@ -6,7 +6,7 @@ use std::mem;
 use libc::c_int;
 
 /// A structure that defines a two dimensional point.
-#[derive(PartialEq, Clone, Show, Copy)]
+#[derive(PartialEq, Clone, Debug, Copy)]
 #[repr(C)]
 pub struct Point {
     pub x: i32,
@@ -14,7 +14,7 @@ pub struct Point {
 }
 
 /// A structure that defines a rectangle, with the origin at the upper left.
-#[derive(PartialEq, Clone, Show, Copy)]
+#[derive(PartialEq, Clone, Debug, Copy)]
 #[repr(C)]
 pub struct Rect {
     pub x: i32,

--- a/src/sdl2/audio.rs
+++ b/src/sdl2/audio.rs
@@ -33,7 +33,7 @@ pub const AUDIOS32SYS : AudioFormat = ll::AUDIO_S32SYS;
 pub const AUDIOF32SYS : AudioFormat = ll::AUDIO_F32SYS;
 
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq, Hash, Show, FromPrimitive)]
+#[derive(Copy, Clone, PartialEq, Hash, Debug, FromPrimitive)]
 pub enum AudioStatus {
     Stopped = ll::SDL_AUDIO_STOPPED as isize,
     Playing = ll::SDL_AUDIO_PLAYING as isize,
@@ -288,7 +288,7 @@ impl<T: AudioFormatNum<T>, CB: AudioCallback<T>> AudioSpecDesired<T, CB> {
 }
 
 #[allow(missing_copy_implementations)]
-#[derive(Show)]
+#[derive(Debug)]
 pub struct AudioSpec {
     pub freq: i32,
     // TODO: Showing format should be prettier

--- a/src/sdl2/controller.rs
+++ b/src/sdl2/controller.rs
@@ -7,7 +7,7 @@ use get_error;
 use sys::controller as ll;
 use sys::event::{SDL_QUERY, SDL_ENABLE};
 
-#[derive(Copy, Clone, PartialEq, Show)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 #[repr(i32)]
 pub enum Axis {
     Invalid      = ll::SDL_CONTROLLER_AXIS_INVALID,
@@ -53,7 +53,7 @@ pub fn wrap_controller_axis(bitflags: u8) -> Axis {
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Show)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 #[repr(i32)]
 pub enum Button {
     Invalid       = ll::SDL_CONTROLLER_BUTTON_INVALID,

--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -82,7 +82,7 @@ pub enum EventType {
     Last = ll::SDL_LASTEVENT,
 }
 
-#[derive(Copy, Clone, Show)]
+#[derive(Copy, Clone, Debug)]
 /// An enum of window events.
 pub enum WindowEventId {
     None,

--- a/src/sdl2/gesture.rs
+++ b/src/sdl2/gesture.rs
@@ -1,1 +1,2 @@
+#[allow(unused)]
 use sys::gesture as ll;

--- a/src/sdl2/haptic.rs
+++ b/src/sdl2/haptic.rs
@@ -1,2 +1,3 @@
 //! Haptic Functions
+#[allow(unused)]
 use sys::haptic as ll;

--- a/src/sdl2/keycode.rs
+++ b/src/sdl2/keycode.rs
@@ -3,7 +3,7 @@ use std::num::ToPrimitive;
 
 use sys::keycode as ll;
 
-#[derive(PartialEq, Eq, FromPrimitive, Show, Copy)]
+#[derive(PartialEq, Eq, FromPrimitive, Debug, Copy)]
 pub enum KeyCode {
     Unknown            = ll::SDLK_UNKNOWN as isize,
     Backspace          = ll::SDLK_BACKSPACE as isize,

--- a/src/sdl2/lib.rs
+++ b/src/sdl2/lib.rs
@@ -1,7 +1,7 @@
 #![crate_name = "sdl2"]
 #![crate_type = "lib"]
 
-#![feature(slicing_syntax, unsafe_destructor)]
+#![feature(slicing_syntax, unsafe_destructor, std_misc, io, libc, hash, core, collections, rand, path)]
 
 extern crate libc;
 extern crate collections;

--- a/src/sdl2/pixels.rs
+++ b/src/sdl2/pixels.rs
@@ -62,7 +62,7 @@ pub struct PixelFormat {
 impl_raw_accessors!((PixelFormat, *const ll::SDL_PixelFormat));
 impl_raw_constructor!((PixelFormat, PixelFormat (raw: *const ll::SDL_PixelFormat)));
 
-#[derive(Copy, Clone, PartialEq, Show, FromPrimitive)]
+#[derive(Copy, Clone, PartialEq, Debug, FromPrimitive)]
 pub enum PixelFormatEnum {
     Unknown = ll::SDL_PIXELFORMAT_UNKNOWN as isize,
     Index1LSB = ll::SDL_PIXELFORMAT_INDEX1LSB as isize,

--- a/src/sdl2/scancode.rs
+++ b/src/sdl2/scancode.rs
@@ -3,7 +3,7 @@ use std::num::ToPrimitive;
 
 use sys::scancode as ll;
 
-#[derive(PartialEq, Eq, FromPrimitive, Show, Copy)]
+#[derive(PartialEq, Eq, FromPrimitive, Debug, Copy)]
 pub enum ScanCode {
     Unknown            = ll::SDL_SCANCODE_UNKNOWN as isize,
     A                  = ll::SDL_SCANCODE_A as isize,

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,3 +1,5 @@
+#![feature(path)]
+
 extern crate sdl2;
 
 #[test]


### PR DESCRIPTION
### Code Review

 - Update `derive(Show)` to the new recommended `derive(Debug)`.
 - Use `#![feature()]` tags for path, io, libc, and others, as necessary.

A clean rebuild no longer has any warnings.
