### PR TITLE
Fixes for Rust nightly

### DIFF
--- a/examples/audio-whitenoise.rs
+++ b/examples/audio-whitenoise.rs
@@ -7,7 +7,9 @@ use sdl2::audio::{AudioCallback, AudioSpecDesired};
 struct MyCallback {
     volume: f32
 }
-impl AudioCallback<f32> for MyCallback {
+impl AudioCallback for MyCallback {
+    pub type Channel = f32;
+
     fn callback(&mut self, out: &mut [f32]) {
         use std::rand::{Rng, thread_rng};
         let mut rng = thread_rng();

--- a/src/sdl2/audio.rs
+++ b/src/sdl2/audio.rs
@@ -3,6 +3,7 @@ use std::ffi::{c_str_to_bytes, CString};
 use std::num::FromPrimitive;
 use libc::{c_int, c_void, uint8_t};
 use std::ops::{Deref, DerefMut};
+use std::marker::PhantomFn;
 
 use get_error;
 use rwops::RWops;
@@ -140,8 +141,12 @@ impl Drop for AudioSpecWAV {
     }
 }
 
-pub trait AudioCallback<T>: Send {
-    fn callback(&mut self, &mut [T]);
+pub trait AudioCallback: Send
+where Self::Channel: AudioFormatNum<Self::Channel>
+{
+    type Channel;
+
+    fn callback(&mut self, &mut [Self::Channel]);
 }
 
 /// The userdata as seen by the SDL callback.
@@ -151,9 +156,7 @@ struct AudioCallbackUserdata<CB> {
 
 /// A phantom type for retreiving the SDL_AudioFormat of a given generic type.
 /// All format types are returned as native-endian.
-///
-/// Example: `assert_eq!(AudioFormatNum::<f32>::get_audio_format(), ll::AUDIO_F32);``
-pub trait AudioFormatNum<T> {
+pub trait AudioFormatNum<T>: PhantomFn<T> {
     fn get_audio_format(self) -> ll::SDL_AudioFormat;
     fn zero() -> Self;
 }
@@ -188,33 +191,33 @@ impl AudioFormatNum<f32> for f32 {
     fn zero() -> f32 { 0.0 }
 }
 
-extern "C" fn audio_callback_marshall<T: AudioFormatNum<T>, CB: AudioCallback<T>>
+extern "C" fn audio_callback_marshall<CB: AudioCallback>
 (userdata: *const c_void, stream: *const uint8_t, len: c_int) {
     use std::raw::Slice;
     use std::mem::{size_of, transmute};
     unsafe {
         let mut cb_userdata: &mut AudioCallbackUserdata<CB> = transmute(userdata);
-        let buf: &mut [T] = transmute(Slice {
+        let buf: &mut [CB::Channel] = transmute(Slice {
             data: stream,
-            len: len as usize / size_of::<T>()
+            len: len as usize / size_of::<CB::Channel>()
         });
 
         cb_userdata.callback.callback(buf);
     }
 }
 
-pub struct AudioSpecDesired<T: AudioFormatNum<T>, CB: AudioCallback<T>> {
+pub struct AudioSpecDesired<CB: AudioCallback> {
     pub freq: i32,
     pub channels: u8,
     pub samples: u16,
     pub callback: CB
 }
 
-impl<T: AudioFormatNum<T>, CB: AudioCallback<T>> AudioSpecDesired<T, CB> {
+impl<CB: AudioCallback> AudioSpecDesired<CB> {
     fn convert_to_ll(freq: i32, channels: u8, samples: u16, userdata: &mut AudioCallbackUserdata<CB>) -> ll::SDL_AudioSpec {
         use std::mem::transmute;
 
-        let format_num: T = AudioFormatNum::zero();
+        let format_num: CB::Channel = AudioFormatNum::zero();
 
         unsafe {
             ll::SDL_AudioSpec {
@@ -225,7 +228,7 @@ impl<T: AudioFormatNum<T>, CB: AudioCallback<T>> AudioSpecDesired<T, CB> {
                 samples: samples,
                 padding: 0,
                 size: 0,
-                callback: Some(audio_callback_marshall::<T, CB>
+                callback: Some(audio_callback_marshall::<CB>
                     as extern "C" fn
                         (arg1: *const c_void,
                          arg2: *const uint8_t,

--- a/src/sdl2/audio.rs
+++ b/src/sdl2/audio.rs
@@ -157,37 +157,37 @@ struct AudioCallbackUserdata<CB> {
 /// A phantom type for retreiving the SDL_AudioFormat of a given generic type.
 /// All format types are returned as native-endian.
 pub trait AudioFormatNum<T>: PhantomFn<T> {
-    fn get_audio_format(self) -> ll::SDL_AudioFormat;
+    fn get_audio_format() -> ll::SDL_AudioFormat;
     fn zero() -> Self;
 }
 /// AUDIO_S8
 impl AudioFormatNum<i8> for i8 {
-    fn get_audio_format(self) -> ll::SDL_AudioFormat { ll::AUDIO_S8 }
+    fn get_audio_format() -> ll::SDL_AudioFormat { ll::AUDIO_S8 }
     fn zero() -> i8 { 0 }
 }
 /// AUDIO_U8
 impl AudioFormatNum<u8> for u8 {
-    fn get_audio_format(self) -> ll::SDL_AudioFormat { ll::AUDIO_U8 }
+    fn get_audio_format() -> ll::SDL_AudioFormat { ll::AUDIO_U8 }
     fn zero() -> u8 { 0 }
 }
 /// AUDIO_S16
 impl AudioFormatNum<i16> for i16 {
-    fn get_audio_format(self) -> ll::SDL_AudioFormat { ll::AUDIO_S16SYS }
+    fn get_audio_format() -> ll::SDL_AudioFormat { ll::AUDIO_S16SYS }
     fn zero() -> i16 { 0 }
 }
 /// AUDIO_U16
 impl AudioFormatNum<u16> for u16 {
-    fn get_audio_format(self) -> ll::SDL_AudioFormat { ll::AUDIO_U16SYS }
+    fn get_audio_format() -> ll::SDL_AudioFormat { ll::AUDIO_U16SYS }
     fn zero() -> u16 { 0 }
 }
 /// AUDIO_S32
 impl AudioFormatNum<i32> for i32 {
-    fn get_audio_format(self) -> ll::SDL_AudioFormat { ll::AUDIO_S32SYS }
+    fn get_audio_format() -> ll::SDL_AudioFormat { ll::AUDIO_S32SYS }
     fn zero() -> i32 { 0 }
 }
 /// AUDIO_F32
 impl AudioFormatNum<f32> for f32 {
-    fn get_audio_format(self) -> ll::SDL_AudioFormat { ll::AUDIO_F32SYS }
+    fn get_audio_format() -> ll::SDL_AudioFormat { ll::AUDIO_F32SYS }
     fn zero() -> f32 { 0.0 }
 }
 
@@ -217,12 +217,10 @@ impl<CB: AudioCallback> AudioSpecDesired<CB> {
     fn convert_to_ll(freq: i32, channels: u8, samples: u16, userdata: &mut AudioCallbackUserdata<CB>) -> ll::SDL_AudioSpec {
         use std::mem::transmute;
 
-        let format_num: CB::Channel = AudioFormatNum::zero();
-
         unsafe {
             ll::SDL_AudioSpec {
                 freq: freq,
-                format: format_num.get_audio_format(),
+                format: <CB::Channel as AudioFormatNum<CB::Channel>>::get_audio_format(),
                 channels: channels,
                 silence: 0,
                 samples: samples,

--- a/src/sdl2/keycode.rs
+++ b/src/sdl2/keycode.rs
@@ -1,4 +1,4 @@
-use std::hash::{self, Hash};
+use std::hash::{Hash, Hasher};
 use std::num::ToPrimitive;
 
 use sys::keycode as ll;
@@ -243,9 +243,9 @@ pub enum KeyCode {
     Sleep              = ll::SDLK_SLEEP as isize,
 }
 
-impl<S: hash::Hasher + hash::Writer> Hash<S> for KeyCode {
+impl Hash for KeyCode {
     #[inline]
-    fn hash(&self, state: &mut S) {
+    fn hash<H>(&self, state: &mut H) where H: Hasher {
         (*self as i32).hash(state);
     }
 }

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -369,7 +369,8 @@ impl<'renderer> RenderDrawer<'renderer> {
         if self.render_target_supported() {
             Some(RenderTarget {
                 raw: self.raw,
-                _marker: ContravariantLifetime
+                _marker_renderer: ContravariantLifetime,
+                _marker_render_drawer: ContravariantLifetime
             })
         } else {
             None
@@ -758,7 +759,8 @@ impl<'renderer> RenderDrawer<'renderer> {
 /// ```
 pub struct RenderTarget<'renderer, 'render_drawer> {
     raw: *const ll::SDL_Renderer,
-    _marker: ContravariantLifetime<'render_drawer>
+    _marker_renderer: ContravariantLifetime<'renderer>,
+    _marker_render_drawer: ContravariantLifetime<'render_drawer>
 }
 
 impl<'renderer, 'render_drawer> RenderTarget<'renderer, 'render_drawer> {
@@ -856,7 +858,6 @@ pub struct TextureQuery {
 ///
 /// Textures are owned by and cannot live longer than the parent `Renderer`.
 /// Each texture is bound to the `'renderer` contravariant lifetime.
-#[derive(PartialEq)] #[allow(raw_pointer_derive)]
 pub struct Texture<'renderer> {
     raw: *const ll::SDL_Texture,
     owned: bool,

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -56,7 +56,7 @@ use std::cell::{RefCell, RefMut, BorrowState};
 use std::ffi::c_str_to_bytes;
 use std::num::FromPrimitive;
 use std::vec::Vec;
-use std::marker::ContravariantLifetime;
+use std::marker::PhantomData;
 
 use sys::render as ll;
 
@@ -369,8 +369,8 @@ impl<'renderer> RenderDrawer<'renderer> {
         if self.render_target_supported() {
             Some(RenderTarget {
                 raw: self.raw,
-                _marker_renderer: ContravariantLifetime,
-                _marker_render_drawer: ContravariantLifetime
+                _marker_renderer: PhantomData,
+                _marker_render_drawer: PhantomData
             })
         } else {
             None
@@ -759,8 +759,8 @@ impl<'renderer> RenderDrawer<'renderer> {
 /// ```
 pub struct RenderTarget<'renderer, 'render_drawer> {
     raw: *const ll::SDL_Renderer,
-    _marker_renderer: ContravariantLifetime<'renderer>,
-    _marker_render_drawer: ContravariantLifetime<'render_drawer>
+    _marker_renderer: PhantomData<&'renderer ()>,
+    _marker_render_drawer: PhantomData<&'render_drawer ()>
 }
 
 impl<'renderer, 'render_drawer> RenderTarget<'renderer, 'render_drawer> {
@@ -840,7 +840,7 @@ impl<'renderer, 'render_drawer> RenderTarget<'renderer, 'render_drawer> {
             Some(Texture {
                 raw: texture_raw,
                 owned: false,
-                _marker: ContravariantLifetime
+                _marker: PhantomData
             })
         }
     }
@@ -863,7 +863,7 @@ pub struct Texture<'renderer> {
     owned: bool,
     /// Textures cannot live longer than the Renderer it was born from: 'a
     /// All SDL textures contain an internal reference to a Renderer
-    _marker: ContravariantLifetime<'renderer>
+    _marker: PhantomData<&'renderer ()>
 }
 
 #[unsafe_destructor]
@@ -1138,7 +1138,7 @@ impl<'renderer> Texture<'renderer> {
         Texture {
             raw: raw,
             owned: true,
-            _marker: ContravariantLifetime
+            _marker: PhantomData
         }
     }
 
@@ -1147,7 +1147,7 @@ impl<'renderer> Texture<'renderer> {
         Texture {
             raw: raw,
             owned: false,
-            _marker: ContravariantLifetime
+            _marker: PhantomData
         }
     }
 

--- a/src/sdl2/scancode.rs
+++ b/src/sdl2/scancode.rs
@@ -1,4 +1,4 @@
-use std::hash::{self, Hash};
+use std::hash::{Hash, Hasher};
 use std::num::ToPrimitive;
 
 use sys::scancode as ll;
@@ -249,9 +249,9 @@ pub enum ScanCode {
     Num                = ll::SDL_NUM_SCANCODES as isize,
 }
 
-impl<S: hash::Hasher + hash::Writer> Hash<S> for ScanCode {
+impl Hash for ScanCode {
     #[inline]
-    fn hash(&self, state: &mut S) {
+    fn hash<H>(&self, state: &mut H) where H: Hasher {
         (*self as i32).hash(state);
     }
 }


### PR DESCRIPTION
The main changes are:
* Hash changes and the removal of hash::Writer
* Requirement to acknowledge phantom types and lifetimes
 * Fixed with the new `PhantomFn` trait

Consequentially, `AudioCallback` now uses an associated type for the channel scalar. This was the most intuitive way to resolve the phantom type problem in `AudioFormatNum` without adding `PhantomData` markers everywhere (or inside `AudioSpecDesired`).

Adding the associated type to `AudioCallback` also means that you can no longer implement an `AudioCallback` of multiple channel scalars simultaneously (say, both `f32` and `u8`).
I believe this is better, as it eliminates conflicting trait implementations and any confusion caused by them.
This change is similar to how [`Iterator`](http://doc.rust-lang.org/std/iter/trait.Iterator.html) now requires an associated type.

There are still a _lot_ of warnings, though.