### PR TITLE
Window thread safety fixes

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -8,7 +8,7 @@ use sdl2::keycode::KeyCode;
 pub fn main() {
     let sdl_context = sdl2::init(sdl2::INIT_VIDEO).unwrap();
 
-    let window = match Window::new("rust-sdl2 demo: Video", WindowPos::PosCentered, WindowPos::PosCentered, 800, 600, OPENGL) {
+    let window = match Window::new(&sdl_context, "rust-sdl2 demo: Video", WindowPos::PosCentered, WindowPos::PosCentered, 800, 600, OPENGL) {
         Ok(window) => window,
         Err(err) => panic!("failed to create window: {}", err)
     };

--- a/examples/renderer-texture.rs
+++ b/examples/renderer-texture.rs
@@ -9,7 +9,7 @@ use sdl2::keycode::KeyCode;
 pub fn main() {
     let sdl_context = sdl2::init(sdl2::INIT_VIDEO).unwrap();
 
-    let window = match Window::new("rust-sdl2 demo: Renderer + Texture", WindowPos::PosCentered, WindowPos::PosCentered, 800, 600, OPENGL) {
+    let window = match Window::new(&sdl_context, "rust-sdl2 demo: Renderer + Texture", WindowPos::PosCentered, WindowPos::PosCentered, 800, 600, OPENGL) {
         Ok(window) => window,
         Err(err) => panic!("failed to create window: {}", err)
     };

--- a/examples/renderer-yuv.rs
+++ b/examples/renderer-yuv.rs
@@ -9,7 +9,7 @@ use sdl2::keycode::KeyCode;
 pub fn main() {
     let sdl_context = sdl2::init(sdl2::INIT_VIDEO).unwrap();
 
-    let window = match Window::new("rust-sdl2 demo: YUV", WindowPos::PosCentered, WindowPos::PosCentered, 800, 600, SHOWN) {
+    let window = match Window::new(&sdl_context, "rust-sdl2 demo: YUV", WindowPos::PosCentered, WindowPos::PosCentered, 800, 600, SHOWN) {
         Ok(window) => window,
         Err(err) => panic!("failed to create window: {}", err)
     };

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -38,6 +38,7 @@
 //! None of the draw methods in `RenderDrawer` are expected to fail.
 //! If they do, a panic is raised and the program is aborted.
 
+use Sdl;
 use event::EventPump;
 use video;
 use video::{Window, WindowProperties};
@@ -190,7 +191,7 @@ impl<'a> Renderer<'a> {
     }
 
     /// Creates a window and default renderer.
-    pub fn new_with_window(width: i32, height: i32, window_flags: video::WindowFlags) -> SdlResult<Renderer<'static>> {
+    pub fn new_with_window(_sdl: &Sdl, width: i32, height: i32, window_flags: video::WindowFlags) -> SdlResult<Renderer<'static>> {
         use sys::video::SDL_Window;
 
         let raw_window: *const SDL_Window = ptr::null();

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -1,11 +1,14 @@
 use libc::{c_int, c_float, uint32_t};
 use std::ffi::{CStr, CString, NulError};
+use std::marker::PhantomData;
 use std::ptr;
 use std::vec::Vec;
 
+use event::EventPump;
 use rect::Rect;
 use surface::Surface;
 use pixels;
+use Sdl;
 use SdlResult;
 use num::FromPrimitive;
 
@@ -156,8 +159,6 @@ impl Drop for GLContext {
     }
 }
 
-#[derive(PartialEq)]
-#[allow(raw_pointer_derive)]
 pub struct Window {
     raw: *const ll::SDL_Window,
     owned: bool
@@ -187,8 +188,26 @@ impl Drop for Window {
     }
 }
 
+/// Contains accessors to a `Window`'s properties.
+pub struct WindowProperties<'a> {
+    raw: *const ll::SDL_Window,
+    _marker: PhantomData<&'a ()>
+}
+
 impl Window {
-    pub fn new(title: &str, x: WindowPos, y: WindowPos, width: i32, height: i32, window_flags: WindowFlags) -> SdlResult<Window> {
+    /// Creates a new Window.
+    ///
+    /// Note: a reference to the SDL context is required to ensure that the
+    /// Window is being created on the same thread as the SDL main thread
+    /// (`Sdl` cannot be moved or referenced across other threads).
+    pub fn new(sdl: &Sdl, title: &str, x: WindowPos, y: WindowPos, width: i32, height: i32, window_flags: WindowFlags) -> SdlResult<Window> {
+        Window::new_with_init(sdl, title, x, y, width, height, window_flags, |_| { Ok(()) })
+    }
+
+    /// Creates a new Window, and initializes the Window with other properties.
+    pub fn new_with_init<'a, F: 'a>(_sdl: &Sdl, title: &str, x: WindowPos, y: WindowPos, width: i32, height: i32, window_flags: WindowFlags, init: F) -> SdlResult<Window>
+    where F: FnOnce(WindowProperties<'a>) -> SdlResult<()>
+    {
         unsafe {
             let buff = CString::new(title).unwrap().as_ptr();
             let raw = ll::SDL_CreateWindow(
@@ -203,13 +222,37 @@ impl Window {
             if raw == ptr::null() {
                 Err(get_error())
             } else {
+                try!(init(WindowProperties {
+                    raw: raw,
+                    _marker: PhantomData
+                }));
+
                 Ok(Window{ raw: raw, owned: true })
             }
         }
     }
 
-    pub fn from_id(id: u32) -> SdlResult<Window> {
-        let raw = unsafe { ll::SDL_GetWindowFromID(id) };
+    /// Accesses the Window properties, such as the position, size and title of a Window.
+    ///
+    /// In order to access a Window's properties, it must be guaranteed that the
+    /// event loop is not running.
+    /// This is why a reference to the application's `EventPump` is required
+    /// (a shared `EventPump` reference is only obtainable if it's not being mutated).
+    /// Event pumping could otherwise mutate a Window's properties without your consent!
+    pub fn properties<'a>(&'a mut self, _event: &'a EventPump) -> WindowProperties<'a> {
+        WindowProperties {
+            raw: self.raw,
+            _marker: PhantomData
+        }
+    }
+
+    /// Get a Window from a stored ID.
+    ///
+    /// Warning: This function is unsafe!
+    /// It may introduce aliased Window values if a Window of the same ID is
+    /// already being used as a variable in the application.
+    pub unsafe fn from_id(id: u32) -> SdlResult<Window> {
+        let raw = ll::SDL_GetWindowFromID(id);
         if raw == ptr::null() {
             Err(get_error())
         } else {
@@ -217,6 +260,29 @@ impl Window {
         }
     }
 
+    pub fn get_id(&self) -> u32 {
+        unsafe { ll::SDL_GetWindowID(self.raw) }
+    }
+
+    pub fn gl_create_context(&self) -> SdlResult<GLContext> {
+        let result = unsafe { ll::SDL_GL_CreateContext(self.raw) };
+        if result == ptr::null() {
+            Err(get_error())
+        } else {
+            Ok(GLContext{raw: result, owned: true})
+        }
+    }
+
+    pub fn gl_make_current(&self, context: &GLContext) -> bool {
+        unsafe { ll::SDL_GL_MakeCurrent(self.raw, context.raw) == 0 }
+    }
+
+    pub fn gl_swap_window(&self) {
+        unsafe { ll::SDL_GL_SwapWindow(self.raw) }
+    }
+}
+
+impl<'a> WindowProperties<'a> {
     pub fn get_display_index(&self) -> SdlResult<i32> {
         let result = unsafe { ll::SDL_GetWindowDisplayIndex(self.raw) };
         if result < 0 {
@@ -226,7 +292,7 @@ impl Window {
         }
     }
 
-    pub fn set_display_mode(&self, display_mode: Option<DisplayMode>) -> bool {
+    pub fn set_display_mode(&mut self, display_mode: Option<DisplayMode>) -> bool {
         return unsafe {
             ll::SDL_SetWindowDisplayMode(
                 self.raw,
@@ -259,10 +325,6 @@ impl Window {
         unsafe{ FromPrimitive::from_u64(ll::SDL_GetWindowPixelFormat(self.raw) as u64).unwrap() }
     }
 
-    pub fn get_id(&self) -> u32 {
-        unsafe { ll::SDL_GetWindowID(self.raw) }
-    }
-
     pub fn get_flags(&self) -> WindowFlags {
         unsafe {
             let raw = ll::SDL_GetWindowFlags(self.raw);
@@ -270,7 +332,7 @@ impl Window {
         }
     }
 
-    pub fn set_title(&self, title: &str) -> Result<(), NulError>{
+    pub fn set_title(&mut self, title: &str) -> Result<(), NulError>{
         let buff =
         match CString::new(title.as_bytes()) {
             Ok(s) => s.as_ptr(),
@@ -287,14 +349,14 @@ impl Window {
         }
     }
 
-    pub fn set_icon(&self, icon: &Surface) {
+    pub fn set_icon(&mut self, icon: &Surface) {
         unsafe { ll::SDL_SetWindowIcon(self.raw, icon.raw()) }
     }
 
     //pub fn SDL_SetWindowData(window: *SDL_Window, name: *c_char, userdata: *c_void) -> *c_void; //TODO: Figure out what this does
     //pub fn SDL_GetWindowData(window: *SDL_Window, name: *c_char) -> *c_void;
 
-    pub fn set_position(&self, x: WindowPos, y: WindowPos) {
+    pub fn set_position(&mut self, x: WindowPos, y: WindowPos) {
         unsafe { ll::SDL_SetWindowPosition(self.raw, unwrap_windowpos(x), unwrap_windowpos(y)) }
     }
 
@@ -305,7 +367,7 @@ impl Window {
         (x as i32, y as i32)
     }
 
-    pub fn set_size(&self, w: i32, h: i32) {
+    pub fn set_size(&mut self, w: i32, h: i32) {
         unsafe { ll::SDL_SetWindowSize(self.raw, w as c_int, h as c_int) }
     }
 
@@ -323,7 +385,7 @@ impl Window {
         (w as i32, h as i32)
     }
 
-    pub fn set_minimum_size(&self, w: i32, h: i32) {
+    pub fn set_minimum_size(&mut self, w: i32, h: i32) {
         unsafe { ll::SDL_SetWindowMinimumSize(self.raw, w as c_int, h as c_int) }
     }
 
@@ -334,7 +396,7 @@ impl Window {
         (w as i32, h as i32)
     }
 
-    pub fn set_maximum_size(&self, w: i32, h: i32) {
+    pub fn set_maximum_size(&mut self, w: i32, h: i32) {
         unsafe { ll::SDL_SetWindowMaximumSize(self.raw, w as c_int, h as c_int) }
     }
 
@@ -345,39 +407,39 @@ impl Window {
         (w as i32, h as i32)
     }
 
-    pub fn set_bordered(&self, bordered: bool) {
+    pub fn set_bordered(&mut self, bordered: bool) {
         unsafe { ll::SDL_SetWindowBordered(self.raw, if bordered { 1 } else { 0 }) }
     }
 
-    pub fn show(&self) {
+    pub fn show(&mut self) {
         unsafe { ll::SDL_ShowWindow(self.raw) }
     }
 
-    pub fn hide(&self) {
+    pub fn hide(&mut self) {
         unsafe { ll::SDL_HideWindow(self.raw) }
     }
 
-    pub fn raise(&self) {
+    pub fn raise(&mut self) {
         unsafe { ll::SDL_RaiseWindow(self.raw) }
     }
 
-    pub fn maximize(&self) {
+    pub fn maximize(&mut self) {
         unsafe { ll::SDL_MaximizeWindow(self.raw) }
     }
 
-    pub fn minimize(&self) {
+    pub fn minimize(&mut self) {
         unsafe { ll::SDL_MinimizeWindow(self.raw) }
     }
 
-    pub fn restore(&self) {
+    pub fn restore(&mut self) {
         unsafe { ll::SDL_RestoreWindow(self.raw) }
     }
 
-    pub fn set_fullscreen(&self, fullscreen_type: FullscreenType) -> bool {
+    pub fn set_fullscreen(&mut self, fullscreen_type: FullscreenType) -> bool {
         unsafe { ll::SDL_SetWindowFullscreen(self.raw, fullscreen_type as uint32_t) == 0 }
     }
 
-    pub fn get_surface(&self) -> SdlResult<Surface> {
+    pub fn get_surface(&mut self) -> SdlResult<Surface> {
         let raw = unsafe { ll::SDL_GetWindowSurface(self.raw) };
 
         if raw == ptr::null() {
@@ -395,7 +457,7 @@ impl Window {
         unsafe { ll::SDL_UpdateWindowSurfaceRects(self.raw, rects.as_ptr(), rects.len() as c_int) == 0}
     }
 
-    pub fn set_grab(&self, grabbed: bool) {
+    pub fn set_grab(&mut self, grabbed: bool) {
         unsafe { ll::SDL_SetWindowGrab(self.raw, if grabbed { 1 } else { 0 }) }
     }
 
@@ -403,7 +465,7 @@ impl Window {
         unsafe { ll::SDL_GetWindowGrab(self.raw) == 1 }
     }
 
-    pub fn set_brightness(&self, brightness: f64) -> bool {
+    pub fn set_brightness(&mut self, brightness: f64) -> bool {
         unsafe { ll::SDL_SetWindowBrightness(self.raw, brightness as c_float) == 0 }
     }
 
@@ -411,7 +473,7 @@ impl Window {
         unsafe { ll::SDL_GetWindowBrightness(self.raw) as f64 }
     }
 
-    pub fn set_gamma_ramp(&self, red: Option<&[u16; 256]>, green: Option<&[u16; 256]>, blue: Option<&[u16; 256]>) -> bool {
+    pub fn set_gamma_ramp(&mut self, red: Option<&[u16; 256]>, green: Option<&[u16; 256]>, blue: Option<&[u16; 256]>) -> bool {
         unsafe {
             let unwrapped_red = match red {
                 Some(values) => values.as_ptr(),
@@ -439,23 +501,6 @@ impl Window {
         } else {
             Err(get_error())
         }
-    }
-
-    pub fn gl_create_context(&self) -> SdlResult<GLContext> {
-        let result = unsafe { ll::SDL_GL_CreateContext(self.raw) };
-        if result == ptr::null() {
-            Err(get_error())
-        } else {
-            Ok(GLContext{raw: result, owned: true})
-        }
-    }
-
-    pub fn gl_make_current(&self, context: &GLContext) -> bool {
-        unsafe { ll::SDL_GL_MakeCurrent(self.raw, context.raw) == 0 }
-    }
-
-    pub fn gl_swap_window(&self) {
-        unsafe { ll::SDL_GL_SwapWindow(self.raw) }
     }
 }
 
@@ -639,8 +684,8 @@ pub fn gl_get_attribute(attr: GLAttr) -> SdlResult<i32> {
     }
 }
 
-pub fn gl_get_current_window() -> SdlResult<Window> {
-    let raw = unsafe { ll::SDL_GL_GetCurrentWindow() };
+pub unsafe fn gl_get_current_window() -> SdlResult<Window> {
+    let raw = ll::SDL_GL_GetCurrentWindow();
     if raw == ptr::null() {
         Err(get_error())
     } else {
@@ -648,8 +693,8 @@ pub fn gl_get_current_window() -> SdlResult<Window> {
     }
 }
 
-pub fn gl_get_current_context() -> SdlResult<GLContext> {
-    let raw = unsafe { ll::SDL_GL_GetCurrentContext() };
+pub unsafe fn gl_get_current_context() -> SdlResult<GLContext> {
+    let raw = ll::SDL_GL_GetCurrentContext();
     if raw == ptr::null() {
         Err(get_error())
     } else {

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -200,6 +200,15 @@ impl Window {
     /// Note: a reference to the SDL context is required to ensure that the
     /// Window is being created on the same thread as the SDL main thread
     /// (`Sdl` cannot be moved or referenced across other threads).
+    ///
+    /// # Example
+    /// ```no_run
+    /// use sdl2::video::{Window, WindowPos};
+    ///
+    /// let sdl_context = sdl2::init(sdl2::INIT_EVERYTHING).unwrap();
+    ///
+    /// let window = Window::new(&sdl_context, "My SDL window", WindowPos::PosCentered, WindowPos::PosCentered, 800, 600, sdl2::video::SHOWN).unwrap();
+    /// ```
     pub fn new(sdl: &Sdl, title: &str, x: WindowPos, y: WindowPos, width: i32, height: i32, window_flags: WindowFlags) -> SdlResult<Window> {
         Window::new_with_init(sdl, title, x, y, width, height, window_flags, |_| { Ok(()) })
     }
@@ -239,6 +248,32 @@ impl Window {
     /// This is why a reference to the application's `EventPump` is required
     /// (a shared `EventPump` reference is only obtainable if it's not being mutated).
     /// Event pumping could otherwise mutate a Window's properties without your consent!
+    ///
+    /// # Example
+    /// ```no_run
+    /// use sdl2::video::{Window, WindowPos};
+    ///
+    /// let mut sdl_context = sdl2::init(sdl2::INIT_EVERYTHING).unwrap();
+    /// let mut window = Window::new(&sdl_context, "My SDL window", WindowPos::PosCentered, WindowPos::PosCentered, 800, 600, sdl2::video::SHOWN).unwrap();
+    /// let mut event_pump = sdl_context.event_pump();
+    ///
+    /// loop {
+    ///     let mut pos = None;
+    ///
+    ///     for event in event_pump.poll_iter() {
+    ///         use sdl2::event::Event;
+    ///         match event {
+    ///             Event::MouseMotion { x, y, .. } => { pos = Some((x, y)); },
+    ///             _ => ()
+    ///         }
+    ///     }
+    ///
+    ///     if let Some((x, y)) = pos {
+    ///         // Set the window title
+    ///         window.properties(&event_pump).set_title(&format!("{}, {}", x, y));
+    ///     }
+    /// }
+    /// ```
     pub fn properties<'a>(&'a mut self, _event: &'a EventPump) -> WindowProperties<'a> {
         WindowProperties {
             raw: self.raw,

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -324,6 +324,13 @@ impl Window {
 }
 
 impl<'a> WindowProperties<'a> {
+    pub unsafe fn from_ll(raw: *const ll::SDL_Window) -> WindowProperties<'a> {
+        WindowProperties {
+            raw: raw,
+            _marker: PhantomData
+        }
+    }
+
     pub fn get_display_index(&self) -> SdlResult<i32> {
         let result = unsafe { ll::SDL_GetWindowDisplayIndex(self.raw) };
         if result < 0 {


### PR DESCRIPTION
A few months ago, I outlined a fundamental thread safety/event loop issue with `Window` in #322.
I believe I found a reasonable fix for it.

* Windows now must be created on the same thread as `Sdl`, which represents the main thread.
* Many of `Window`'s methods have moved to `WindowProperties`. It is accessed with `Window::properties()` and requires a shared reference to `EventPump`.
* `Surface` accepts a lifetime argument. This is to bring safety to `Surface::from_data()`, a function that creates a surface from a buffer, without copying said buffer. A lifetime for `Surface` has the additional benefit of making `WindowProperties::get_surface()` safe.
* `Renderer` also accepts a lifetime to meet the requirements of `Surface`'s lifetime.

```rust
let sdl_context = sdl2::init(sdl2::INIT_EVERYTHING).unwrap();
let mut Window = Window::new("blah", ...).unwrap();
// ...
window.set_size(512, 512);
```
becomes
```rust
let sdl_context = sdl2::init(sdl2::INIT_EVERYTHING).unwrap();
let mut Window = Window::new(&sdl_context, "blah", ...).unwrap();
// ...
window.properties(&event_pump).set_size(512, 512);
```

The idea behind having `Window::properties()` accept a reference to the event pump, is to make sure the event loop is not running while Window properties are being accessed. `SDL_PumpEvents()` can mutate the properties of every Window in the application, so this is a way to ensure they doesn't suddenly change on us. It's basically a borrowchecker hack.
It consequentially means that `Window::properties()` cannot be used inside the event loop.

If there are any questions/concerns, please ask!

Fixes #322