### PR TITLE
EventPump and sdl2::Sdl context type

### DIFF
--- a/examples/audio-whitenoise.rs
+++ b/examples/audio-whitenoise.rs
@@ -20,7 +20,7 @@ impl AudioCallback<f32> for MyCallback {
 }
 
 fn main() {
-    sdl2::init(sdl2::INIT_AUDIO);
+    let _sdl_context = sdl2::init(sdl2::INIT_AUDIO).unwrap();
 
     let desired_spec = AudioSpecDesired {
         freq: 44100,

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -3,8 +3,6 @@ extern crate sdl2;
 use sdl2::video::{Window, WindowPos, OPENGL};
 use sdl2::render::{RenderDriverIndex, ACCELERATED, Renderer};
 use sdl2::pixels::Color;
-use sdl2::event::poll_event;
-use sdl2::event::Event::{Quit, KeyDown};
 use sdl2::keycode::KeyCode;
 
 pub fn main() {
@@ -25,15 +23,20 @@ pub fn main() {
     drawer.clear();
     drawer.present();
 
-    loop {
-        match poll_event() {
-            Quit{..} => break,
-            KeyDown { keycode: key, .. } => {
-                if key == KeyCode::Escape {
-                    break;
-                }
+    let mut running = true;
+    let mut event_pump = sdl_context.event_pump();
+
+    while running {
+        for event in event_pump.poll_iter() {
+            use sdl2::event::Event;
+
+            match event {
+                Event::Quit {..} | Event::KeyDown { keycode: KeyCode::Escape, .. } => {
+                    running = false
+                },
+                _ => {}
             }
-            _ => {}
         }
+        // The rest of the game loop goes here...
     }
 }

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -8,7 +8,7 @@ use sdl2::event::Event::{Quit, KeyDown};
 use sdl2::keycode::KeyCode;
 
 pub fn main() {
-    sdl2::init(sdl2::INIT_VIDEO);
+    let sdl_context = sdl2::init(sdl2::INIT_VIDEO).unwrap();
 
     let window = match Window::new("rust-sdl2 demo: Video", WindowPos::PosCentered, WindowPos::PosCentered, 800, 600, OPENGL) {
         Ok(window) => window,
@@ -36,6 +36,4 @@ pub fn main() {
             _ => {}
         }
     }
-
-    sdl2::quit();
 }

--- a/examples/game_controller.rs
+++ b/examples/game_controller.rs
@@ -1,12 +1,8 @@
-#![feature(io, std_misc, core)]
-
+#![feature(core)]
 extern crate sdl2;
 
 use sdl2::{joystick, controller};
-use sdl2::event::Event;
 use sdl2::controller::GameController;
-use std::old_io::timer::sleep;
-use std::time::duration::Duration;
 use std::num::SignedInt;
 
 fn main() {
@@ -44,7 +40,7 @@ fn main() {
         }
     }
 
-    let controller = 
+    let controller =
         match controller {
             Some(c) => c,
             None     => panic!("Couldn't open any controller"),
@@ -52,8 +48,12 @@ fn main() {
 
     println!("Controller mapping: {}", controller.mapping());
 
-    loop {
-        match sdl2::event::poll_event() {
+    let mut event_pump = sdl_context.event_pump();
+
+    for event in event_pump.wait_iter() {
+        use sdl2::event::Event;
+
+        match event {
             Event::ControllerAxisMotion{ axis, value: val, .. } => {
                 // Axis motion is an absolute value in the range
                 // [-32768, 32767]. Let's simulate a very rough dead
@@ -67,9 +67,6 @@ fn main() {
             Event::ControllerButtonUp{ button, .. } =>
                 println!("Button {:?} up", button),
             Event::Quit{..} => break,
-            Event::None =>
-                // Don't hog the CPU while waiting for events
-                sleep(Duration::milliseconds(100)),
             _ => (),
         }
     }

--- a/examples/game_controller.rs
+++ b/examples/game_controller.rs
@@ -10,7 +10,7 @@ use std::time::duration::Duration;
 use std::num::SignedInt;
 
 fn main() {
-    sdl2::init(sdl2::INIT_GAME_CONTROLLER);
+    let sdl_context = sdl2::init(sdl2::INIT_GAME_CONTROLLER).unwrap();
 
     let available =
         match joystick::num_joysticks() {
@@ -73,6 +73,4 @@ fn main() {
             _ => (),
         }
     }
-
-    sdl2::quit();
 }

--- a/examples/joystick.rs
+++ b/examples/joystick.rs
@@ -1,9 +1,7 @@
+#![feature(core)]
 extern crate sdl2;
 
 use sdl2::joystick::{Joystick, num_joysticks};
-use sdl2::event::Event;
-use std::old_io::timer::sleep;
-use std::time::duration::Duration;
 use std::num::SignedInt;
 
 fn main() {
@@ -32,12 +30,16 @@ fn main() {
         }
     }
 
-    if joystick.is_none() { 
+    if joystick.is_none() {
         panic!("Couldn't open any joystick");
     };
 
-    loop {
-        match sdl2::event::poll_event() {
+    let mut event_pump = sdl_context.event_pump();
+
+    for event in event_pump.wait_iter() {
+        use sdl2::event::Event;
+
+        match event {
             Event::JoyAxisMotion{ axis_idx, value: val, .. } => {
                 // Axis motion is an absolute value in the range
                 // [-32768, 32767]. Let's simulate a very rough dead
@@ -53,9 +55,6 @@ fn main() {
             Event::JoyHatMotion{ hat_idx, state, .. } =>
                 println!("Hat {} moved to {:?}", hat_idx, state),
             Event::Quit{..} => break,
-            Event::None =>
-                // Don't hog the CPU while waiting for events
-                sleep(Duration::milliseconds(100)),
             _ => (),
         }
     }

--- a/examples/joystick.rs
+++ b/examples/joystick.rs
@@ -7,7 +7,7 @@ use std::time::duration::Duration;
 use std::num::SignedInt;
 
 fn main() {
-    sdl2::init(sdl2::INIT_JOYSTICK);
+    let sdl_context = sdl2::init(sdl2::INIT_JOYSTICK).unwrap();
 
     let available =
         match num_joysticks() {
@@ -59,6 +59,4 @@ fn main() {
             _ => (),
         }
     }
-
-    sdl2::quit();
 }

--- a/examples/renderer-texture.rs
+++ b/examples/renderer-texture.rs
@@ -4,8 +4,6 @@ use sdl2::video::{Window, WindowPos, OPENGL};
 use sdl2::render::{RenderDriverIndex, ACCELERATED, Renderer};
 use sdl2::pixels::PixelFormatEnum;
 use sdl2::rect::Rect;
-use sdl2::event::poll_event;
-use sdl2::event::Event::{Quit, KeyDown};
 use sdl2::keycode::KeyCode;
 
 pub fn main() {
@@ -40,15 +38,20 @@ pub fn main() {
     drawer.copy_ex(&texture, None, Some(Rect::new(450, 100, 256, 256)), 30.0, None, (false, false));
     drawer.present();
 
-    loop {
-        match poll_event() {
-            Quit{..} => break,
-            KeyDown { keycode: key, .. } => {
-                if key == KeyCode::Escape {
-                    break;
-                }
+    let mut running = true;
+    let mut event_pump = sdl_context.event_pump();
+
+    while running {
+        for event in event_pump.poll_iter() {
+            use sdl2::event::Event;
+
+            match event {
+                Event::Quit {..} | Event::KeyDown { keycode: KeyCode::Escape, .. } => {
+                    running = false
+                },
+                _ => {}
             }
-            _ => {}
         }
+        // The rest of the game loop goes here...
     }
 }

--- a/examples/renderer-texture.rs
+++ b/examples/renderer-texture.rs
@@ -9,7 +9,7 @@ use sdl2::event::Event::{Quit, KeyDown};
 use sdl2::keycode::KeyCode;
 
 pub fn main() {
-    sdl2::init(sdl2::INIT_VIDEO);
+    let sdl_context = sdl2::init(sdl2::INIT_VIDEO).unwrap();
 
     let window = match Window::new("rust-sdl2 demo: Renderer + Texture", WindowPos::PosCentered, WindowPos::PosCentered, 800, 600, OPENGL) {
         Ok(window) => window,
@@ -51,6 +51,4 @@ pub fn main() {
             _ => {}
         }
     }
-
-    sdl2::quit();
 }

--- a/examples/renderer-yuv.rs
+++ b/examples/renderer-yuv.rs
@@ -4,8 +4,6 @@ use sdl2::video::{Window, WindowPos, SHOWN};
 use sdl2::render::{RenderDriverIndex, ACCELERATED, Renderer};
 use sdl2::pixels::PixelFormatEnum;
 use sdl2::rect::Rect;
-use sdl2::event::poll_event;
-use sdl2::event::Event::{Quit, KeyDown};
 use sdl2::keycode::KeyCode;
 
 pub fn main() {
@@ -56,15 +54,20 @@ pub fn main() {
     drawer.copy(&texture, None, Some(Rect::new(100, 100, 256, 256)));
     drawer.present();
 
-    loop {
-        match poll_event() {
-            Quit{..} => break,
-            KeyDown { keycode: key, .. } => {
-                if key == KeyCode::Escape {
-                    break;
-                }
+    let mut running = true;
+    let mut event_pump = sdl_context.event_pump();
+
+    while running {
+        for event in event_pump.poll_iter() {
+            use sdl2::event::Event;
+
+            match event {
+                Event::Quit {..} | Event::KeyDown { keycode: KeyCode::Escape, .. } => {
+                    running = false
+                },
+                _ => {}
             }
-            _ => {}
         }
+        // The rest of the game loop goes here...
     }
 }

--- a/examples/renderer-yuv.rs
+++ b/examples/renderer-yuv.rs
@@ -9,7 +9,7 @@ use sdl2::event::Event::{Quit, KeyDown};
 use sdl2::keycode::KeyCode;
 
 pub fn main() {
-    sdl2::init(sdl2::INIT_VIDEO);
+    let sdl_context = sdl2::init(sdl2::INIT_VIDEO).unwrap();
 
     let window = match Window::new("rust-sdl2 demo: YUV", WindowPos::PosCentered, WindowPos::PosCentered, 800, 600, SHOWN) {
         Ok(window) => window,
@@ -67,6 +67,4 @@ pub fn main() {
             _ => {}
         }
     }
-
-    sdl2::quit();
 }

--- a/sdl2-sys/src/event.rs
+++ b/sdl2-sys/src/event.rs
@@ -444,9 +444,9 @@ pub type SDL_EventFilter =
 extern "C" {
     pub fn SDL_free(mem: *const c_void);
     pub fn SDL_PumpEvents();
-    /*pub fn SDL_PeepEvents(events: &[SDL_Event], numevents: c_int,
-                                action: SDL_eventaction, minType: uint32_t,
-                                maxType: uint32_t) -> c_int;*/
+    pub fn SDL_PeepEvents(events: *mut SDL_Event, numevents: c_int,
+                                action: SDL_eventaction,
+                                minType: uint32_t, maxType: uint32_t) -> c_int;
     pub fn SDL_HasEvent(_type: uint32_t) -> SDL_bool;
     pub fn SDL_HasEvents(minType: uint32_t, maxType: uint32_t) ->
               SDL_bool;

--- a/src/sdl2/sdl.rs
+++ b/src/sdl2/sdl.rs
@@ -1,4 +1,5 @@
 use std::ffi::{c_str_to_bytes, CString};
+use std::marker::{NoCopy, PhantomData};
 
 use sys::sdl as ll;
 
@@ -27,30 +28,116 @@ pub enum Error {
 
 pub type SdlResult<T> = Result<T, String>;
 
-pub fn init(flags: InitFlag) -> bool {
-    unsafe {
-        ll::SDL_Init(flags.bits()) == 0
+use std::sync::atomic::{AtomicBool, ATOMIC_BOOL_INIT};
+/// Only one Sdl context can be alive at a time.
+/// Set to false by default (not alive).
+static IS_SDL_CONTEXT_ALIVE: AtomicBool = ATOMIC_BOOL_INIT;
+
+/// The SDL context type. Initialize with `sdl2::init()`.
+///
+/// From a thread-safety perspective, `Sdl` represents the main thread.
+/// Only one instance of `Sdl` is allowed per process, and cannot be moved or
+/// used across non-main threads.
+///
+/// As such, `Sdl` is a useful type for ensuring that SDL types that can only
+/// be used on the main thread are initialized that way.
+///
+/// For instance, `SDL_PumpEvents()` is not thread safe, and may only be
+/// called on the main thread.
+/// All functionality that calls `SDL_PumpEvents()` is thus put into an
+/// `EventPump` type, which can only be obtained through `Sdl`.
+/// This guarantees that the only way to call event-pumping functions is on
+/// the main thread.
+pub struct Sdl {
+    _marker: NoCopy
+}
+
+impl !Send for Sdl {}
+impl !Sync for Sdl {}
+
+impl Sdl {
+    /// Initializes specific SDL subsystems.
+    pub fn init_subsystem(&self, flags: InitFlag) -> SdlResult<Subsystem> {
+        unsafe {
+            if ll::SDL_InitSubSystem(flags.bits()) == 0 {
+                Ok(Subsystem {
+                    flags: flags,
+                    _marker: PhantomData
+                })
+            } else {
+                Err(get_error())
+            }
+        }
+    }
+
+    /// Returns the mask of the specified subsystems which have previously been initialized.
+    pub fn was_init(&self, flags: InitFlag) -> InitFlag {
+        unsafe {
+            let raw = ll::SDL_WasInit(flags.bits());
+            flags & InitFlag::from_bits(raw).unwrap()
+        }
     }
 }
 
-pub fn init_subsystem(flags: InitFlag) -> bool {
-    unsafe {
-        ll::SDL_InitSubSystem(flags.bits()) == 0
+impl Drop for Sdl {
+    fn drop(&mut self) {
+        use std::sync::atomic::Ordering;
+
+        let was_alive = IS_SDL_CONTEXT_ALIVE.swap(false, Ordering::Relaxed);
+        assert!(was_alive);
+
+        unsafe { ll::SDL_Quit(); }
     }
 }
 
-pub fn quit_subsystem(flags: InitFlag) {
-    unsafe { ll::SDL_QuitSubSystem(flags.bits()); }
+/// A RAII value representing initalized SDL subsystems. See `sdl2::Sdl::init_subsystem()`.
+///
+/// Subsystem initialization is ref-counted. Once `Subsystem::drop()` is called,
+/// the specified subsystems' ref-counts are decremented via `SDL_QuitSubSystem`.
+pub struct Subsystem<'sdl> {
+    flags: InitFlag,
+    _marker: PhantomData<&'sdl Sdl>
 }
 
-pub fn quit() {
-    unsafe { ll::SDL_Quit(); }
+#[unsafe_destructor]
+impl<'sdl> Drop for Subsystem<'sdl> {
+    fn drop(&mut self) {
+        unsafe { ll::SDL_QuitSubSystem(self.flags.bits()); }
+    }
 }
 
-pub fn was_inited(flags: InitFlag) -> InitFlag {
+/// Initializes the SDL library.
+/// This must be called before using any other SDL function.
+///
+/// # Example
+/// ```no_run
+/// let sdl_context = sdl2::init(sdl2::INIT_EVERYTHING).unwrap();
+///
+/// let mut event_pump = sdl_context.event_pump();
+/// for event in event_pump.poll_iter() {
+///     // ...
+/// }
+///
+/// // SDL_Quit() is called here as `sdl_context` is dropped.
+/// ```
+pub fn init(flags: InitFlag) -> SdlResult<Sdl> {
     unsafe {
-        let raw = ll::SDL_WasInit(flags.bits());
-        flags & InitFlag::from_bits(raw).unwrap()
+        use std::sync::atomic::Ordering;
+
+        // Atomically switch the `IS_SDL_CONTEXT_ALIVE` global to true
+        let was_alive = IS_SDL_CONTEXT_ALIVE.swap(true, Ordering::Relaxed);
+
+        if was_alive {
+            IS_SDL_CONTEXT_ALIVE.swap(false, Ordering::Relaxed);
+            Err(format!("Cannot have more than one `Sdl` in use at the same time"))
+        } else {
+            if ll::SDL_Init(flags.bits()) == 0 {
+                Ok(Sdl { _marker: NoCopy })
+            } else {
+                IS_SDL_CONTEXT_ALIVE.swap(false, Ordering::Relaxed);
+                Err(get_error())
+            }
+        }
     }
 }
 

--- a/src/sdl2/sdl.rs
+++ b/src/sdl2/sdl.rs
@@ -2,6 +2,7 @@ use std::ffi::{c_str_to_bytes, CString};
 use std::marker::{NoCopy, PhantomData};
 
 use sys::sdl as ll;
+use event::EventPump;
 
 bitflags! {
     flags InitFlag: u32 {
@@ -77,6 +78,11 @@ impl Sdl {
             flags & InitFlag::from_bits(raw).unwrap()
         }
     }
+
+    /// Obtains the SDL event pump.
+    pub fn event_pump(&self) -> EventPump {
+        unsafe { EventPump::_unchecked_new() }
+    }
 }
 
 impl Drop for Sdl {
@@ -132,7 +138,9 @@ pub fn init(flags: InitFlag) -> SdlResult<Sdl> {
             Err(format!("Cannot have more than one `Sdl` in use at the same time"))
         } else {
             if ll::SDL_Init(flags.bits()) == 0 {
-                Ok(Sdl { _marker: NoCopy })
+                Ok(Sdl {
+                    _marker: NoCopy
+                })
             } else {
                 IS_SDL_CONTEXT_ALIVE.swap(false, Ordering::Relaxed);
                 Err(get_error())

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -4,8 +4,6 @@ extern crate sdl2;
 
 #[test]
 fn audio_spec_wav() {
-    sdl2::init(sdl2::INIT_AUDIO);
-
     let wav = sdl2::audio::AudioSpecWAV::load_wav(&Path::new("./tests/sine.wav")).unwrap();
 
     assert_eq!(wav.freq, 22050);
@@ -14,6 +12,4 @@ fn audio_spec_wav() {
 
     let buffer = wav.get_buffer();
     assert_eq!(buffer.len(), 4410);
-
-    sdl2::quit();
 }


### PR DESCRIPTION
**If this is merged, it will cause quite a disturbance: literally every SDL2 project will break!**

This is the result from what was discussed in #324.

### A quick migration guide

#### Initialization
```rust
/// sdl2::init(...);
/// sdl2::quit();
let sdl_context: sdl2::Sdl = sdl2::init(...).unwrap();

// `SDL_Quit()` is called automagically!
```
The most obvious change here is that you no longer have to call `sdl2::quit()`. Once the `Sdl` type is dropped, cleanup is done automatically.

The _true_ reason the SDL "context" object was added was for thread safety reasons.
Some of SDL's types and functions require initialization or use exclusively on the main thread (such as `SDL_PumpEvents()`, `SDL_Window`). Adding a non-`Send`able type that represents the SDL main thread gives Rust a way to statically guarantee that event pumping (and later `Window` creation) only occurs there.


#### Event loop
```rust
// loop {
//     match poll_event() {
//         Event::None => break,
//         // ...
//     }
// }
let mut event_pump = sdl_context.event_pump();
for event in event_pump.poll_iter() {
    match event {
        // ...
    }
}
```

The `Sdl` context must be accessible in order to pump events (be it by polling or waiting).
This is because in SDL2, all functions that pump events must be done on the main thread: `SDL_PollEvent()`, `SDL_WaitEvent()`, `SDL_WaitEventTimeout()`, `SDL_PumpEvents()`

#### Other non-trivial use cases
Many projects aren't as simple as the `rust-sdl2` examples suggest. Larger projects will often abstract the SDL initialization and event loop. Fortunately, this is fairly easy to address:
<table>
<tr>
<td>
<h5>Old</h5>
<pre>
struct MyGame {
    player: Player,
    enemies: Vec&lt;Enemy&gt;,
    // ...
}

impl MyGame {
    pub fn new() -> MyGame {
        sdl2::init(sdl2::INIT_EVERYTHING);
        // ...
        MyGame { ... }
    }

    fn poll_events(&mut self) {
        loop {
            match poll_event() {
                // ...
            }
        }
    }
}

let game = MyGame::new();
</pre>
</td>
<td>
<h5>New</h5>
<pre>
struct MyGame&lt;'a&gt; {
    sdl: &'a sdl2::Sdl,
    player: Player,
    enemies: Vec&lt;Enemy&gt;,
    // ...
}

impl&lt;'a&gt; MyGame&lt;'a&gt; {
    pub fn new&lt;'b&gt;(sdl: &'b sdl2::Sdl) -> MyGame&lt;'b&gt; {
        // ...
        MyGame { sdl: sdl, ... }
    }

    fn poll_events(&mut self) {
        let mut event_pump = self.sdl.event_pump();
        for event in event_pump.poll_iter() {
            // ...
        }
    }
}

let sdl = sdl2::init(sdl2::INIT_EVERYTHING).unwrap();
let game = MyGame::new(&sdl);
</pre>
</td>
</tr>
</table>

If it suits your needs, you can change `MyGame` to owning `Sdl` instead of borrowing it.

#### Some docs
`sdl2::Sdl`: https://nukep.github.io/rust-sdl2/sdl2/sdl/struct.Sdl.html
`sdl2::init()`: https://nukep.github.io/rust-sdl2/sdl2/sdl/fn.init.html
`sdl2::event::EventPump`: https://nukep.github.io/rust-sdl2/sdl2/event/struct.EventPump.html

---

#340 should be merged first. This is rebased from the changes from #340, so this should merge cleanly.

Closes #324
Fixes #256 