### PR TITLE
Add lifetime to RWops, coerce Paths, update audio/surface RWops functions

### DIFF
--- a/src/sdl2/audio.rs
+++ b/src/sdl2/audio.rs
@@ -208,14 +208,14 @@ pub struct AudioSpecWAV {
 }
 
 impl AudioSpecWAV {
-    /// Loads a WAVE from the file path. Uses `SDL_LoadWAV_RW`.
-    pub fn load_wav(path: &Path) -> SdlResult<AudioSpecWAV> {
-        let ops = try!(RWops::from_file(path, "rb"));
-        AudioSpecWAV::load_wav_rw(&ops)
+    /// Loads a WAVE from the file path.
+    pub fn load_wav<P: AsRef<Path>>(path: P) -> SdlResult<AudioSpecWAV> {
+        let mut file = try!(RWops::from_file(path, "rb"));
+        AudioSpecWAV::load_wav_rw(&mut file)
     }
 
-    /// Loads a WAVE from the data source. Uses `SDL_LoadWAV_RW`.
-    pub fn load_wav_rw(src: &RWops) -> SdlResult<AudioSpecWAV> {
+    /// Loads a WAVE from the data source.
+    pub fn load_wav_rw(src: &mut RWops) -> SdlResult<AudioSpecWAV> {
         use std::mem::uninitialized;
         use std::ptr::null_mut;
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,10 +1,8 @@
 extern crate sdl2;
 
-use std::path::Path;
-
 #[test]
 fn audio_spec_wav() {
-    let wav = sdl2::audio::AudioSpecWAV::load_wav(&Path::new("./tests/sine.wav")).unwrap();
+    let wav = sdl2::audio::AudioSpecWAV::load_wav("./tests/sine.wav").unwrap();
 
     assert_eq!(wav.freq, 22050);
     assert_eq!(wav.format, sdl2::audio::AudioFormat::S16LSB);


### PR DESCRIPTION
* `SDL_RWFromConstMem` and `SDL_RWFromMem` only references the
  buffer, and never copies it - ergo, lifetime.
* `AsRef<Path>` lets us use ordinary string slices as path arguments,
  like in `std::fs::File`.