### PR TITLE
Use crates.io libc.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ path       = "src/sdl2/lib.rs"
 
 [dependencies]
 bitflags = "0.1"
+libc = "*"
 
 [dependencies.sdl2-sys]
 

--- a/sdl2-sys/Cargo.toml
+++ b/sdl2-sys/Cargo.toml
@@ -13,6 +13,9 @@ build = "build.rs"
 name = "sdl2-sys"
 path = "src/lib.rs"
 
+[dependencies]
+libc = "*"
+
 [build-dependencies]
 pkg-config = "0.1.7"
 

--- a/sdl2-sys/src/lib.rs
+++ b/sdl2-sys/src/lib.rs
@@ -1,6 +1,6 @@
 #![allow(non_camel_case_types)]
 
-#![feature(core, libc)]
+#![feature(core)]
 
 extern crate libc;
 

--- a/src/sdl2/lib.rs
+++ b/src/sdl2/lib.rs
@@ -1,7 +1,7 @@
 #![crate_name = "sdl2"]
 #![crate_type = "lib"]
 
-#![feature(slicing_syntax, unsafe_destructor, optin_builtin_traits, std_misc, io, libc, hash, core, collections, rand, path)]
+#![feature(slicing_syntax, unsafe_destructor, optin_builtin_traits, std_misc, io, hash, core, collections, rand, path)]
 
 extern crate libc;
 extern crate collections;


### PR DESCRIPTION
Using a different version can cause annoying conflicts when used with packages that do use the crates.io version, like `gl-rs`:

     expected `extern "C" fn(u32, *const libc::types::common::c95::c_void) -> u32`,
        found `extern "C" fn(u32, *const libc::types::common::c95::c_void) -> u32`
    (expected enum `libc::types::common::c95::c_void`,
        found a different enum `libc::types::common::c95::c_void`) [E0308]

I'm not sure if a catchall version is appropriate, though.