### PR TITLE
Fix RenderTarget::get return value lifetime.

### DIFF
--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -728,12 +728,21 @@ pub struct RenderTarget<'render_drawer> {
 
 impl<'render_drawer> RenderTarget<'render_drawer> {
     /// Resets the render target to the default render target.
-    pub fn reset(&mut self) -> SdlResult<()> {
+    pub fn reset<'a>(&mut self) -> SdlResult<Option<Texture<'a>>> {
         unsafe {
-            if ll::SDL_SetRenderTarget(self.raw, ptr::null()) == 0 {
-                Ok(())
+            let texture_raw = ll::SDL_GetRenderTarget(self.raw);
+
+            if ll::SDL_SetRenderTarget(self.raw, ptr::null()) != 0 {
+                return Err(get_error());
+            }
+            if texture_raw == ptr::null() {
+                Ok(None)
             } else {
-                Err(get_error())
+                Ok(Some(Texture {
+                    raw: texture_raw,
+                    owned: false,
+                    _marker: ContravariantLifetime
+                }))
             }
         }
     }

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -727,32 +727,40 @@ pub struct RenderTarget<'render_drawer> {
 }
 
 impl<'render_drawer> RenderTarget<'render_drawer> {
+    fn get_with_lifetime<'a>(&self) -> Option<Texture<'a>> {
+        let texture_raw = unsafe{ ll::SDL_GetRenderTarget(self.raw) };
+        if texture_raw == ptr::null() {
+            None
+        }
+        else {
+            Some(Texture {
+                raw: texture_raw,
+                owned: false,
+                _marker: ContravariantLifetime
+            })
+        }
+    }
+
     /// Resets the render target to the default render target.
     pub fn reset<'a>(&mut self) -> SdlResult<Option<Texture<'a>>> {
+        let target = self.get_with_lifetime::<'a>();
         unsafe {
-            let texture_raw = ll::SDL_GetRenderTarget(self.raw);
-
-            if ll::SDL_SetRenderTarget(self.raw, ptr::null()) != 0 {
-                return Err(get_error());
+            if ll::SDL_SetRenderTarget(self.raw, ptr::null()) == 0 {
+                Ok(target)
             }
-            if texture_raw == ptr::null() {
-                Ok(None)
-            } else {
-                Ok(Some(Texture {
-                    raw: texture_raw,
-                    owned: false,
-                    _marker: ContravariantLifetime
-                }))
+            else {
+                return Err(get_error());
             }
         }
     }
 
     /// Sets the render target to the provided texture.
     /// The texture must be created with the texture access: `sdl2::render::TextureAccess::Target`.
-    pub fn set(&mut self, texture: Texture) -> SdlResult<()> {
+    pub fn set<'a>(&mut self, texture: Texture) -> SdlResult<Option<Texture<'a>>> {
+        let target = self.get_with_lifetime::<'a>();
         unsafe {
             if ll::SDL_SetRenderTarget(self.raw, texture.raw) == 0 {
-                Ok(())
+                Ok(target)
             } else {
                 Err(get_error())
             }
@@ -760,7 +768,8 @@ impl<'render_drawer> RenderTarget<'render_drawer> {
     }
 
     /// Creates a new texture and sets it as the render target.
-    pub fn create_and_set(&mut self, format: pixels::PixelFormatEnum, width: i32, height: i32) -> SdlResult<Texture> {
+    pub fn create_and_set<'a>(&mut self, format: pixels::PixelFormatEnum, width: i32, height: i32) -> SdlResult<Option<Texture<'a>>> {
+        let target = self.get_with_lifetime::<'a>();
         let new_texture_raw = unsafe {
             let access = ll::SDL_TEXTUREACCESS_TARGET;
             ll::SDL_CreateTexture(self.raw, format as uint32_t, access as c_int, width as c_int, height as c_int)
@@ -771,11 +780,7 @@ impl<'render_drawer> RenderTarget<'render_drawer> {
         } else {
             unsafe {
                 if ll::SDL_SetRenderTarget(self.raw, new_texture_raw) == 0 {
-                    Ok(Texture {
-                        raw: new_texture_raw,
-                        owned: false,
-                        _marker: ContravariantLifetime
-                    })
+                    Ok(target)
                 } else {
                     Err(get_error())
                 }


### PR DESCRIPTION
I'am Rust Beginner, I dont certain that is a bug or just I wrong.

I want render a `Texuture` then get it, for example:

    drawer
        .render_target().unwrap()
        .create_and_set(PixelFormatEnum::RGBA8888, 1000, 1000).unwrap();
    // do something render.
    let mut target = drawer.render_target().unwrap();
    let tex = target.get().unwrap();
    target.reset() // borrow target more than once at a time. previous borrow is `tex`.
    drawer.copy(&tex, None, None) // borrow drawer more than once at a time. previous borrow is `target`.


the `tex` borrowed `target`, so I can't drop `target`, then `target` is borrowed `drawer`, so I can't borrow `drawer` more than once at a time...

I try to fix this, look like success.
but I not sure patch is correct.