### PR TITLE
Remove SurfaceFlag, Surface::new uses PixelFormatEnum

### DIFF
--- a/sdl2-sys/src/pixels.rs
+++ b/sdl2-sys/src/pixels.rs
@@ -1,5 +1,7 @@
 use libc::{c_int, uint8_t, uint32_t};
 
+pub type SDL_bool = c_int;
+
 //SDL_pixels.h
 #[derive(Copy, Clone)]
 #[repr(C)]
@@ -86,4 +88,7 @@ extern "C" {
     pub fn SDL_GetRGBA(pixel: uint32_t, format: *mut SDL_PixelFormat, r: *mut uint8_t, g: *mut uint8_t, b: *mut uint8_t, a: *mut uint8_t);
     pub fn SDL_MapRGB(format: *mut SDL_PixelFormat, r: uint8_t, g: uint8_t, b: uint8_t) -> uint32_t;
     pub fn SDL_MapRGBA(format: *mut SDL_PixelFormat, r: uint8_t, g: uint8_t, b: uint8_t, a: uint8_t) -> uint32_t;
+
+    pub fn SDL_PixelFormatEnumToMasks(format: uint32_t, bpp: *mut c_int, rmask: *mut uint32_t, gmask: *mut uint32_t, bmask: *mut uint32_t, amask: *mut uint32_t) -> SDL_bool;
+    pub fn SDL_MasksToPixelFormatEnum(bpp: c_int, rmask: uint32_t, gmask: uint32_t, bmask: uint32_t, amask: uint32_t) -> uint32_t;
 }


### PR DESCRIPTION
* `SurfaceFlag` was deprecated in SDL2 and actually does nothing.
  `SDL_CreateRGBSurface()` simply ignores the flag.
* `SDL_CreateRGBSurface()` internally converts the parameters from pixel masks to a
  `PixelFormatEnum` anyway, which means that we can simplify `Surface::new()` to work
  for most use cases.
  For passing masks explicitly, there's `Surface::from_pixelmasks()`.
* width, height and pitch are unsigned.