### PR TITLE
Audio API changes

### DIFF
--- a/examples/audio-squarewave.rs
+++ b/examples/audio-squarewave.rs
@@ -1,0 +1,54 @@
+extern crate sdl2;
+
+use sdl2::audio::{AudioCallback, AudioDevice, AudioSpecDesired};
+
+struct SquareWave {
+    phase_inc: f32,
+    phase: f32,
+    volume: f32
+}
+
+impl AudioCallback for SquareWave {
+    type Channel = f32;
+
+    fn callback(&mut self, out: &mut [f32]) {
+        // Generate a square wave
+        for x in out.iter_mut() {
+            *x = match self.phase {
+                0.0...0.5 => self.volume,
+                _ => -self.volume
+            };
+            self.phase = (self.phase + self.phase_inc) % 1.0;
+        }
+    }
+}
+
+fn main() {
+    let _sdl_context = sdl2::init(sdl2::INIT_AUDIO).unwrap();
+
+    let desired_spec = AudioSpecDesired {
+        freq: Some(44100),
+        channels: Some(1),  // mono
+        samples: None       // default sample size
+    };
+
+    let device = AudioDevice::open_playback(None, desired_spec, |spec| {
+        // Show obtained AudioSpec
+        println!("{:?}", spec);
+
+        // initialize the audio callback
+        SquareWave {
+            phase_inc: 440.0 / spec.freq as f32,
+            phase: 0.0,
+            volume: 0.25
+        }
+    }).unwrap();
+
+    // Start playback
+    device.resume();
+
+    // Play for 2 seconds
+    sdl2::timer::delay(2000);
+
+    // Device is automatically closed when dropped
+}

--- a/examples/audio-whitenoise.rs
+++ b/examples/audio-whitenoise.rs
@@ -24,9 +24,9 @@ fn main() {
     let _sdl_context = sdl2::init(sdl2::INIT_AUDIO).unwrap();
 
     let desired_spec = AudioSpecDesired {
-        freq: 44100,
-        channels: 1,
-        samples: 0
+        freq: Some(44100),
+        channels: Some(1),  // mono
+        samples: None,      // default sample size
     };
 
     // None: use default device

--- a/examples/audio-whitenoise.rs
+++ b/examples/audio-whitenoise.rs
@@ -1,7 +1,7 @@
 extern crate sdl2;
 extern crate rand;
 
-use sdl2::audio::{AudioCallback, AudioSpecDesired};
+use sdl2::audio::{AudioCallback, AudioDevice, AudioSpecDesired};
 
 struct MyCallback {
     volume: f32
@@ -26,19 +26,16 @@ fn main() {
     let desired_spec = AudioSpecDesired {
         freq: 44100,
         channels: 1,
-        samples: 0,
-        callback: MyCallback { volume: 0.5 },
+        samples: 0
     };
 
     // None: use default device
-    // false: Playback
-    let mut device = match desired_spec.open_audio_device(None, false) {
-        Ok(device) => device,
-        Err(s) => panic!("{:?}", s)
-    };
+    let mut device = AudioDevice::open_playback(None, desired_spec, |spec| {
+        // Show obtained AudioSpec
+        println!("{:?}", spec);
 
-    // Show obtained AudioSpec
-    println!("{:?}", device.get_spec());
+        MyCallback { volume: 0.5 }
+    }).unwrap();
 
     // Start playback
     device.resume();

--- a/src/sdl2/audio.rs
+++ b/src/sdl2/audio.rs
@@ -1,4 +1,53 @@
 //! Audio Functions
+//!
+//! # Example
+//! ```no_run
+//! use sdl2::audio::{AudioCallback, AudioDevice, AudioSpecDesired};
+//!
+//! struct SquareWave {
+//!     phase_inc: f32,
+//!     phase: f32,
+//!     volume: f32
+//! }
+//!
+//! impl AudioCallback for SquareWave {
+//!     type Channel = f32;
+//!
+//!     fn callback(&mut self, out: &mut [f32]) {
+//!         // Generate a square wave
+//!         for x in out.iter_mut() {
+//!             *x = match self.phase {
+//!                 0.0...0.5 => self.volume,
+//!                 _ => -self.volume
+//!             };
+//!             self.phase = (self.phase + self.phase_inc) % 1.0;
+//!         }
+//!     }
+//! }
+//!
+//! let _sdl_context = sdl2::init(sdl2::INIT_AUDIO).unwrap();
+//!
+//! let desired_spec = AudioSpecDesired {
+//!     freq: Some(44100),
+//!     channels: Some(1),  // mono
+//!     samples: None       // default sample size
+//! };
+//!
+//! let device = AudioDevice::open_playback(None, desired_spec, |spec| {
+//!     // initialize the audio callback
+//!     SquareWave {
+//!         phase_inc: 440.0 / spec.freq as f32,
+//!         phase: 0.0,
+//!         volume: 0.25
+//!     }
+//! }).unwrap();
+//!
+//! // Start playback
+//! device.resume();
+//!
+//! // Play for 2 seconds
+//! sdl2::timer::delay(2000);
+//! ```
 use std::ffi::{CStr, CString};
 use std::num::FromPrimitive;
 use libc::{c_int, c_void, uint8_t};


### PR DESCRIPTION
It's me, again!

Here are some functional improvements to the audio API. Basically, the way the audio device is opened is now changed to account for fallback values and obtained AudioSpecs.
```rust
let desired_spec = AudioSpecDesired {
    freq: 44100,
    channels: 1,
    samples: 0,
    callback: MyCallback { actual_freq: ??? }
};

let device = desired_spec.open_audio_device(None, false).unwrap();
```
becomes
```rust
let desired_spec = AudioSpecDesired {
    freq: Some(44100),
    channels: Some(1),
    samples: None          // get default sample size
};

let device = AudioDevice::open_playback(None, desired_spec, |spec| {
    MyCallback { actual_freq: spec.freq }
}).unwrap();
```

`AudioDevice::open_playback` seems more natural to me than "opening an AudioSpec".

---

There's now no way to open a capturing audio device; Rust was complaining about an unused enum variant after introducing `open_playback`, so I got rid of the feature. SDL2 itself doesn't support capturing devices yet, and can be added back in at a later date.