### PR TITLE
Fixed a few deprecation warnings.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ path       = "src/sdl2/lib.rs"
 [dependencies]
 bitflags = "0.1"
 libc = "*"
+rand = "*"
 
 [dependencies.sdl2-sys]
 

--- a/sdl2-sys/build.rs
+++ b/sdl2-sys/build.rs
@@ -3,7 +3,7 @@
 extern crate "pkg-config" as pkg_config;
 
 fn main() {
-    if std::env::var("CARGO_FEATURE_USE_PKGCONFIG").is_some() {
+    if std::env::var("CARGO_FEATURE_USE_PKGCONFIG").is_ok() {
       if build_pkgconfig() { return; }
       panic!("Could not find SDL2 via pkgconfig");
     } else {

--- a/sdl2-sys/build.rs
+++ b/sdl2-sys/build.rs
@@ -1,9 +1,9 @@
-#![feature(os)]
+#![feature(env)]
 
 extern crate "pkg-config" as pkg_config;
 
 fn main() {
-    if std::os::getenv("CARGO_FEATURE_USE_PKGCONFIG").is_some() {
+    if std::env::var("CARGO_FEATURE_USE_PKGCONFIG").is_some() {
       if build_pkgconfig() { return; }
       panic!("Could not find SDL2 via pkgconfig");
     } else {

--- a/src/sdl2/lib.rs
+++ b/src/sdl2/lib.rs
@@ -1,7 +1,7 @@
 #![crate_name = "sdl2"]
 #![crate_type = "lib"]
 
-#![feature(slicing_syntax, unsafe_destructor, optin_builtin_traits, std_misc, io, hash, core, collections, rand, path)]
+#![feature(slicing_syntax, unsafe_destructor, optin_builtin_traits, std_misc, io, hash, core, collections, path)]
 
 extern crate libc;
 extern crate collections;

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -51,7 +51,7 @@ use std::raw;
 use libc::{c_int, uint32_t, c_double, c_void};
 use rect::Point;
 use rect::Rect;
-use std::cell::{RefCell, RefMut};
+use std::cell::{RefCell, RefMut, BorrowState};
 use std::ffi::c_str_to_bytes;
 use std::num::FromPrimitive;
 use std::vec::Vec;
@@ -266,9 +266,9 @@ impl Renderer {
     /// }
     /// ```
     pub fn drawer(&self) -> RenderDrawer {
-        match self.drawer_borrow.try_borrow_mut() {
-            Some(borrow) => RenderDrawer::new(self.raw, borrow),
-            None => panic!("Renderer drawer already borrowed")
+        match self.drawer_borrow.borrow_state() {
+            BorrowState::Unused => RenderDrawer::new(self.raw, self.drawer_borrow.borrow_mut()),
+            _ => panic!("Renderer drawer already borrowed")
         }
     }
 

--- a/src/sdl2/surface.rs
+++ b/src/sdl2/surface.rs
@@ -114,7 +114,7 @@ impl Surface {
 
             let raw_pixels = (*self.raw).pixels as *mut _;
             let len = (*self.raw).pitch as usize * ((*self.raw).h as usize);
-            let pixels = ::std::slice::from_raw_mut_buf(&raw_pixels, len);
+            let pixels = ::std::slice::from_raw_parts_mut(raw_pixels, len);
             let rv = f(pixels);
             ll::SDL_UnlockSurface(self.raw);
             rv


### PR DESCRIPTION
- Added crates.io rand crate as dependency.
- Replaced std::os:getenv by std::env::var.
- Replaced std::slice::from_raw_mut_buf by
  std::slice::from_raw_parts_mut.
- Replaced std::cell::try_borrow_mut by std::cell::borrow_state.