### PR TITLE
More renderer changes

### DIFF
--- a/examples/renderer-yuv.rs
+++ b/examples/renderer-yuv.rs
@@ -1,0 +1,72 @@
+extern crate sdl2;
+
+use sdl2::video::{Window, WindowPos, SHOWN};
+use sdl2::render::{RenderDriverIndex, ACCELERATED, Renderer};
+use sdl2::pixels::PixelFormatEnum;
+use sdl2::rect::Rect;
+use sdl2::event::poll_event;
+use sdl2::event::Event::{Quit, KeyDown};
+use sdl2::keycode::KeyCode;
+
+pub fn main() {
+    sdl2::init(sdl2::INIT_VIDEO);
+
+    let window = match Window::new("rust-sdl2 demo: YUV", WindowPos::PosCentered, WindowPos::PosCentered, 800, 600, SHOWN) {
+        Ok(window) => window,
+        Err(err) => panic!("failed to create window: {}", err)
+    };
+
+    let renderer = match Renderer::from_window(window, RenderDriverIndex::Auto, ACCELERATED) {
+        Ok(renderer) => renderer,
+        Err(err) => panic!("failed to create renderer: {}", err)
+    };
+
+    let mut texture = renderer.create_texture_streaming(PixelFormatEnum::IYUV, (256, 256)).unwrap();
+    // Create a U-V gradient
+    texture.with_lock(None, |buffer: &mut [u8], pitch: usize| {
+        // `pitch` is the width of the Y component
+        // The U and V components are half the width and height of Y
+
+        let w = 256;
+        let h = 256;
+
+        // Set Y (constant)
+        for y in 0us..h {
+            for x in 0us..w {
+                let offset = y*pitch + x;
+                buffer[offset] = 128;
+            }
+        }
+
+        let y_size = pitch*h;
+
+        // Set U and V (X and Y)
+        for y in 0us..h/2 {
+            for x in 0us..w/2 {
+                let u_offset = y_size + y*pitch/2 + x;
+                let v_offset = y_size + (pitch/2 * h/2) + y*pitch/2 + x;
+                buffer[u_offset] = (x*2) as u8;
+                buffer[v_offset] = (y*2) as u8;
+            }
+        }
+    }).unwrap();
+
+    let mut drawer = renderer.drawer();
+    drawer.clear();
+    drawer.copy(&texture, None, Some(Rect::new(100, 100, 256, 256)));
+    drawer.present();
+
+    loop {
+        match poll_event() {
+            Quit{..} => break,
+            KeyDown { keycode: key, .. } => {
+                if key == KeyCode::Escape {
+                    break;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    sdl2::quit();
+}

--- a/sdl2-sys/src/render.rs
+++ b/sdl2-sys/src/render.rs
@@ -77,6 +77,7 @@ extern "C" {
     pub fn SDL_SetTextureBlendMode(texture: *const SDL_Texture, blendMode: SDL_BlendMode) -> c_int;
     pub fn SDL_GetTextureBlendMode(texture: *const SDL_Texture, blendMode: *const SDL_BlendMode) -> c_int;
     pub fn SDL_UpdateTexture(texture: *const SDL_Texture, rect: *const SDL_Rect, pixels: *const c_void, pitch: c_int) -> c_int;
+    pub fn SDL_UpdateYUVTexture(texture: *const SDL_Texture, rect: *const SDL_Rect, Yplane: *const uint8_t, Ypitch: c_int, Uplane: *const uint8_t, Upitch: c_int, Vplane: *const uint8_t, Vpitch: c_int) -> c_int;
     pub fn SDL_LockTexture(texture: *const SDL_Texture, rect: *const SDL_Rect, pixels: *const *const c_void, pitch: *const c_int) -> c_int;
     pub fn SDL_UnlockTexture(texture: *const SDL_Texture);
     pub fn SDL_RenderTargetSupported(renderer: *const SDL_Renderer) -> SDL_bool;

--- a/src/sdl2/pixels.rs
+++ b/src/sdl2/pixels.rs
@@ -103,6 +103,21 @@ pub enum PixelFormatEnum {
 }
 
 impl PixelFormatEnum {
+    /// Calculates the total byte size of an image buffer, given its pitch
+    /// and height.
+    pub fn byte_size_from_pitch_and_height(&self, pitch: usize, height: usize) -> usize {
+        match *self {
+            PixelFormatEnum::YV12 | PixelFormatEnum::IYUV => {
+                // YUV is 4:2:0.
+                // `pitch` is the width of the Y component, and
+                // `height` is the height of the Y component.
+                // U and V have half the width and height of Y.
+                pitch * height + 2 * (pitch / 2 * height / 2)
+            },
+            _ => pitch * height
+        }
+    }
+
     pub fn byte_size_of_pixels(&self, num_of_pixels: usize) -> usize {
         match *self {
             PixelFormatEnum::RGB332

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -968,7 +968,7 @@ impl<'renderer> Texture<'renderer> {
 
             let ret = ll::SDL_LockTexture(self.raw, actual_rect, &pixels, &pitch);
             if ret == 0 {
-                let size = pitch as usize * q.height as usize;
+                let size = q.format.byte_size_from_pitch_and_height(pitch as usize, q.height as usize);
                 Ok( (raw::Slice { data: pixels as *const u8, len: size }, pitch) )
             } else {
                 Err(get_error())

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -743,6 +743,7 @@ impl<'render_drawer> RenderTarget<'render_drawer> {
     pub fn set(&mut self, texture: Texture) -> SdlResult<()> {
         unsafe {
             if ll::SDL_SetRenderTarget(self.raw, texture.raw) == 0 {
+                mem::forget(texture);
                 Ok(())
             } else {
                 Err(get_error())

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -734,6 +734,28 @@ impl<'renderer> RenderDrawer<'renderer> {
 }
 
 /// A handle for getting/setting the render target of the render context.
+///
+/// # Example
+/// ```no_run
+/// use sdl2::pixels::{Color, PixelFormatEnum};
+/// use sdl2::rect::Rect;
+/// use sdl2::render::{RenderDrawer, Texture};
+///
+/// // Draw a red rectangle to a new texture
+/// fn draw_to_texture<'renderer>(drawer: &mut RenderDrawer<'renderer>) -> Texture<'renderer> {
+///     drawer.render_target()
+///         .expect("This platform doesn't support render targets")
+///         .create_and_set(PixelFormatEnum::RGBA8888, 512, 512);
+///
+///     // Start drawing
+///     drawer.clear();
+///     drawer.set_draw_color(Color::RGB(255, 0, 0));
+///     drawer.fill_rect(Rect::new(100, 100, 256, 256));
+///
+///     let texture: Option<Texture> = drawer.render_target().unwrap().reset().unwrap();
+///     texture.unwrap()
+/// }
+/// ```
 pub struct RenderTarget<'renderer, 'render_drawer> {
     raw: *const ll::SDL_Renderer,
     _marker: ContravariantLifetime<'render_drawer>


### PR DESCRIPTION
Woo, some more render changes!
Again, the changes are all rolled into one nice PR.

* You can now obtain old textures that were set in `RenderTarget`, as brought up in #335.
 * It's important to get render target textures back for drawing. Doing so is the entire point of `RenderTarget`.
* Hopefully, the YUV slice length issue from #334 is solved once and for all.
* Multiple-of-two dimensions and pitches are required for planar YUV formats.
 * `Renderer::create_texture()`, `Texture::update()` and `Texture::update_yuv()` will return an error if they're not supplied.
 * Unfortunately, SDL doesn't perform this check for us. It's crucial
  that we guarantee this for `rust-sdl2` because array slice lengths
  must be predictable and derivable.
* A YUV example was added to solidify our understanding of the YUV pixel formats.
* `Texture::update_yuv()`, which implements `SDL_UpdateYUVTexture()` was added
 * I noticed it was missing. It will probably be useful for whatever @pcwalton is doing. :)

Closes #335