### PR TITLE
Update to rustc 1.0.0-dev (c9b03c24e 2015-03-12) (built 2015-03-13).

### DIFF
--- a/examples/audio-whitenoise.rs
+++ b/examples/audio-whitenoise.rs
@@ -7,7 +7,7 @@ struct MyCallback {
     volume: f32
 }
 impl AudioCallback for MyCallback {
-    pub type Channel = f32;
+    type Channel = f32;
 
     fn callback(&mut self, out: &mut [f32]) {
         use self::rand::{Rng, thread_rng};

--- a/sdl2-sys/src/lib.rs
+++ b/sdl2-sys/src/lib.rs
@@ -1,7 +1,5 @@
 #![allow(non_camel_case_types)]
 
-#![feature(core)]
-
 extern crate libc;
 
 pub mod scancode;

--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -429,7 +429,7 @@ impl Event {
                     data2: ptr::null(),
                 };
                 unsafe {
-                    ptr::copy_memory(mem::transmute::<_,*mut ll::SDL_UserEvent>(&ret), &event, 1);
+                    ptr::copy(mem::transmute::<_,*mut ll::SDL_UserEvent>(&ret), &event, 1);
                 }
                 Some(ret)
             },
@@ -449,7 +449,7 @@ impl Event {
         };
 
         // if event type has not been defined, treat it as a UserEvent
-        let event_type: EventType = FromPrimitive::from_uint(raw_type as usize).unwrap_or(EventType::User);
+        let event_type: EventType = FromPrimitive::from_usize(raw_type as usize).unwrap_or(EventType::User);
         unsafe { match event_type {
             EventType::Quit => {
                 let ref event = *raw.quit();
@@ -951,7 +951,7 @@ pub struct EventPollIterator<'a> {
 }
 
 impl<'a> Iterator for EventPollIterator<'a> {
-    pub type Item = Event;
+    type Item = Event;
 
     fn next(&mut self) -> Option<Event> {
         self.event_pump.poll_event()
@@ -965,7 +965,7 @@ pub struct EventWaitIterator<'a> {
 }
 
 impl<'a> Iterator for EventWaitIterator<'a> {
-    pub type Item = Event;
+    type Item = Event;
     fn next(&mut self) -> Option<Event> { Some(self.event_pump.wait_event()) }
 }
 
@@ -977,7 +977,7 @@ pub struct EventWaitTimeoutIterator<'a> {
 }
 
 impl<'a> Iterator for EventWaitTimeoutIterator<'a> {
-    pub type Item = Event;
+    type Item = Event;
     fn next(&mut self) -> Option<Event> { self.event_pump.wait_event_timeout(self.timeout) }
 }
 

--- a/src/sdl2/keyboard.rs
+++ b/src/sdl2/keyboard.rs
@@ -46,7 +46,7 @@ pub fn get_keyboard_state() -> HashMap<ScanCode, bool> {
 
     let mut current = 0;
     while current < raw.len() {
-        state.insert(FromPrimitive::from_int(current as isize)
+        state.insert(FromPrimitive::from_isize(current as isize)
                         .unwrap_or(ScanCode::Unknown),
                      raw[current] == 1);
         current += 1;
@@ -65,14 +65,14 @@ pub fn set_mod_state(flags: Mod) {
 
 pub fn get_key_from_scancode(scancode: ScanCode) -> KeyCode {
     unsafe {
-        FromPrimitive::from_int(ll::SDL_GetKeyFromScancode(scancode as u32) as isize)
+        FromPrimitive::from_isize(ll::SDL_GetKeyFromScancode(scancode as u32) as isize)
             .unwrap_or(KeyCode::Unknown)
     }
 }
 
 pub fn get_scancode_from_key(key: KeyCode) -> ScanCode {
     unsafe {
-        FromPrimitive::from_int(ll::SDL_GetScancodeFromKey(key as i32) as isize)
+        FromPrimitive::from_isize(ll::SDL_GetScancodeFromKey(key as i32) as isize)
             .unwrap_or(ScanCode::Unknown)
     }
 }
@@ -91,7 +91,7 @@ pub fn get_scancode_from_name(name: &str) -> Result<ScanCode, NulError> {
             Ok(s) => s.as_ptr(),
             Err(e) => return Err(e),
         };
-        Ok(FromPrimitive::from_int(ll::SDL_GetScancodeFromName(name) as isize)
+        Ok(FromPrimitive::from_isize(ll::SDL_GetScancodeFromName(name) as isize)
             .unwrap_or(ScanCode::Unknown))
     }
 }
@@ -110,7 +110,7 @@ pub fn get_key_from_name(name: &str) -> Result<KeyCode, NulError> {
             Ok(s) => s.as_ptr(),
             Err(e) => return Err(e),
         };
-        Ok(FromPrimitive::from_int(ll::SDL_GetKeyFromName(name) as isize)
+        Ok(FromPrimitive::from_isize(ll::SDL_GetKeyFromName(name) as isize)
             .unwrap_or(KeyCode::Unknown))
     }
 }

--- a/src/sdl2/lib.rs
+++ b/src/sdl2/lib.rs
@@ -2,7 +2,7 @@
 #![crate_type = "lib"]
 
 #![feature(unsafe_destructor, optin_builtin_traits, std_misc, old_io, core)]
-#![feature(collections, old_path, os)]
+#![feature(collections, old_path)]
 
 extern crate libc;
 extern crate collections;


### PR DESCRIPTION
This commit fixes errors and clean all warnings about deprecated and unused stuff.