### PR TITLE
Move no_std from sdl2-sys to a cargo feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ install:
 script:
     - cargo build -v
     - cargo build -v --features "use-pkgconfig"
+    - cd sdl2-sys && cargo build --features no_std
     - cargo test -v
     - cargo doc -v
 after_success:

--- a/sdl2-sys/Cargo.toml
+++ b/sdl2-sys/Cargo.toml
@@ -24,3 +24,4 @@ optional = true
 
 default = []
 use-pkgconfig = ["pkg-config"]
+no_std = []

--- a/sdl2-sys/src/audio.rs
+++ b/sdl2-sys/src/audio.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "no_std")]
 use core::prelude::*;
 use libc::{c_int, c_uint, c_void, uint8_t, uint32_t};
 use libc::{uint16_t, c_double, c_char};

--- a/sdl2-sys/src/controller.rs
+++ b/sdl2-sys/src/controller.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "no_std")]
 use core::prelude::*;
 use libc::{c_int, c_char, c_uchar, c_uint, c_void, int16_t, uint8_t};
 use joystick::{SDL_Joystick, SDL_JoystickGUID};

--- a/sdl2-sys/src/event.rs
+++ b/sdl2-sys/src/event.rs
@@ -6,6 +6,7 @@ use gesture::SDL_GestureID;
 use keyboard::SDL_Keysym;
 use touch::SDL_FingerID;
 use touch::SDL_TouchID;
+#[cfg(feature = "no_std")]
 use core::prelude::*;
 
 pub type SDL_bool = c_int;

--- a/sdl2-sys/src/haptic.rs
+++ b/sdl2-sys/src/haptic.rs
@@ -1,4 +1,5 @@
 use joystick::SDL_Joystick;
+#[cfg(feature = "no_std")]
 use core::prelude::*;
 use libc::{c_int, c_uint, c_char, c_float, c_void, int16_t, int32_t, uint8_t, uint16_t, uint32_t};
 

--- a/sdl2-sys/src/lib.rs
+++ b/sdl2-sys/src/lib.rs
@@ -1,8 +1,9 @@
-#![feature(no_std, core)]
-#![no_std]
+#![cfg_attr(feature = "no_std", feature(no_std, core))]
+#![cfg_attr(feature = "no_std", no_std)]
 #![allow(non_camel_case_types)]
 
 extern crate libc;
+#[cfg(feature = "no_std")]
 extern crate core;
 
 pub mod scancode;

--- a/sdl2-sys/src/rect.rs
+++ b/sdl2-sys/src/rect.rs
@@ -2,8 +2,12 @@
 Rectangle Functions
  */
 
+#[cfg(feature = "no_std")]
 use core::prelude::*;
+#[cfg(feature = "no_std")]
 use core::intrinsics::transmute;
+#[cfg(not(feature = "no_std"))]
+use std::mem::transmute;
 use libc::c_int;
 
 /// A structure that defines a two dimensional point.

--- a/sdl2-sys/src/timer.rs
+++ b/sdl2-sys/src/timer.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "no_std")]
 use core::prelude::*;
 use libc::{uint32_t, uint64_t, c_void, c_int};
 

--- a/sdl2-sys/src/video.rs
+++ b/sdl2-sys/src/video.rs
@@ -1,6 +1,7 @@
 use rect::Rect;
 use surface::SDL_Surface;
 
+#[cfg(feature = "no_std")]
 use core::prelude::*;
 use libc::{c_void, c_int, c_float, c_char, uint16_t, uint32_t};
 


### PR DESCRIPTION
This way sdl2-sys will compile on the beta channel.
If needed, sdl2-sys can be compiled using `cargo build --features no_std`.