### PR TITLE
Make EventPump exclusively borrow the SDL context

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -4,7 +4,7 @@ use sdl2::pixels::Color;
 use sdl2::keycode::KeyCode;
 
 pub fn main() {
-    let sdl_context = sdl2::init().video().unwrap();
+    let mut sdl_context = sdl2::init().video().unwrap();
 
     let window = sdl_context.window("rust-sdl2 demo: Video", 800, 600)
         .position_centered()
@@ -20,10 +20,9 @@ pub fn main() {
     drawer.present();
 
     let mut running = true;
-    let mut event_pump = sdl_context.event_pump();
 
     while running {
-        for event in event_pump.poll_iter() {
+        for event in sdl_context.event_pump().poll_iter() {
             use sdl2::event::Event;
 
             match event {

--- a/examples/game_controller.rs
+++ b/examples/game_controller.rs
@@ -4,7 +4,7 @@ use sdl2::{joystick, controller};
 use sdl2::controller::GameController;
 
 fn main() {
-    let sdl_context = sdl2::init().game_controller().unwrap();
+    let mut sdl_context = sdl2::init().game_controller().unwrap();
 
     let available =
         match joystick::num_joysticks() {
@@ -46,9 +46,7 @@ fn main() {
 
     println!("Controller mapping: {}", controller.mapping());
 
-    let mut event_pump = sdl_context.event_pump();
-
-    for event in event_pump.wait_iter() {
+    for event in sdl_context.event_pump().wait_iter() {
         use sdl2::event::Event;
 
         match event {

--- a/examples/joystick.rs
+++ b/examples/joystick.rs
@@ -3,7 +3,7 @@ extern crate sdl2;
 use sdl2::joystick::{Joystick, num_joysticks};
 
 fn main() {
-    let sdl_context = sdl2::init().joystick().unwrap();
+    let mut sdl_context = sdl2::init().joystick().unwrap();
 
     let available =
         match num_joysticks() {
@@ -32,9 +32,7 @@ fn main() {
         panic!("Couldn't open any joystick");
     };
 
-    let mut event_pump = sdl_context.event_pump();
-
-    for event in event_pump.wait_iter() {
+    for event in sdl_context.event_pump().wait_iter() {
         use sdl2::event::Event;
 
         match event {

--- a/examples/renderer-texture.rs
+++ b/examples/renderer-texture.rs
@@ -5,7 +5,7 @@ use sdl2::rect::Rect;
 use sdl2::keycode::KeyCode;
 
 pub fn main() {
-    let sdl_context = sdl2::init().video().unwrap();
+    let mut sdl_context = sdl2::init().video().unwrap();
 
     let window = sdl_context.window("rust-sdl2 demo: Video", 800, 600)
         .position_centered()
@@ -35,10 +35,9 @@ pub fn main() {
     drawer.present();
 
     let mut running = true;
-    let mut event_pump = sdl_context.event_pump();
 
     while running {
-        for event in event_pump.poll_iter() {
+        for event in sdl_context.event_pump().poll_iter() {
             use sdl2::event::Event;
 
             match event {

--- a/examples/renderer-yuv.rs
+++ b/examples/renderer-yuv.rs
@@ -5,7 +5,7 @@ use sdl2::rect::Rect;
 use sdl2::keycode::KeyCode;
 
 pub fn main() {
-    let sdl_context = sdl2::init().video().unwrap();
+    let mut sdl_context = sdl2::init().video().unwrap();
 
     let window = sdl_context.window("rust-sdl2 demo: Video", 800, 600)
         .position_centered()
@@ -51,10 +51,9 @@ pub fn main() {
     drawer.present();
 
     let mut running = true;
-    let mut event_pump = sdl_context.event_pump();
 
     while running {
-        for event in event_pump.poll_iter() {
+        for event in sdl_context.event_pump().poll_iter() {
             use sdl2::event::Event;
 
             match event {

--- a/examples/window-properties.rs
+++ b/examples/window-properties.rs
@@ -1,0 +1,52 @@
+extern crate sdl2;
+
+use sdl2::pixels::Color;
+
+pub fn main() {
+    let mut sdl_context = sdl2::init().video().unwrap();
+
+    let window = sdl_context.window("rust-sdl2 demo: Window", 800, 600)
+        .resizable()
+        .build()
+        .unwrap();
+
+    let mut renderer = window.renderer().present_vsync().build().unwrap();
+
+    let mut running = true;
+    let mut tick = 0;
+
+    while running {
+        for event in sdl_context.event_pump().poll_iter() {
+            use sdl2::event::Event;
+            use sdl2::keycode::KeyCode;
+
+            match event {
+                Event::Quit {..} | Event::KeyDown { keycode: KeyCode::Escape, .. } => {
+                    running = false
+                },
+                _ => {}
+            }
+        }
+
+        {
+            // Update the window title.
+            // &sdl_context is needed to safely access the Window and to ensure that the event loop
+            // isn't running (which could mutate the Window).
+
+            // Note: if you don't use renderer: window.properties(&sdl_context);
+            let mut props = renderer.window_properties(&sdl_context).unwrap();
+
+            let position = props.get_position();
+            let size = props.get_size();
+            let title = format!("Window - pos({}x{}), size({}x{}): {}", position.0, position.1, size.0, size.1, tick);
+            props.set_title(&title).unwrap();
+
+            tick += 1;
+        }
+
+        let mut drawer = renderer.drawer();
+        drawer.set_draw_color(Color::RGB(0, 0, 0));
+        drawer.clear();
+        drawer.present();
+    }
+}

--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -24,6 +24,7 @@ use mouse::{Mouse, MouseState};
 use scancode::ScanCode;
 use get_error;
 use SdlResult;
+use Sdl;
 
 use sys::event as ll;
 
@@ -902,6 +903,30 @@ impl Event {
     }
 }
 
+unsafe fn poll_event() -> Option<Event> {
+    let mut raw = mem::uninitialized();
+    let has_pending = ll::SDL_PollEvent(&mut raw) == 1;
+
+    if has_pending { Some(Event::from_ll(raw)) }
+    else { None }
+}
+
+unsafe fn wait_event() -> Event {
+    let mut raw = mem::uninitialized();
+    let success = ll::SDL_WaitEvent(&mut raw) == 1;
+
+    if success { Event::from_ll(raw) }
+    else { panic!(get_error()) }
+}
+
+unsafe fn wait_event_timeout(timeout: u32) -> Option<Event> {
+    let mut raw = mem::uninitialized();
+    let success = ll::SDL_WaitEventTimeout(&mut raw, timeout as c_int) == 1;
+
+    if success { Some(Event::from_ll(raw)) }
+    else { None }
+}
+
 /// A thread-safe type that encapsulates SDL event-pumping functions.
 pub struct EventPump<'sdl> {
     _sdl:    PhantomData<&'sdl ()>,
@@ -915,11 +940,7 @@ impl<'sdl> EventPump<'sdl> {
     ///
     /// If no events are pending, `None` is returned.
     pub fn poll_event(&mut self) -> Option<Event> {
-        let mut raw = unsafe { mem::uninitialized() };
-        let has_pending = unsafe { ll::SDL_PollEvent(&mut raw) == 1 as c_int };
-
-        if has_pending { Some(Event::from_ll(raw)) }
-        else { None }
+        unsafe { poll_event() }
     }
 
     /// Returns a polling iterator that calls `poll_event()`.
@@ -929,8 +950,7 @@ impl<'sdl> EventPump<'sdl> {
     /// ```no_run
     /// let mut sdl_context = sdl2::init().everything().unwrap();
     ///
-    /// let mut event_pump = sdl_context.event_pump();
-    /// for event in event_pump.poll_iter() {
+    /// for event in sdl_context.event_pump().poll_iter() {
     ///     use sdl2::event::Event;
     ///     match event {
     ///         Event::KeyDown {..} => { /*...*/ },
@@ -940,7 +960,7 @@ impl<'sdl> EventPump<'sdl> {
     /// ```
     pub fn poll_iter(&mut self) -> EventPollIterator {
         EventPollIterator {
-            event_pump: unsafe { EventPump::_unchecked_new() }
+            _marker: PhantomData
         }
     }
 
@@ -951,24 +971,12 @@ impl<'sdl> EventPump<'sdl> {
 
     /// Waits indefinitely for the next available event.
     pub fn wait_event(&mut self) -> Event {
-        unsafe {
-            let mut raw = mem::uninitialized();
-            let success = ll::SDL_WaitEvent(&mut raw) == 1;
-
-            if success { Event::from_ll(raw) }
-            else { panic!(get_error()) }
-        }
+        unsafe { wait_event() }
     }
 
     /// Waits until the specified timeout (in milliseconds) for the next available event.
     pub fn wait_event_timeout(&mut self, timeout: u32) -> Option<Event> {
-        unsafe {
-            let mut raw = mem::uninitialized();
-            let success = ll::SDL_WaitEventTimeout(&mut raw, timeout as c_int) == 1;
-
-            if success { Some(Event::from_ll(raw)) }
-            else { None }
-        }
+        unsafe { wait_event_timeout(timeout) }
     }
 
     /// Returns a waiting iterator that calls `wait_event()`.
@@ -976,7 +984,7 @@ impl<'sdl> EventPump<'sdl> {
     /// Note: The iterator will never terminate.
     pub fn wait_iter(&mut self) -> EventWaitIterator {
         EventWaitIterator {
-            event_pump: unsafe { EventPump::_unchecked_new() }
+            _marker: PhantomData
         }
     }
 
@@ -986,14 +994,14 @@ impl<'sdl> EventPump<'sdl> {
     /// exceeds the specified timeout.
     pub fn wait_timeout_iter(&mut self, timeout: u32) -> EventWaitTimeoutIterator {
         EventWaitTimeoutIterator {
-            event_pump: unsafe { EventPump::_unchecked_new() },
+            _marker: PhantomData,
             timeout: timeout
         }
     }
 
-    /// Internal use only; used by `sdl2::Sdl::event_pump()`
-    #[doc(hidden)]
-    pub unsafe fn _unchecked_new<'a>() -> EventPump<'a> {
+    /// Obtains the SDL event pump.
+    pub fn new(_sdl: &'sdl mut Sdl) -> EventPump<'sdl> {
+        // Called on the main SDL thread.
         EventPump {
             _sdl: PhantomData,
             _nosend: PhantomData,
@@ -1004,38 +1012,36 @@ impl<'sdl> EventPump<'sdl> {
 /// An iterator that calls `EventPump::poll_event()`.
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 pub struct EventPollIterator<'a> {
-    event_pump: EventPump<'a>
+    _marker: PhantomData<&'a ()>
 }
 
 impl<'a> Iterator for EventPollIterator<'a> {
     type Item = Event;
 
-    fn next(&mut self) -> Option<Event> {
-        self.event_pump.poll_event()
-    }
+    fn next(&mut self) -> Option<Event> { unsafe { poll_event() } }
 }
 
 /// An iterator that calls `EventPump::wait_event()`.
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 pub struct EventWaitIterator<'a> {
-    event_pump: EventPump<'a>
+    _marker: PhantomData<&'a ()>
 }
 
 impl<'a> Iterator for EventWaitIterator<'a> {
     type Item = Event;
-    fn next(&mut self) -> Option<Event> { Some(self.event_pump.wait_event()) }
+    fn next(&mut self) -> Option<Event> { unsafe { Some(wait_event()) } }
 }
 
 /// An iterator that calls `EventPump::wait_event_timeout()`.
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 pub struct EventWaitTimeoutIterator<'a> {
-    event_pump: EventPump<'a>,
+    _marker: PhantomData<&'a ()>,
     timeout: u32
 }
 
 impl<'a> Iterator for EventWaitTimeoutIterator<'a> {
     type Item = Event;
-    fn next(&mut self) -> Option<Event> { self.event_pump.wait_event_timeout(self.timeout) }
+    fn next(&mut self) -> Option<Event> { unsafe { wait_event_timeout(self.timeout) } }
 }
 
 /// Removes all events in the event queue that match the specified event type.

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -28,7 +28,7 @@
 //! None of the draw methods in `RenderDrawer` are expected to fail.
 //! If they do, a panic is raised and the program is aborted.
 
-use event::EventPump;
+use Sdl;
 use video::{Window, WindowProperties, WindowPropertiesGetters};
 use surface;
 use surface::Surface;
@@ -258,20 +258,20 @@ impl<'a> Renderer<'a> {
 
     /// Accesses the Window properties, such as the position, size and title of a Window.
     /// Returns None if the renderer is not associated with a Window.
-    pub fn window_properties<'b>(&'b mut self, event: &'b EventPump) -> Option<WindowProperties<'b>>
+    pub fn window_properties<'b>(&'b mut self, sdl: &'b Sdl) -> Option<WindowProperties<'b>>
     {
         match self.parent.as_mut() {
-            Some(&mut RendererParent::Window(ref mut window)) => Some(window.properties(event)),
+            Some(&mut RendererParent::Window(ref mut window)) => Some(window.properties(sdl)),
             _ => None
         }
     }
 
     /// Accesses the Window getters, such as the position, size and title of a Window.
     /// Returns None if the renderer is not associated with a Window.
-    pub fn window_properties_getters<'b>(&'b self, event: &'b EventPump) -> Option<WindowPropertiesGetters<'b>>
+    pub fn window_properties_getters<'b>(&'b self, sdl: &'b Sdl) -> Option<WindowPropertiesGetters<'b>>
     {
         match self.parent.as_ref() {
-            Some(&RendererParent::Window(ref window)) => Some(window.properties_getters(event)),
+            Some(&RendererParent::Window(ref window)) => Some(window.properties_getters(sdl)),
             _ => None
         }
     }

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -268,10 +268,10 @@ impl<'a> Renderer<'a> {
 
     /// Accesses the Window getters, such as the position, size and title of a Window.
     /// Returns None if the renderer is not associated with a Window.
-    pub fn window_properties_getters<'b>(&'b self, sdl: &'b Sdl) -> Option<WindowPropertiesGetters<'b>>
+    pub fn window_properties_getters(&self) -> Option<WindowPropertiesGetters>
     {
         match self.parent.as_ref() {
-            Some(&RendererParent::Window(ref window)) => Some(window.properties_getters(sdl)),
+            Some(&RendererParent::Window(ref window)) => Some(window.properties_getters()),
             _ => None
         }
     }

--- a/src/sdl2/sdl.rs
+++ b/src/sdl2/sdl.rs
@@ -49,8 +49,8 @@ impl Sdl {
     }
 
     /// Obtains the SDL event pump.
-    pub fn event_pump(&self) -> EventPump {
-        unsafe { EventPump::_unchecked_new() }
+    pub fn event_pump(&mut self) -> EventPump {
+        EventPump::new(self)
     }
 
     /// Initializes a new `WindowBuilder`; a convenience method that calls `WindowBuilder::new()`.
@@ -192,10 +192,9 @@ impl InitBuilder {
 ///
 /// # Example
 /// ```no_run
-/// let sdl_context = sdl2::init().everything().unwrap();
+/// let mut sdl_context = sdl2::init().everything().unwrap();
 ///
-/// let mut event_pump = sdl_context.event_pump();
-/// for event in event_pump.poll_iter() {
+/// for event in sdl_context.event_pump().poll_iter() {
 ///     // ...
 /// }
 ///

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -598,7 +598,8 @@ impl Window {
         }
     }
 
-    pub fn properties_getters<'a>(&'a self, _sdl: &'a Sdl) -> WindowPropertiesGetters<'a> {
+    /// Accesses the read-only Window properties.
+    pub fn properties_getters(&self) -> WindowPropertiesGetters {
         WindowPropertiesGetters {
             window_properties: WindowProperties {
                 raw: self.raw,

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -6,7 +6,6 @@ use std::ops::Deref;
 use std::ptr;
 use std::vec::Vec;
 
-use event::EventPump;
 use rect::Rect;
 use render::RendererBuilder;
 use surface::Surface;
@@ -566,20 +565,19 @@ impl Window {
     ///
     /// In order to access a Window's properties, it must be guaranteed that the
     /// event loop is not running.
-    /// This is why a reference to the application's `EventPump` is required
-    /// (a shared `EventPump` reference is only obtainable if it's not being mutated).
-    /// Event pumping could otherwise mutate a Window's properties without your consent!
+    /// This is why a reference to the application's SDL context is required
+    /// (a shared `Sdl` reference is only obtainable if the event loop is not running).
+    /// The event loop could otherwise mutate a Window's properties without your consent!
     ///
     /// # Example
     /// ```no_run
     /// let mut sdl_context = sdl2::init().everything().unwrap();
     /// let mut window = sdl_context.window("My SDL window", 800, 600).build().unwrap();
-    /// let mut event_pump = sdl_context.event_pump();
     ///
     /// loop {
     ///     let mut pos = None;
     ///
-    ///     for event in event_pump.poll_iter() {
+    ///     for event in sdl_context.event_pump().poll_iter() {
     ///         use sdl2::event::Event;
     ///         match event {
     ///             Event::MouseMotion { x, y, .. } => { pos = Some((x, y)); },
@@ -589,18 +587,18 @@ impl Window {
     ///
     ///     if let Some((x, y)) = pos {
     ///         // Set the window title
-    ///         window.properties(&event_pump).set_title(&format!("{}, {}", x, y));
+    ///         window.properties(&sdl_context).set_title(&format!("{}, {}", x, y));
     ///     }
     /// }
     /// ```
-    pub fn properties<'a>(&'a mut self, _event: &'a EventPump) -> WindowProperties<'a> {
+    pub fn properties<'a>(&'a mut self, _sdl: &'a Sdl) -> WindowProperties<'a> {
         WindowProperties {
             raw: self.raw,
             _marker: PhantomData
         }
     }
 
-    pub fn properties_getters<'a>(&'a self, _event: &'a EventPump) -> WindowPropertiesGetters<'a> {
+    pub fn properties_getters<'a>(&'a self, _sdl: &'a Sdl) -> WindowPropertiesGetters<'a> {
         WindowPropertiesGetters {
             window_properties: WindowProperties {
                 raw: self.raw,


### PR DESCRIPTION
The changes are only slightly breaking. Most people will only need to change the SDL context at the beginning of their program to be mutable:
```rust
let mut sdl_context = sdl2::init().video().build().unwrap();
```

To acquire an `EventPump`, it now requires a mutual borrow of `Sdl`. This is to statically ensure a single event loop, and that it's never possible to have two or more event loops at a time.

It's no longer necessary to create a dummy `EventPump` handle in functions that only access window properties. `properties()` accepts `&Sdl` instead of `&EventPump`:
```rust
fn set_title(&mut self, value: &str) {
    self.window.properties(&self.sdl_context).set_title(value).unwrap();
}
```
is equivalent to the old
```rust
fn set_title(&mut self, value: &str) {
    let event_pump = self.sdl_context.event_pump();
    self.window.properties(&event_pump).set_title(value).unwrap();
}
```