### PR TITLE
Removed stability and deprecation attributes that can no longer be used outside of std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 name    = "sdl2"
 description = "SDL2 bindings for Rust"
 repository = "https://github.com/AngryLawyer/rust-sdl2"
-version = "0.2.1"
+version = "0.2.2"
 license = "MIT"
 authors = [ "Tony Aldridge <tony@angry-lawyer.com>" ]
 keywords = ["SDL", "windowing", "graphics"]
@@ -14,7 +14,7 @@ name       = "sdl2"
 path       = "src/sdl2/lib.rs"
 
 [dependencies]
-num = "0.1.22"
+num = "0.1.23"
 bitflags = "0.1"
 libc = "0.1.6"
 rand = "0.3.7"

--- a/sdl2-sys/Cargo.toml
+++ b/sdl2-sys/Cargo.toml
@@ -3,7 +3,7 @@
 name = "sdl2-sys"
 description = "Raw SDL2 bindings for Rust, used internally rust-sdl2"
 repository = "https://github.com/AngryLawyer/rust-sdl2"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Tony Aldridge <tony@angry-lawyer.com>"]
 license = "MIT"
 links = "SDL2"
@@ -14,7 +14,7 @@ name = "sdl2_sys"
 path = "src/lib.rs"
 
 [dependencies]
-num = "0.1.22"
+num = "0.1.23"
 libc = "0.1.6"
 
 [build-dependencies.pkg-config]

--- a/src/sdl2/audio.rs
+++ b/src/sdl2/audio.rs
@@ -491,7 +491,6 @@ impl AudioCVT {
         }
     }
 
-    #[unstable="Certain conversions may cause buffer overflows. See AngryLawyer/rust-sdl2 issue #270."]
     pub fn convert(&self, mut src: Vec<u8>) -> Vec<u8> {
         //! Convert audio data to a desired audio format.
         //!

--- a/src/sdl2/surface.rs
+++ b/src/sdl2/surface.rs
@@ -390,7 +390,6 @@ impl<'a> Surface<'a> {
         }
     }
 
-    #[deprecated]
     pub fn upper_blit_scaled(&self, src_rect: Option<Rect>,
                              dst: &mut Surface, dst_rect: Option<Rect>) -> SdlResult<()> {
 

--- a/src/sdl2/timer.rs
+++ b/src/sdl2/timer.rs
@@ -20,7 +20,6 @@ pub fn delay(ms: u32) {
 
 pub type TimerCallback<'a> = Box<FnMut() -> u32+'a+Sync>;
 
-#[unstable = "Unstable because of move to unboxed closures and `box` syntax"]
 pub struct Timer<'a> {
     callback: Option<Box<TimerCallback<'a>>>,
     _delay: u32,


### PR DESCRIPTION
Updated num dependency to 0.1.23
Updated version to 0.2.2