### PR TITLE
Remove #[derive(FromPrimitive)] and use AsOsStr

### DIFF
--- a/src/sdl2/keycode.rs
+++ b/src/sdl2/keycode.rs
@@ -4,7 +4,7 @@ use num::{ToPrimitive, FromPrimitive};
 
 use sys::keycode as ll;
 
-#[derive(PartialEq, Eq, FromPrimitive, Debug, Copy, Clone)]
+#[derive(PartialEq, Eq, Debug, Copy, Clone)]
 pub enum KeyCode {
     Unknown            = ll::SDLK_UNKNOWN as isize,
     Backspace          = ll::SDLK_BACKSPACE as isize,

--- a/src/sdl2/rwops.rs
+++ b/src/sdl2/rwops.rs
@@ -1,4 +1,4 @@
-use std::ffi::{CString, AsOsStr};
+use std::ffi::CString;
 use std::io;
 use std::path::Path;
 use libc::{c_void, c_int, size_t};

--- a/src/sdl2/scancode.rs
+++ b/src/sdl2/scancode.rs
@@ -3,7 +3,7 @@ use num::{ToPrimitive, FromPrimitive};
 
 use sys::scancode as ll;
 
-#[derive(PartialEq, Eq, FromPrimitive, Debug, Copy, Clone)]
+#[derive(PartialEq, Eq, Debug, Copy, Clone)]
 pub enum ScanCode {
     Unknown            = ll::SDL_SCANCODE_UNKNOWN as isize,
     A                  = ll::SDL_SCANCODE_A as isize,


### PR DESCRIPTION
The derivation was not used anymore, and it seems that AsOsStr is not needed anymore either.

Fixes building on latest nightly.