### PR TITLE
Add #[derives] (Copy, Clone, Hash, etc.) where they can be added

### DIFF
--- a/sdl2-sys/src/joystick.rs
+++ b/sdl2-sys/src/joystick.rs
@@ -5,7 +5,7 @@ pub type SDL_bool = c_int;
 pub type SDL_Joystick = c_void;
 
 #[allow(dead_code)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash)]
 #[repr(C)]
 pub struct SDL_JoystickGUID {
     pub data: [uint8_t; 16],

--- a/src/sdl2/audio.rs
+++ b/src/sdl2/audio.rs
@@ -61,7 +61,7 @@ use SdlResult;
 
 use sys::audio as ll;
 
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
 pub enum AudioFormat {
     /// Unsigned 8-bit samples
     U8 = ll::AUDIO_U8 as isize,
@@ -133,7 +133,7 @@ impl AudioFormat {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq, Hash, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 pub enum AudioStatus {
     Stopped = ll::SDL_AUDIO_STOPPED as isize,
     Playing = ll::SDL_AUDIO_PLAYING as isize,
@@ -355,7 +355,7 @@ impl AudioSpecDesired {
 }
 
 #[allow(missing_copy_implementations)]
-#[derive(Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 pub struct AudioSpec {
     pub freq: i32,
     pub format: AudioFormat,

--- a/src/sdl2/controller.rs
+++ b/src/sdl2/controller.rs
@@ -8,7 +8,7 @@ use joystick;
 use sys::controller as ll;
 use sys::event::{SDL_QUERY, SDL_ENABLE};
 
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 #[repr(i32)]
 pub enum Axis {
     Invalid      = ll::SDL_CONTROLLER_AXIS_INVALID,
@@ -58,7 +58,7 @@ pub fn wrap_controller_axis(bitflags: u8) -> Axis {
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 #[repr(i32)]
 pub enum Button {
     Invalid       = ll::SDL_CONTROLLER_BUTTON_INVALID,
@@ -156,7 +156,7 @@ pub fn get_event_state() -> bool {
 }
 
 /// Possible return values for `add_mapping`
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 pub enum MappingStatus {
     Added   = 1,
     Updated = 0,

--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -28,7 +28,7 @@ use SdlResult;
 use sys::event as ll;
 
 /// Types of events that can be delivered.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 #[repr(u32)]
 pub enum EventType {
     First = ll::SDL_FIRSTEVENT,
@@ -145,7 +145,7 @@ impl FromPrimitive for EventType {
     fn from_u64(n: u64) -> Option<EventType> { FromPrimitive::from_i64(n as i64) }
 }
 
-#[derive(PartialEq, Copy, Clone, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 /// An enum of window events.
 pub enum WindowEventId {
     None,
@@ -187,6 +187,7 @@ impl WindowEventId {
     }
 }
 
+#[derive(Clone, PartialEq)]
 /// Different event types.
 pub enum Event {
     Quit { timestamp: u32 },

--- a/src/sdl2/joystick.rs
+++ b/src/sdl2/joystick.rs
@@ -255,7 +255,7 @@ impl Drop for Joystick {
 
 /// Wrapper around a SDL_JoystickGUID, a globally unique identifier
 /// for a joystick.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash)]
 pub struct Guid {
     raw: ll::SDL_JoystickGUID,
 }
@@ -321,7 +321,7 @@ impl Display for Guid {
 /// combinations make sense: 5 for instance would mean up and down at
 /// the same time... To simplify things I turn it into an enum which
 /// is how the SDL2 docs present it anyway (using macros).
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 pub enum HatState {
     Centered  = 0,
     Up        = 0x01,

--- a/src/sdl2/keycode.rs
+++ b/src/sdl2/keycode.rs
@@ -1,10 +1,8 @@
-use std::hash::{Hash, Hasher};
-
 use num::{ToPrimitive, FromPrimitive};
 
 use sys::keycode as ll;
 
-#[derive(PartialEq, Eq, Debug, Copy, Clone)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 pub enum KeyCode {
     Unknown            = ll::SDLK_UNKNOWN as isize,
     Backspace          = ll::SDLK_BACKSPACE as isize,
@@ -242,13 +240,6 @@ pub enum KeyCode {
     KbdIllumUp         = ll::SDLK_KBDILLUMUP as isize,
     Eject              = ll::SDLK_EJECT as isize,
     Sleep              = ll::SDLK_SLEEP as isize,
-}
-
-impl Hash for KeyCode {
-    #[inline]
-    fn hash<H>(&self, state: &mut H) where H: Hasher {
-        (*self as i32).hash(state);
-    }
 }
 
 impl ToPrimitive for KeyCode {

--- a/src/sdl2/mouse.rs
+++ b/src/sdl2/mouse.rs
@@ -7,7 +7,7 @@ use video;
 
 use sys::mouse as ll;
 
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 #[repr(u32)]
 pub enum SystemCursor {
     Arrow = ll::SDL_SYSTEM_CURSOR_ARROW,
@@ -24,7 +24,6 @@ pub enum SystemCursor {
     Hand = ll::SDL_SYSTEM_CURSOR_HAND,
 }
 
-#[derive(PartialEq)] #[allow(raw_pointer_derive)]
 pub struct Cursor {
     raw: *mut ll::SDL_Cursor,
     owned: bool
@@ -86,7 +85,7 @@ impl Cursor {
     }
 }
 
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 pub enum Mouse {
     Left,
     Middle,
@@ -96,6 +95,7 @@ pub enum Mouse {
     Unknown(u8)
 }
 
+#[derive(Copy, Clone, Eq, PartialEq, Hash)]
 pub struct MouseState {
     flags: u32
 }

--- a/src/sdl2/pixels.rs
+++ b/src/sdl2/pixels.rs
@@ -7,14 +7,13 @@ use sys::pixels as ll;
 use SdlResult;
 use get_error;
 
-#[derive(PartialEq)] #[allow(raw_pointer_derive, missing_copy_implementations)]
 pub struct Palette {
     raw: *mut ll::SDL_Palette
 }
 
 impl_raw_accessors!((Palette, *mut ll::SDL_Palette));
 
-#[derive(PartialEq, Clone, Copy)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 pub enum Color {
     RGB(u8, u8, u8),
     RGBA(u8, u8, u8, u8)
@@ -69,7 +68,6 @@ pub struct PixelMasks {
     pub amask: u32
 }
 
-#[derive(PartialEq)] #[allow(raw_pointer_derive, missing_copy_implementations)]
 pub struct PixelFormat {
     raw: *mut ll::SDL_PixelFormat
 }
@@ -77,7 +75,7 @@ pub struct PixelFormat {
 impl_raw_accessors!((PixelFormat, *mut ll::SDL_PixelFormat));
 impl_raw_constructor!((PixelFormat, PixelFormat (raw: *mut ll::SDL_PixelFormat)));
 
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 pub enum PixelFormatEnum {
     Unknown = ll::SDL_PIXELFORMAT_UNKNOWN as isize,
     Index1LSB = ll::SDL_PIXELFORMAT_INDEX1LSB as isize,

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -49,7 +49,7 @@ use std::rc::Rc;
 
 use sys::render as ll;
 
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 pub enum TextureAccess {
     Static = ll::SDL_TEXTUREACCESS_STATIC as isize,
     Streaming = ll::SDL_TEXTUREACCESS_STREAMING as isize,
@@ -73,7 +73,7 @@ impl FromPrimitive for TextureAccess {
 
 /// A structure that contains information on the capabilities of a render driver
 /// or the current render context.
-#[derive(PartialEq)]
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub struct RendererInfo {
     pub name: String,
     pub flags: u32,
@@ -82,7 +82,7 @@ pub struct RendererInfo {
     pub max_texture_height: i32
 }
 
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 pub enum BlendMode {
     None = ll::SDL_BLENDMODE_NONE as isize,
     Blend = ll::SDL_BLENDMODE_BLEND as isize,
@@ -871,7 +871,7 @@ impl<'renderer> RenderTarget<'renderer> {
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 pub struct TextureQuery {
     pub format: pixels::PixelFormatEnum,
     pub access: TextureAccess,

--- a/src/sdl2/scancode.rs
+++ b/src/sdl2/scancode.rs
@@ -1,9 +1,8 @@
-use std::hash::{Hash, Hasher};
 use num::{ToPrimitive, FromPrimitive};
 
 use sys::scancode as ll;
 
-#[derive(PartialEq, Eq, Debug, Copy, Clone)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 pub enum ScanCode {
     Unknown            = ll::SDL_SCANCODE_UNKNOWN as isize,
     A                  = ll::SDL_SCANCODE_A as isize,
@@ -247,13 +246,6 @@ pub enum ScanCode {
     App1               = ll::SDL_SCANCODE_APP1 as isize,
     App2               = ll::SDL_SCANCODE_APP2 as isize,
     Num                = ll::SDL_NUM_SCANCODES as isize,
-}
-
-impl Hash for ScanCode {
-    #[inline]
-    fn hash<H>(&self, state: &mut H) where H: Hasher {
-        (*self as i32).hash(state);
-    }
 }
 
 impl ToPrimitive for ScanCode {

--- a/src/sdl2/sdl.rs
+++ b/src/sdl2/sdl.rs
@@ -5,7 +5,7 @@ use sys::sdl as ll;
 use event::EventPump;
 use video::WindowBuilder;
 
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 pub enum Error {
     NoMemError = ll::SDL_ENOMEM as isize,
     ReadError = ll::SDL_EFREAD as isize,

--- a/src/sdl2/version.rs
+++ b/src/sdl2/version.rs
@@ -8,7 +8,7 @@ use std::fmt;
 use sys::version as ll;
 
 /// A structure that contains information about the version of SDL in use.
-#[derive(PartialEq, Copy, Clone)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 pub struct Version {
     /// major version
     pub major: u8,

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -19,7 +19,7 @@ use get_error;
 
 use sys::video as ll;
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 pub enum GLProfile {
     /// OpenGL core profile - deprecated functions are disabled
     Core,
@@ -320,7 +320,7 @@ pub mod gl_attr {
     }
 }
 
-#[derive(Clone, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 pub struct DisplayMode {
     pub format: u32,
     pub w: i32,
@@ -358,14 +358,14 @@ impl DisplayMode {
     }
 }
 
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 pub enum FullscreenType {
     FTOff = 0,
     FTTrue = 0x00000001,
     FTDesktop = 0x00001001,
 }
 
-#[derive(PartialEq, Copy, Clone)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 pub enum WindowPos {
     PosUndefined,
     PosCentered,


### PR DESCRIPTION
In particular, try to derive as much as possible from:
`#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug]`