### PR TITLE
Fix range, remove as_slice and some transmutes

### DIFF
--- a/sdl2-sys/src/audio.rs
+++ b/sdl2-sys/src/audio.rs
@@ -25,7 +25,7 @@ pub const AUDIO_S32SYS : SDL_AudioFormat =     AUDIO_S32LSB;
 pub const AUDIO_F32SYS : SDL_AudioFormat =     AUDIO_F32LSB;
 
 pub type SDL_AudioCallback =
-    Option<extern "C" fn (arg1: *const c_void, arg2: *const uint8_t, arg3: c_int)>;
+    Option<extern "C" fn (arg1: *mut c_void, arg2: *mut uint8_t, arg3: c_int)>;
 #[allow(missing_copy_implementations)]
 #[repr(C)]
 pub struct SDL_AudioSpec {

--- a/sdl2-sys/src/render.rs
+++ b/sdl2-sys/src/render.rs
@@ -78,7 +78,7 @@ extern "C" {
     pub fn SDL_GetTextureBlendMode(texture: *const SDL_Texture, blendMode: *const SDL_BlendMode) -> c_int;
     pub fn SDL_UpdateTexture(texture: *const SDL_Texture, rect: *const SDL_Rect, pixels: *const c_void, pitch: c_int) -> c_int;
     pub fn SDL_UpdateYUVTexture(texture: *const SDL_Texture, rect: *const SDL_Rect, Yplane: *const uint8_t, Ypitch: c_int, Uplane: *const uint8_t, Upitch: c_int, Vplane: *const uint8_t, Vpitch: c_int) -> c_int;
-    pub fn SDL_LockTexture(texture: *const SDL_Texture, rect: *const SDL_Rect, pixels: *const *const c_void, pitch: *const c_int) -> c_int;
+    pub fn SDL_LockTexture(texture: *const SDL_Texture, rect: *const SDL_Rect, pixels: *mut *mut c_void, pitch: *mut c_int) -> c_int;
     pub fn SDL_UnlockTexture(texture: *const SDL_Texture);
     pub fn SDL_RenderTargetSupported(renderer: *const SDL_Renderer) -> SDL_bool;
     pub fn SDL_SetRenderTarget(renderer: *const SDL_Renderer, texture: *const SDL_Texture) -> c_int;

--- a/src/sdl2/audio.rs
+++ b/src/sdl2/audio.rs
@@ -492,10 +492,10 @@ mod test {
         use std::iter::repeat;
 
         // 0,1,2,3, ...
-        let buffer: Vec<u8> = range(0, 255).collect();
+        let buffer: Vec<u8> = (0..255).collect();
 
         // 0,0,1,1,2,2,3,3, ...
-        let new_buffer_expected: Vec<u8> = range(0, 255).flat_map(|v| repeat(v).take(2)).collect();
+        let new_buffer_expected: Vec<u8> = (0..255).flat_map(|v| repeat(v).take(2)).collect();
 
         let cvt = AudioCVT::new(AUDIOU8, 1, 44100, AUDIOU8, 2, 44100).unwrap();
         assert!(cvt.is_conversion_needed());

--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -416,7 +416,7 @@ impl ::std::fmt::Debug for Event {
 // TODO: Remove this when from_utf8 is updated in Rust
 impl Event {
     fn to_ll(self) -> Option<ll::SDL_Event> {
-        let ret = unsafe { mem::uninitialized() };
+        let mut ret = unsafe { mem::uninitialized() };
         match self {
             // just ignore timestamp
             Event::User { window_id, _type, code, .. } => {
@@ -429,7 +429,7 @@ impl Event {
                     data2: ptr::null(),
                 };
                 unsafe {
-                    ptr::copy(mem::transmute::<_,*mut ll::SDL_UserEvent>(&ret), &event, 1);
+                    ptr::copy(&mut ret as *mut ll::SDL_Event as *mut ll::SDL_UserEvent, &event, 1);
                 }
                 Some(ret)
             },

--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -525,11 +525,10 @@ impl Event {
                 let ref event = *raw.edit();
 
                 let text = String::from_utf8_lossy(
-                        event.text.iter()
+                        &event.text.iter()
                             .take_while(|&b| (*b) != 0i8)
                             .map(|&b| b as u8)
                             .collect::<Vec<u8>>()
-                            .as_slice()
                     ).to_owned().into_owned();
                 Event::TextEditing {
                     timestamp: event.timestamp,
@@ -543,11 +542,10 @@ impl Event {
                 let ref event = *raw.text();
 
                 let text = String::from_utf8_lossy(
-                        event.text.iter()
+                        &event.text.iter()
                             .take_while(|&b| (*b) != 0i8)
                             .map(|&b| b as u8)
                             .collect::<Vec<u8>>()
-                            .as_slice()
                     ).to_owned().into_owned();
                 Event::TextInput {
                     timestamp: event.timestamp,

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -720,8 +720,7 @@ impl<'renderer> RenderDrawer<'renderer> {
 
             // Pass the interior of `pixels: Vec<u8>` to SDL
             let ret = {
-                let pixels_ref: raw::Slice<u8> = mem::transmute(pixels.as_slice());
-                ll::SDL_RenderReadPixels(self.raw, actual_rect, format as uint32_t, pixels_ref.data as *mut c_void, pitch as c_int)
+                ll::SDL_RenderReadPixels(self.raw, actual_rect, format as uint32_t, pixels.as_mut_ptr() as *mut c_void, pitch as c_int)
             };
 
             if ret == 0 {


### PR DESCRIPTION
* `range(a,b)` was removed, so I updated it to `(a..b)`
* as_slice is unstable and in our case not needed
* Some transmutes could easily be replaced by other functions. I changed these so the code would hopefully be a little clearer.
* During the change above, I updated some `*const` to `*mut` in sys as that reflected the upstream better.