### PR TITLE
Update io, path and collections

### DIFF
--- a/src/sdl2/audio.rs
+++ b/src/sdl2/audio.rs
@@ -4,6 +4,7 @@ use std::num::FromPrimitive;
 use libc::{c_int, c_void, uint8_t};
 use std::ops::{Deref, DerefMut};
 use std::marker::PhantomFn;
+use std::path::Path;
 
 use get_error;
 use rwops::RWops;

--- a/src/sdl2/keyboard.rs
+++ b/src/sdl2/keyboard.rs
@@ -41,7 +41,8 @@ pub fn get_keyboard_state() -> HashMap<ScanCode, bool> {
     let mut state: HashMap<ScanCode, bool> = HashMap::new();
     let count = 0;
 
-    let raw = unsafe { Vec::from_raw_buf(ll::SDL_GetKeyboardState(&count),
+    let state_ptr = unsafe { ll::SDL_GetKeyboardState(&count) };
+    let raw = unsafe { ::std::slice::from_raw_parts(state_ptr,
                                           count as usize) };
 
     let mut current = 0;

--- a/src/sdl2/lib.rs
+++ b/src/sdl2/lib.rs
@@ -1,8 +1,8 @@
 #![crate_name = "sdl2"]
 #![crate_type = "lib"]
 
-#![feature(unsafe_destructor, optin_builtin_traits, std_misc, old_io, core)]
-#![feature(collections, old_path)]
+#![feature(unsafe_destructor, optin_builtin_traits, std_misc, core, io)]
+#![feature(collections)]
 
 extern crate libc;
 extern crate collections;

--- a/src/sdl2/lib.rs
+++ b/src/sdl2/lib.rs
@@ -2,10 +2,8 @@
 #![crate_type = "lib"]
 
 #![feature(unsafe_destructor, optin_builtin_traits, std_misc, core, io)]
-#![feature(collections)]
 
 extern crate libc;
-extern crate collections;
 #[macro_use]
 extern crate bitflags;
 extern crate "sdl2-sys" as sys;

--- a/src/sdl2/surface.rs
+++ b/src/sdl2/surface.rs
@@ -1,4 +1,5 @@
 use std::mem;
+use std::path::Path;
 use rect::Rect;
 use get_error;
 use SdlResult;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,6 +1,6 @@
-#![feature(old_path)]
-
 extern crate sdl2;
+
+use std::path::Path;
 
 #[test]
 fn audio_spec_wav() {


### PR DESCRIPTION
This is an update to the new IO. It also uses the new Path module. This makes it a breaking change for anyone using RWOps.
Furthermore, I changed an unnecessary use of Vec::from_raw_buf, as slice::from_raw_parts was enough.

The only function that need a look at is the flush() method for io::Write. Currently it just returns Ok, without actually doing anything.