### PR TITLE
Feature for slicing syntax no longer required

### DIFF
--- a/src/sdl2/lib.rs
+++ b/src/sdl2/lib.rs
@@ -1,7 +1,7 @@
 #![crate_name = "sdl2"]
 #![crate_type = "lib"]
 
-#![feature(slicing_syntax, unsafe_destructor, optin_builtin_traits, std_misc, io, hash, core, collections, path)]
+#![feature(unsafe_destructor, optin_builtin_traits, std_misc, io, hash, core, collections, path)]
 
 extern crate libc;
 extern crate collections;


### PR DESCRIPTION
Slicing syntax is stable in the 1.0 nightly, we no longer need to explicitly mark it as feature.