### PR TITLE
Only use the pkg-config dep when needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ install:
     - sudo apt-get install libsdl2-dev
 script:
     - cargo build -v
+    - cargo build -v --features "use-pkgconfig"
     - cargo test -v
     - cargo doc -v
 after_success:

--- a/sdl2-sys/Cargo.toml
+++ b/sdl2-sys/Cargo.toml
@@ -16,10 +16,11 @@ path = "src/lib.rs"
 [dependencies]
 libc = "*"
 
-[build-dependencies]
-pkg-config = "0.1.7"
+[build-dependencies.pkg-config]
+version = "0.1.7"
+optional = true
 
 [features]
 
 default = []
-use-pkgconfig = []
+use-pkgconfig = ["pkg-config"]

--- a/sdl2-sys/build.rs
+++ b/sdl2-sys/build.rs
@@ -1,17 +1,22 @@
-#![feature(os)]
-
+#[cfg(feature="pkg-config")]
 extern crate "pkg-config" as pkg_config;
 
 fn main() {
-    if std::os::getenv("CARGO_FEATURE_USE_PKGCONFIG").is_some() {
-      if build_pkgconfig() { return; }
-      panic!("Could not find SDL2 via pkgconfig");
-    } else {
+    if !build_pkgconfig() {
       println!("cargo:rustc-flags=-l SDL2");
     }
 }
 
+#[cfg(not(feature="pkg-config"))]
+fn build_pkgconfig() -> bool {
+    false
+}
+
+#[cfg(feature="pkg-config")]
 fn build_pkgconfig() -> bool {
     let opts = pkg_config::default_options("sdl2");
-    pkg_config::find_library_opts("sdl2", &opts).is_ok()
+    if pkg_config::find_library_opts("sdl2", &opts).is_err() {
+        panic!("Could not find SDL2 via pkgconfig");
+    }
+    true
 }


### PR DESCRIPTION
This commit ensures the pkg-config crate will only be downloaded when
the feature is enabled.

An additional test has been added to travis to ensure it will also be tested properly