### PR TITLE
first approach to fix SDL_GL_GetProcAddress

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,7 @@ Then you need to add this to add this initialization code to establish the
 bindings:
 
 ```rust
-    gl::load_with(|s| unsafe {
-        std::mem::transmute(sdl2::video::gl_get_proc_address(s))
-    });
+    gl::load_with(sdl2::video::gl_get_proc_address);
 ```
 
 Note that these bindings are very raw, and many of the calls will require

--- a/sdl2-sys/src/video.rs
+++ b/sdl2-sys/src/video.rs
@@ -199,7 +199,7 @@ extern "C" {
     pub fn SDL_DisableScreenSaver();
     pub fn SDL_GL_GetDrawableSize(window: *mut SDL_Window, w: *mut c_int, h: *mut c_int);
     pub fn SDL_GL_LoadLibrary(path: *const c_char) -> c_int;
-    pub fn SDL_GL_GetProcAddress(procname: *const c_char) -> Option<extern "system" fn()>;
+    pub fn SDL_GL_GetProcAddress(procname: *const c_char) -> *const c_void;
     pub fn SDL_GL_UnloadLibrary();
     pub fn SDL_GL_ExtensionSupported(extension: *const c_char) -> SDL_bool;
     pub fn SDL_GL_SetAttribute(attr: SDL_GLattr, value: c_int) -> c_int;

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -1,4 +1,4 @@
-use libc::{c_int, c_float, uint32_t};
+use libc::{c_void, c_int, c_float, uint32_t};
 use std::ffi::{CStr, CString, NulError};
 use std::marker::PhantomData;
 use std::mem;
@@ -748,12 +748,12 @@ pub fn gl_unload_library() {
     unsafe { ll::SDL_GL_UnloadLibrary(); }
 }
 
-pub fn gl_get_proc_address(procname: &str) -> Option<extern "system" fn()> {
+pub fn gl_get_proc_address(procname: &str) -> *const c_void {
     unsafe {
         let procname =
         match CString::new(procname) {
             Ok(s) => s.as_ptr(),
-            Err(_) => return None,
+            Err(_) => return 0 as *const c_void,
         };
         ll::SDL_GL_GetProcAddress(procname)
     }


### PR DESCRIPTION
Careful with this pull request, I'm a rust newbie! :)

I think there is a problem with the return type of SDL_GL_GetProcAddress. This C function returns a `const void*` pointer and not a rust `Option<extern "system" fn()>` data type. So there should be at least a change in the `sdl2-sys`-part.

The next issue is whether to use `Option<extern "system" fn()>` or `*const c_void` as return type in the rust API. For the moment I changed it to `*const c_void` as both gl-rs and glium seem to prefer this return type. It is not the "rust way" of doing it, but for the usual use case it creates the least friction. 

Maybe - and this is a question for the designers/maintainers - the best way would be to provide a rust `gl_get_proc_address` function with `Option<extern "system" fn()>` return type and a `gl_get_proc_address_c_void` function that provides the frequently required `*const c_void` return type. Please think about it and comment.
