### PR TITLE
Make `use sys::rwops as ll` and `use sys::version as ll` public so rust-sd2_mixer can build properly

### DIFF
--- a/src/sdl2/rwops.rs
+++ b/src/sdl2/rwops.rs
@@ -5,7 +5,7 @@ use libc::{c_void, c_int, size_t};
 use get_error;
 use SdlResult;
 
-use sys::rwops as ll;
+pub use sys::rwops as ll;
 
 #[derive(PartialEq)] #[allow(raw_pointer_derive)]
 pub struct RWops {

--- a/src/sdl2/version.rs
+++ b/src/sdl2/version.rs
@@ -5,7 +5,7 @@ Querying SDL Version
 use std::ffi::c_str_to_bytes;
 use std::fmt;
 
-use sys::version as ll;
+pub use sys::version as ll;
 
 /// A structure that contains information about the version of SDL in use.
 #[derive(PartialEq, Copy, Clone)]


### PR DESCRIPTION
This is currently causing errors with rust-sdl2_mixer because it relies on those two use statements being public. This seemed like the easiest fix to me, but should rust-sdl2_mixer be using sdl2-sys directly instead?