### PR TITLE
Add missing flag values for GLContextFlags attribute

### DIFF
--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -48,6 +48,15 @@ pub enum GLProfile {
   GLESProfile = 0x0004,
 }
 
+/// Flags for the GLContextFlags GL attribute
+bitflags! {
+    flags GLContexFlag: i32 {
+        const GL_CONTEXT_DEBUG              = 0x0001,
+        const GL_CONTEXT_FORWARD_COMPATIBLE = 0x0002,
+        const GL_CONTEXT_ROBUST_ACCESS      = 0x0004,
+        const GL_CONTEXT_RESET_ISOLATION    = 0x0008,
+    }
+}
 
 fn empty_sdl_display_mode() -> ll::SDL_DisplayMode {
     ll::SDL_DisplayMode {


### PR DESCRIPTION
I needed that to create a debug OpenGL context.

On a side note, the current `gl_set_attribute` interface is a bit ugly rust-wise because it's obviously completely type-unsafe. You have to cast all the parameters down to `i32`, if you mixup the parameters and use a `GLProfile` instead of a `GLContexFlag` your code will mess up without any warning.