### PR TITLE
expose SDL_UpperBlitScaled as blit_scaled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 name    = "sdl2"
 description = "SDL2 bindings for Rust"
 repository = "https://github.com/AngryLawyer/rust-sdl2"
-version = "0.0.26"
+version = "0.0.27"
 license = "MIT"
 authors = [ "Tony Aldridge <tony@angry-lawyer.com>" ]
 keywords = ["SDL", "windowing", "graphics"]

--- a/src/sdl2/surface.rs
+++ b/src/sdl2/surface.rs
@@ -353,6 +353,20 @@ impl Surface {
         }
     }
 
+    pub fn blit_scaled(&self, src_rect: Option<Rect>,
+                             dst: &mut Surface, dst_rect: Option<Rect>) -> SdlResult<()> {
+
+        match unsafe {
+            let src_rect_ptr = mem::transmute(src_rect.as_ref());
+            let dst_rect_ptr = mem::transmute(dst_rect.as_ref());
+            ll::SDL_UpperBlitScaled(self.raw, src_rect_ptr, dst.raw, dst_rect_ptr)
+        } {
+            0 => Ok(()),
+            _ => Err(get_error())
+        }
+    }
+
+    #[deprecated]
     pub fn upper_blit_scaled(&self, src_rect: Option<Rect>,
                              dst: &mut Surface, dst_rect: Option<Rect>) -> SdlResult<()> {
 


### PR DESCRIPTION
This matches the SDL header behavior. `blit_scaled` is a copy of `upper_blit_scaled` (users shouldn't incur any penalty if currently using `upper_blit_scaled`.)

resolves #328