### PR TITLE
Allow accesses to Window property getters with `&Window`.

### DIFF
--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -31,7 +31,7 @@
 use Sdl;
 use event::EventPump;
 use video;
-use video::{Window, WindowProperties};
+use video::{Window, WindowProperties, WindowPropertiesGetters};
 use surface;
 use surface::Surface;
 use pixels;
@@ -251,6 +251,16 @@ impl<'a> Renderer<'a> {
     {
         match self.parent.as_mut() {
             Some(&mut RendererParent::Window(ref mut window)) => Some(window.properties(event)),
+            _ => None
+        }
+    }
+
+    /// Accesses the Window getters, such as the position, size and title of a Window.
+    /// Returns None if the renderer is not associated with a Window.
+    pub fn window_properties_getters<'b>(&'b self, event: &'b EventPump) -> Option<WindowPropertiesGetters<'b>>
+    {
+        match self.parent.as_ref() {
+            Some(&RendererParent::Window(ref window)) => Some(window.properties_getters(event)),
             _ => None
         }
     }

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -2,6 +2,7 @@ use libc::{c_int, c_float, uint32_t};
 use std::ffi::{CStr, CString, NulError};
 use std::marker::PhantomData;
 use std::mem;
+use std::ops::Deref;
 use std::ptr;
 use std::vec::Vec;
 
@@ -192,6 +193,21 @@ pub struct WindowProperties<'a> {
     _marker: PhantomData<&'a ()>
 }
 
+/// Contains getters to a `Window`'s properties.
+///
+/// This type acts as an immutable guard to `WindowProperties` using `Deref`.
+pub struct WindowPropertiesGetters<'a> {
+    window_properties: WindowProperties<'a>
+}
+
+impl<'a> Deref for WindowPropertiesGetters<'a> {
+    type Target = WindowProperties<'a>;
+
+    fn deref(&self) -> &WindowProperties<'a> {
+        &self.window_properties
+    }
+}
+
 impl Window {
     /// Creates a new Window.
     ///
@@ -276,6 +292,15 @@ impl Window {
         WindowProperties {
             raw: self.raw,
             _marker: PhantomData
+        }
+    }
+
+    pub fn properties_getters<'a>(&'a self, _event: &'a EventPump) -> WindowPropertiesGetters<'a> {
+        WindowPropertiesGetters {
+            window_properties: WindowProperties {
+                raw: self.raw,
+                _marker: PhantomData
+            }
         }
     }
 


### PR DESCRIPTION
This is a quick and dirty fix that allows accesses to Window getters using a shared `&Window` reference.

Fixes #394