### PR TITLE
Some bitflag! and const tidyup from mouse and audio

### DIFF
--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -622,7 +622,7 @@ impl Event {
                     timestamp: event.timestamp,
                     window_id: event.windowID,
                     which: event.which,
-                    mousestate: mouse::MouseState::from_bits_truncate(event.state),
+                    mousestate: mouse::MouseState::from_flags(event.state),
                     x: event.x,
                     y: event.y,
                     xrel: event.xrel,

--- a/src/sdl2/mouse.rs
+++ b/src/sdl2/mouse.rs
@@ -96,13 +96,44 @@ pub enum Mouse {
     Unknown(u8)
 }
 
-bitflags! {
-    flags MouseState: u32 {
-        const LEFTMOUSESTATE = ll::SDL_BUTTON_LMASK,
-        const MIDDLEMOUSESTATE = ll::SDL_BUTTON_MMASK,
-        const RIGHTMOUSESTATE = ll::SDL_BUTTON_RMASK,
-        const X1MOUSESTATE = ll::SDL_BUTTON_X1MASK,
-        const X2MOUSESTATE = ll::SDL_BUTTON_X2MASK,
+pub struct MouseState {
+    flags: u32
+}
+
+impl MouseState {
+    /// Tests if a mouse button was pressed.
+    pub fn button(&self, button: Mouse) -> bool {
+        match button {
+            Mouse::Left => self.left(),
+            Mouse::Middle => self.middle(),
+            Mouse::Right => self.right(),
+            Mouse::X1 => self.x1(),
+            Mouse::X2 => self.x2(),
+            Mouse::Unknown(x) => {
+                assert!(x <= 32);
+                let mask = 1 << ((x as u32) - 1);
+                (self.flags & mask) != 0
+            }
+        }
+    }
+
+    /// Tests if the left mouse button was pressed.
+    pub fn left(&self) -> bool { (self.flags & ll::SDL_BUTTON_LMASK) != 0 }
+
+    /// Tests if the middle mouse button was pressed.
+    pub fn middle(&self) -> bool { (self.flags & ll::SDL_BUTTON_MMASK) != 0 }
+
+    /// Tests if the right mouse button was pressed.
+    pub fn right(&self) -> bool { (self.flags & ll::SDL_BUTTON_RMASK) != 0 }
+
+    /// Tests if the X1 mouse button was pressed.
+    pub fn x1(&self) -> bool { (self.flags & ll::SDL_BUTTON_X1MASK) != 0 }
+
+    /// Tests if the X2 mouse button was pressed.
+    pub fn x2(&self) -> bool { (self.flags & ll::SDL_BUTTON_X2MASK) != 0 }
+
+    pub fn from_flags(flags: u32) -> MouseState {
+        MouseState { flags: flags }
     }
 }
 
@@ -131,7 +162,7 @@ pub fn get_mouse_state() -> (MouseState, i32, i32) {
     let mut y = 0;
     unsafe {
         let raw = ll::SDL_GetMouseState(&mut x, &mut y);
-        return (MouseState::from_bits_truncate(raw), x as i32, y as i32);
+        return (MouseState::from_flags(raw), x as i32, y as i32);
     }
 }
 
@@ -140,7 +171,7 @@ pub fn get_relative_mouse_state() -> (MouseState, i32, i32) {
     let mut y = 0;
     unsafe {
         let raw = ll::SDL_GetRelativeMouseState(&mut x, &mut y);
-        return (MouseState::from_bits_truncate(raw), x as i32, y as i32);
+        return (MouseState::from_flags(raw), x as i32, y as i32);
     }
 }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -7,7 +7,7 @@ fn audio_spec_wav() {
     let wav = sdl2::audio::AudioSpecWAV::load_wav(&Path::new("./tests/sine.wav")).unwrap();
 
     assert_eq!(wav.freq, 22050);
-    assert_eq!(wav.format, sdl2::audio::AUDIOS16LSB);
+    assert_eq!(wav.format, sdl2::audio::AudioFormat::S16LSB);
     assert_eq!(wav.channels, 1);
 
     let buffer = wav.get_buffer();


### PR DESCRIPTION
* `audio` no longer exposes aliased ffi constants; an enum is used for `AudioFormat` instead.
* `MouseState` is now a `struct` and not a `bitflag!`. It's now easier to test for buttons (`state.left()` instead of `state.contains(sdl2::mouse::LEFTMOUSESTATE)`).