### PR TITLE
Upgraded `Timer` API and fix `Timer` tests...

### DIFF
--- a/src/sdl2/timer.rs
+++ b/src/sdl2/timer.rs
@@ -21,7 +21,7 @@ pub fn delay(ms: u32) {
 #[unstable = "Unstable because of move to unboxed closures and `box` syntax"]
 pub struct Timer<F> {
     callback: Option<Box<F>>,
-    _delay: usize,
+    _delay: u32,
     raw: ll::SDL_TimerID,
 }
 
@@ -30,11 +30,10 @@ impl<F> Timer<F> {
     /// The timer is started immediately, it will be cancelled either:
     ///   * when the timer is dropped
     ///   * or when the callback returns a non-positive continuation interval
-    pub fn new(delay: usize, callback: Box<F>) -> Timer<F>
+    pub fn new(delay: u32, callback: Box<F>) -> Timer<F>
     where F: Fn() -> u32, F: Send {
-
-        let timer = unsafe {
-            let timer_id = ll::SDL_AddTimer(delay as u32,
+        unsafe {
+            let timer_id = ll::SDL_AddTimer(delay,
                                             Some(c_timer_callback::<F>),
                                             mem::transmute_copy(&callback));
 
@@ -43,9 +42,7 @@ impl<F> Timer<F> {
                 _delay: delay,
                 raw: timer_id,
             }
-        };
-
-        return timer;
+        }
     }
 
     pub fn into_inner(mut self) -> Box<F> { self.callback.take().unwrap() }

--- a/src/sdl2/timer.rs
+++ b/src/sdl2/timer.rs
@@ -18,6 +18,7 @@ pub fn delay(ms: u32) {
     unsafe { ll::SDL_Delay(ms) }
 }
 
+#[unstable = "Unstable because of move to unboxed closures and `box` syntax"]
 pub struct Timer<F> {
     _callback: Box<F>,
     _delay: usize,
@@ -25,7 +26,6 @@ pub struct Timer<F> {
 }
 
 impl<F> Timer<F> {
-    #[unstable]
     /// Constructs a new timer using the boxed closure `callback`.
     /// The timer is started immediately, it will be cancelled either:
     ///   * when the timer is dropped


### PR DESCRIPTION
This PR is based on the feedback from issue #320 ... it introduces a more Rust-like interface for the Timer wrapper that is much less error-prone, and also memory safe!

To summarize how it works: 

* The user passes a `boxed` closure to the timer, e.g: `let t = Timer::new(Box::new(move|| { ... }));`
* The timer runs until that closure returns a 0-interval OR ...
* The timer is forcibly cancelled when it is dropped, this is because the closure will go out of scope, so further
  invocations would point to freed memory.

---

This also improves thread safety over the previous API(s), from the SDL2 documentation:

> Use this function to set up a callback function to be run _on a separate thread_ after the specified number of milliseconds has elapsed.

Since the callback might be run on a separate thread: the closure's environment must satisfy `Send` so that it can be moved to the thread the timer will run on.

Knowing this: it would also be unsafe to allow the closure to freely mutate its environment, so the closure does not allow for a mutable environment. In practice this simply means you have to protect mutable data w/ a `Mutex` or `RwLock`, and shared data w/ an `Arc`.

---

The tests have been improved so they hopefully don't fail spuriously anymore. I accomplished this by simply adding an upper-bound to the timer's callback so it stops trying to acquire the mutex after a certain number of iterations.

---

The whole thing is marked `unstable` for a number of reasons:

1. ... well, we've changed it 3 times now, so it really isn't stable
2. Since we're forcing the caller to wrap the closure in a `Box<T>` we may ~~need~~ want to change the API based on how the placement-new syntax (`#![feature(box)]`) pans out in rust-1.0.0
3. We may want some sugar so the caller doesn't have to wrap the closure in a `Box<T>` themselves?
