### PR TITLE
Fix Copy, plus reduce the used features

### DIFF
--- a/sdl2-sys/src/audio.rs
+++ b/sdl2-sys/src/audio.rs
@@ -42,7 +42,7 @@ pub struct SDL_AudioSpec {
 pub type SDL_AudioFilter =
     Option<extern "C" fn (arg1: *const SDL_AudioCVT, arg2: SDL_AudioFormat)>;
 #[allow(dead_code, missing_copy_implementations, raw_pointer_derive)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct SDL_AudioCVT {
     pub needed: c_int,

--- a/sdl2-sys/src/event.rs
+++ b/sdl2-sys/src/event.rs
@@ -14,7 +14,7 @@ pub type SDL_bool = c_int;
 pub type SDL_EventState = uint8_t;
 pub const SDL_DISABLE: SDL_EventState = 0;
 pub const SDL_ENABLE: SDL_EventState = 1;
-pub const SDL_QUERY: SDL_EventState = -1;
+pub const SDL_QUERY: SDL_EventState = 0xFF;
 
 pub type SDL_SysWMmsg = c_void;
 

--- a/sdl2-sys/src/touch.rs
+++ b/sdl2-sys/src/touch.rs
@@ -5,7 +5,7 @@ pub type SDL_FingerID = int64_t;
 pub type SDL_Finger = Finger;
 pub type TouchDevice = SDL_TouchID;
 
-#[derive(PartialEq, Copy)]
+#[derive(PartialEq, Copy, Clone)]
 #[repr(C)]
 pub struct Finger {
     id: TouchDevice,

--- a/src/sdl2/audio.rs
+++ b/src/sdl2/audio.rs
@@ -407,7 +407,7 @@ impl<'a, CB> Drop for AudioDeviceLockGuard<'a, CB> {
     }
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct AudioCVT {
     raw: ll::SDL_AudioCVT
 }

--- a/src/sdl2/audio.rs
+++ b/src/sdl2/audio.rs
@@ -400,7 +400,6 @@ impl<'a, CB: 'a> DerefMut for AudioDeviceLockGuard<'a, CB> {
     fn deref_mut(&mut self) -> &mut CB { &mut self.device.userdata.callback }
 }
 
-#[unsafe_destructor]
 impl<'a, CB> Drop for AudioDeviceLockGuard<'a, CB> {
     fn drop(&mut self) {
         unsafe { ll::SDL_UnlockAudioDevice(self.device.device_id.id()) }

--- a/src/sdl2/controller.rs
+++ b/src/sdl2/controller.rs
@@ -156,7 +156,7 @@ pub fn get_event_state() -> bool {
 }
 
 /// Possible return values for `add_mapping`
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub enum MappingStatus {
     Added   = 1,
     Updated = 0,

--- a/src/sdl2/joystick.rs
+++ b/src/sdl2/joystick.rs
@@ -255,7 +255,7 @@ impl Drop for Joystick {
 
 /// Wrapper around a SDL_JoystickGUID, a globally unique identifier
 /// for a joystick.
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct Guid {
     raw: ll::SDL_JoystickGUID,
 }
@@ -321,7 +321,7 @@ impl Display for Guid {
 /// combinations make sense: 5 for instance would mean up and down at
 /// the same time... To simplify things I turn it into an enum which
 /// is how the SDL2 docs present it anyway (using macros).
-#[derive(Copy, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub enum HatState {
     Centered  = 0,
     Up        = 0x01,

--- a/src/sdl2/keycode.rs
+++ b/src/sdl2/keycode.rs
@@ -3,7 +3,7 @@ use std::num::ToPrimitive;
 
 use sys::keycode as ll;
 
-#[derive(PartialEq, Eq, FromPrimitive, Debug, Copy)]
+#[derive(PartialEq, Eq, FromPrimitive, Debug, Copy, Clone)]
 pub enum KeyCode {
     Unknown            = ll::SDLK_UNKNOWN as isize,
     Backspace          = ll::SDLK_BACKSPACE as isize,

--- a/src/sdl2/lib.rs
+++ b/src/sdl2/lib.rs
@@ -1,7 +1,7 @@
 #![crate_name = "sdl2"]
 #![crate_type = "lib"]
 
-#![feature(optin_builtin_traits, std_misc, core)]
+#![feature(optin_builtin_traits, core)]
 
 extern crate libc;
 #[macro_use]

--- a/src/sdl2/lib.rs
+++ b/src/sdl2/lib.rs
@@ -1,7 +1,7 @@
 #![crate_name = "sdl2"]
 #![crate_type = "lib"]
 
-#![feature(unsafe_destructor, optin_builtin_traits, std_misc, core)]
+#![feature(optin_builtin_traits, std_misc, core)]
 
 extern crate libc;
 #[macro_use]

--- a/src/sdl2/lib.rs
+++ b/src/sdl2/lib.rs
@@ -2,6 +2,7 @@
 #![crate_type = "lib"]
 
 #![feature(optin_builtin_traits, core)]
+#![cfg_attr(test, feature(std_misc))]
 
 extern crate libc;
 #[macro_use]

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -51,7 +51,7 @@ use std::ptr;
 use libc::{c_int, uint32_t, c_double, c_void};
 use rect::Point;
 use rect::Rect;
-use std::cell::{RefCell, RefMut, BorrowState};
+use std::cell::{RefCell, RefMut};
 use std::ffi::CStr;
 use std::num::FromPrimitive;
 use std::vec::Vec;
@@ -266,10 +266,7 @@ impl Renderer {
     /// }
     /// ```
     pub fn drawer(&self) -> RenderDrawer {
-        match self.drawer_borrow.borrow_state() {
-            BorrowState::Unused => RenderDrawer::new(self.raw, self.drawer_borrow.borrow_mut()),
-            _ => panic!("Renderer drawer already borrowed")
-        }
+        RenderDrawer::new(self.raw, self.drawer_borrow.borrow_mut())
     }
 
     /// Unwraps the window or surface the rendering context was created from.

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -862,7 +862,6 @@ pub struct Texture<'renderer> {
     _marker: PhantomData<&'renderer ()>
 }
 
-#[unsafe_destructor]
 impl<'renderer> Drop for Texture<'renderer> {
     fn drop(&mut self) {
         if self.owned {

--- a/src/sdl2/scancode.rs
+++ b/src/sdl2/scancode.rs
@@ -3,7 +3,7 @@ use std::num::ToPrimitive;
 
 use sys::scancode as ll;
 
-#[derive(PartialEq, Eq, FromPrimitive, Debug, Copy)]
+#[derive(PartialEq, Eq, FromPrimitive, Debug, Copy, Clone)]
 pub enum ScanCode {
     Unknown            = ll::SDL_SCANCODE_UNKNOWN as isize,
     A                  = ll::SDL_SCANCODE_A as isize,

--- a/src/sdl2/sdl.rs
+++ b/src/sdl2/sdl.rs
@@ -105,7 +105,6 @@ pub struct Subsystem<'sdl> {
     _marker: PhantomData<&'sdl Sdl>
 }
 
-#[unsafe_destructor]
 impl<'sdl> Drop for Subsystem<'sdl> {
     fn drop(&mut self) {
         unsafe { ll::SDL_QuitSubSystem(self.flags.bits()); }

--- a/src/sdl2/timer.rs
+++ b/src/sdl2/timer.rs
@@ -54,7 +54,6 @@ impl<'a> Timer<'a> {
     }
 }
 
-#[unsafe_destructor]
 impl<'a> Drop for Timer<'a> {
     fn drop(&mut self) {
         let ret = unsafe { ll::SDL_RemoveTimer(self.raw) };

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -125,7 +125,7 @@ pub enum FullscreenType {
     FTDesktop = 0x00001001,
 }
 
-#[derive(PartialEq, Copy)]
+#[derive(PartialEq, Copy, Clone)]
 pub enum WindowPos {
     PosUndefined,
     PosCentered,


### PR DESCRIPTION
* Implement Clone where Copy is needed
* Remove all uses of `unsafe_destructor`, these are no longer needed
* Remove the `BorrowState`, this way we only need `std_misc` when testing