### PR TITLE
Renderer changes

### DIFF
--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -101,21 +101,19 @@ pub enum BlendMode {
 }
 
 impl RendererInfo {
-    pub fn from_ll(info: &ll::SDL_RendererInfo) -> RendererInfo {
+    pub unsafe fn from_ll(info: &ll::SDL_RendererInfo) -> RendererInfo {
         let actual_flags = RendererFlags::from_bits(info.flags).unwrap();
 
-        unsafe {
-            let texture_formats: Vec<pixels::PixelFormatEnum> = info.texture_formats[0..(info.num_texture_formats as usize)].iter().map(|&format| {
-                FromPrimitive::from_i64(format as i64).unwrap()
-            }).collect();
+        let texture_formats: Vec<pixels::PixelFormatEnum> = info.texture_formats[0..(info.num_texture_formats as usize)].iter().map(|&format| {
+            FromPrimitive::from_i64(format as i64).unwrap()
+        }).collect();
 
-            RendererInfo {
-                name: String::from_utf8_lossy(c_str_to_bytes(&info.name)).to_string(),
-                flags: actual_flags,
-                texture_formats: texture_formats,
-                max_texture_width: info.max_texture_width as i32,
-                max_texture_height: info.max_texture_height as i32
-            }
+        RendererInfo {
+            name: String::from_utf8_lossy(c_str_to_bytes(&info.name)).to_string(),
+            flags: actual_flags,
+            texture_formats: texture_formats,
+            max_texture_width: info.max_texture_width as i32,
+            max_texture_height: info.max_texture_height as i32
         }
     }
 }
@@ -1050,7 +1048,7 @@ pub fn get_render_driver_info(index: i32) -> SdlResult<RendererInfo> {
     };
     let result = unsafe { ll::SDL_GetRenderDriverInfo(index as c_int, &out) == 0 };
     if result {
-        Ok(RendererInfo::from_ll(&out))
+        unsafe { Ok(RendererInfo::from_ll(&out)) }
     } else {
         Err(get_error())
     }

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -211,14 +211,42 @@ impl Renderer {
     #[inline]
     pub fn get_parent(&self) -> &RendererParent { self.parent.as_ref().unwrap() }
 
-    /// Unwraps the window or surface the rendering context was created from.
     #[inline]
-    pub unsafe fn raw(&self) -> *const ll::SDL_Renderer { self.raw }
+    pub fn get_parent_as_window(&self) -> Option<&Window> {
+        match self.get_parent() {
+            &RendererParent::Window(ref window) => Some(window),
+            _ => None
+        }
+    }
+
+    #[inline]
+    pub fn get_parent_as_surface(&self) -> Option<&Surface> {
+        match self.get_parent() {
+            &RendererParent::Surface(ref surface) => Some(surface),
+            _ => None
+        }
+    }
 
     #[inline]
     pub fn unwrap_parent(mut self) -> RendererParent {
         use std::mem;
         mem::replace(&mut self.parent, None).unwrap()
+    }
+
+    #[inline]
+    pub fn unwrap_parent_as_window(self) -> Option<Window> {
+        match self.unwrap_parent() {
+            RendererParent::Window(window) => Some(window),
+            _ => None
+        }
+    }
+
+    #[inline]
+    pub fn unwrap_parent_as_surface(self) -> Option<Surface> {
+        match self.unwrap_parent() {
+            RendererParent::Surface(surface) => Some(surface),
+            _ => None
+        }
     }
 
     /// Provides drawing methods for the renderer.
@@ -251,6 +279,10 @@ impl Renderer {
             None => panic!("Renderer drawer already borrowed")
         }
     }
+
+    /// Unwraps the window or surface the rendering context was created from.
+    #[inline]
+    pub unsafe fn raw(&self) -> *const ll::SDL_Renderer { self.raw }
 }
 
 /// Texture-creating methods for the renderer

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -261,7 +261,7 @@ impl Renderer {
     /// fn test_draw(renderer: &Renderer) {
     ///     let mut drawer = renderer.drawer();
     ///     drawer.clear();
-    ///     drawer.draw_rect(&Rect::new(50, 50, 150, 175));
+    ///     drawer.draw_rect(Rect::new(50, 50, 150, 175));
     ///     drawer.present();
     /// }
     /// ```
@@ -566,9 +566,9 @@ impl<'renderer> RenderDrawer<'renderer> {
     /// Draws a rectangle on the current rendering target.
     /// # Panics
     /// Panics if drawing fails for any reason (e.g. driver failure)
-    pub fn draw_rect(&mut self, rect: &Rect) {
+    pub fn draw_rect(&mut self, rect: Rect) {
         unsafe {
-            if ll::SDL_RenderDrawRect(self.raw, rect) != 0 {
+            if ll::SDL_RenderDrawRect(self.raw, &rect) != 0 {
                 panic!("Error drawing rect: {}", get_error())
             }
         }
@@ -589,9 +589,9 @@ impl<'renderer> RenderDrawer<'renderer> {
     /// color.
     /// # Panics
     /// Panics if drawing fails for any reason (e.g. driver failure)
-    pub fn fill_rect(&mut self, rect: &Rect) {
+    pub fn fill_rect(&mut self, rect: Rect) {
         unsafe {
-            if ll::SDL_RenderFillRect(self.raw, rect) != 0 {
+            if ll::SDL_RenderFillRect(self.raw, &rect) != 0 {
                 panic!("Error filling rect: {}", get_error())
             }
         }

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -183,7 +183,7 @@ impl Renderer {
     /// Creates a 2D software rendering context for a surface.
     pub fn from_surface(surface: surface::Surface) -> SdlResult<Renderer> {
         let raw_renderer = unsafe { ll::SDL_CreateSoftwareRenderer(surface.raw()) };
-        if raw_renderer == ptr::null() {
+        if raw_renderer != ptr::null() {
             Ok(Renderer {
                 raw: raw_renderer,
                 parent: Some(RendererParent::Surface(surface)),


### PR DESCRIPTION
I queued up some Renderer changes over the course of two days so that it's all in one nice PR. :)

So, `Renderer::drawer()` now returns a simple `RenderDrawer<'renderer>` instead of `RefMut<RendererDrawer>`. This is actually to address a safety concern.

You were literally able to swap the RenderDrawers of two renderers. This is what you get when you have mutable references to things. :|
```rust
fn swap_drawers(r1: &Renderer, r2: &Renderer) {
    let d1_mut = r1.drawer().deref_mut();
    let d2_mut = r2.drawer().deref_mut();
    // whaaaattt...
    std::mem::swap(d1_mut, d2_mut);
}
```
You can't do this anymore because `Renderer::drawer()` returns a value and not a mutable reference or a type with `DerefMut`.

As I was writing this PR, I caught the same issue with `RenderDrawer::render_target()`. It now returns a value with a lifetime.

This PR makes _almost_ no breaking changes.
The only breaking changes are that `Renderer::drawer()` and `RenderDrawer::render_target()` each technically return a different type (although most people won't notice), and that `RendererInfo::from_ll()` is now unsafe.

---
Fixes #319
Implements ergonomic additions from https://github.com/AngryLawyer/rust-sdl2/issues/317#issuecomment-72596475
https://github.com/xsleonard/rust-sdl2_image/pull/28
