### PR TITLE
Fix spurious timer test failures

### DIFF
--- a/src/sdl2/timer.rs
+++ b/src/sdl2/timer.rs
@@ -72,25 +72,30 @@ extern "C" fn c_timer_callback(_interval: u32, param: *const c_void) -> uint32_t
 }
 
 
+#[cfg(test)] use std::sync::{StaticMutex, MUTEX_INIT};
+#[cfg(test)] static TIMER_INIT_LOCK: StaticMutex = MUTEX_INIT;
+
 #[test]
 fn test_timer_runs_multiple_times() {
     use std::sync::{Arc, Mutex};
+    let running = TIMER_INIT_LOCK.lock().unwrap();
+    ::sdl::init(::sdl::INIT_TIMER);
 
     let local_num = Arc::new(Mutex::new(0));
     let timer_num = local_num.clone();
 
-    let timer = Timer::new(100, Box::new(|| {
+    let timer = Timer::new(20, Box::new(|| {
         // increment up to 10 times (0 -> 9)
         // tick again in 100ms after each increment
         //
         let mut num = timer_num.lock().unwrap();
         if *num < 9 {
             *num += 1;
-            100
+            20
         } else { 0 }
     }));
 
-    delay(1200);                         // tick the timer at least 10 times w/ 200ms of "buffer"
+    delay(250);                         // tick the timer at least 10 times w/ 200ms of "buffer"
     let num = local_num.lock().unwrap(); // read the number back
     assert_eq!(*num, 9);                 // it should have incremented at least 10 times...
 }
@@ -98,16 +103,18 @@ fn test_timer_runs_multiple_times() {
 #[test]
 fn test_timer_runs_at_least_once() {
     use std::sync::{Arc, Mutex};
+    let running = TIMER_INIT_LOCK.lock().unwrap();
+    ::sdl::init(::sdl::INIT_TIMER);
 
     let local_flag = Arc::new(Mutex::new(false));
     let timer_flag = local_flag.clone();
 
-    let timer = Timer::new(500, Box::new(|| {
+    let timer = Timer::new(20, Box::new(|| {
         let mut flag = timer_flag.lock().unwrap();
         *flag = true; 0
     }));
 
-    delay(700);
+    delay(50);
     let flag = local_flag.lock().unwrap();
     assert_eq!(*flag, true);
 }
@@ -115,24 +122,26 @@ fn test_timer_runs_at_least_once() {
 #[test]
 fn test_timer_can_be_recreated() {
     use std::sync::{Arc, Mutex};
+    let running = TIMER_INIT_LOCK.lock().unwrap();
+    ::sdl::init(::sdl::INIT_TIMER);
 
     let local_num = Arc::new(Mutex::new(0));
     let timer_num = local_num.clone();
 
     // run the timer once and reclaim its closure
-    let mut timer_1 = Timer::new(100, Box::new(move|| {
+    let mut timer_1 = Timer::new(20, Box::new(move|| {
         let mut num = timer_num.lock().unwrap();
         *num += 1; // increment the number
         0          // do not run timer again
     }));
 
     // reclaim closure after timer runs
-    delay(200);
+    delay(50);
     let closure = timer_1.into_inner();
 
     // create a second timer and increment again
-    let timer_2 = Timer::new(100, closure);
-    delay(200);
+    let timer_2 = Timer::new(20, closure);
+    delay(50);
 
     // check that timer was incremented twice
     let num = local_num.lock().unwrap();

--- a/src/sdl2/timer.rs
+++ b/src/sdl2/timer.rs
@@ -34,7 +34,7 @@ impl<'a> Timer<'a> {
     ///   * or when the callback returns a non-positive continuation interval
     pub fn new(delay: u32, callback: TimerCallback<'a>) -> Timer<'a> {
         unsafe {
-			let callback = Box::new(callback);
+            let callback = Box::new(callback);
             let timer_id = ll::SDL_AddTimer(delay,
                                             Some(c_timer_callback),
                                             mem::transmute_copy(&callback));
@@ -47,11 +47,11 @@ impl<'a> Timer<'a> {
         }
     }
 
-	/// Returns the closure as a trait-object and cancels the timer
-	/// by consuming it...
-	pub fn into_inner(mut self) -> TimerCallback<'a> {
-		*self.callback.take().unwrap()
-	}
+    /// Returns the closure as a trait-object and cancels the timer
+    /// by consuming it...
+    pub fn into_inner(mut self) -> TimerCallback<'a> {
+        *self.callback.take().unwrap()
+    }
 }
 
 #[unsafe_destructor]


### PR DESCRIPTION
While I certainly improved the failure rate of the tests, it still wasn't perfect.
There seems to be some underlying safety issue with lazily initializing the timer subsystem from multiple threads. (See my comments on issue #314.)

This simple fix forces the timer tests to run sequentially using a static mutex. While the test holds this lock it is safe to call `sdl::init(INIT_TIMER)` without interfering with any other tests.

---

Previously I got about 5 failures per 100 iterations of the test suite. With these improvements I see no failures in _1000 iterations._

NOTE: PR #325 seems to have failed Travis as a result of such a spurious failure.