### PR TITLE
Fix dangling pointers from CString, deal with interior nul bytes

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -4,7 +4,7 @@ use sdl2::pixels::Color;
 use sdl2::keycode::KeyCode;
 
 pub fn main() {
-    let sdl_context = sdl2::init().video().unwrap();
+    let mut sdl_context = sdl2::init().video().unwrap();
 
     let window = sdl_context.window("rust-sdl2 demo: Video", 800, 600)
         .position_centered()
@@ -20,10 +20,9 @@ pub fn main() {
     drawer.present();
 
     let mut running = true;
-    let mut event_pump = sdl_context.event_pump();
 
     while running {
-        for event in event_pump.poll_iter() {
+        for event in sdl_context.event_pump().poll_iter() {
             use sdl2::event::Event;
 
             match event {

--- a/examples/game_controller.rs
+++ b/examples/game_controller.rs
@@ -4,7 +4,7 @@ use sdl2::{joystick, controller};
 use sdl2::controller::GameController;
 
 fn main() {
-    let sdl_context = sdl2::init().game_controller().unwrap();
+    let mut sdl_context = sdl2::init().game_controller().unwrap();
 
     let available =
         match joystick::num_joysticks() {
@@ -46,9 +46,7 @@ fn main() {
 
     println!("Controller mapping: {}", controller.mapping());
 
-    let mut event_pump = sdl_context.event_pump();
-
-    for event in event_pump.wait_iter() {
+    for event in sdl_context.event_pump().wait_iter() {
         use sdl2::event::Event;
 
         match event {

--- a/examples/joystick.rs
+++ b/examples/joystick.rs
@@ -3,7 +3,7 @@ extern crate sdl2;
 use sdl2::joystick::{Joystick, num_joysticks};
 
 fn main() {
-    let sdl_context = sdl2::init().joystick().unwrap();
+    let mut sdl_context = sdl2::init().joystick().unwrap();
 
     let available =
         match num_joysticks() {
@@ -32,9 +32,7 @@ fn main() {
         panic!("Couldn't open any joystick");
     };
 
-    let mut event_pump = sdl_context.event_pump();
-
-    for event in event_pump.wait_iter() {
+    for event in sdl_context.event_pump().wait_iter() {
         use sdl2::event::Event;
 
         match event {

--- a/examples/renderer-texture.rs
+++ b/examples/renderer-texture.rs
@@ -5,7 +5,7 @@ use sdl2::rect::Rect;
 use sdl2::keycode::KeyCode;
 
 pub fn main() {
-    let sdl_context = sdl2::init().video().unwrap();
+    let mut sdl_context = sdl2::init().video().unwrap();
 
     let window = sdl_context.window("rust-sdl2 demo: Video", 800, 600)
         .position_centered()
@@ -35,10 +35,9 @@ pub fn main() {
     drawer.present();
 
     let mut running = true;
-    let mut event_pump = sdl_context.event_pump();
 
     while running {
-        for event in event_pump.poll_iter() {
+        for event in sdl_context.event_pump().poll_iter() {
             use sdl2::event::Event;
 
             match event {

--- a/examples/renderer-yuv.rs
+++ b/examples/renderer-yuv.rs
@@ -5,7 +5,7 @@ use sdl2::rect::Rect;
 use sdl2::keycode::KeyCode;
 
 pub fn main() {
-    let sdl_context = sdl2::init().video().unwrap();
+    let mut sdl_context = sdl2::init().video().unwrap();
 
     let window = sdl_context.window("rust-sdl2 demo: Video", 800, 600)
         .position_centered()
@@ -51,10 +51,9 @@ pub fn main() {
     drawer.present();
 
     let mut running = true;
-    let mut event_pump = sdl_context.event_pump();
 
     while running {
-        for event in event_pump.poll_iter() {
+        for event in sdl_context.event_pump().poll_iter() {
             use sdl2::event::Event;
 
             match event {

--- a/examples/window-properties.rs
+++ b/examples/window-properties.rs
@@ -1,0 +1,52 @@
+extern crate sdl2;
+
+use sdl2::pixels::Color;
+
+pub fn main() {
+    let mut sdl_context = sdl2::init().video().unwrap();
+
+    let window = sdl_context.window("rust-sdl2 demo: Window", 800, 600)
+        .resizable()
+        .build()
+        .unwrap();
+
+    let mut renderer = window.renderer().present_vsync().build().unwrap();
+
+    let mut running = true;
+    let mut tick = 0;
+
+    while running {
+        for event in sdl_context.event_pump().poll_iter() {
+            use sdl2::event::Event;
+            use sdl2::keycode::KeyCode;
+
+            match event {
+                Event::Quit {..} | Event::KeyDown { keycode: KeyCode::Escape, .. } => {
+                    running = false
+                },
+                _ => {}
+            }
+        }
+
+        {
+            // Update the window title.
+            // &sdl_context is needed to safely access the Window and to ensure that the event loop
+            // isn't running (which could mutate the Window).
+
+            // Note: if you don't use renderer: window.properties(&sdl_context);
+            let mut props = renderer.window_properties(&sdl_context).unwrap();
+
+            let position = props.get_position();
+            let size = props.get_size();
+            let title = format!("Window - pos({}x{}), size({}x{}): {}", position.0, position.1, size.0, size.1, tick);
+            props.set_title(&title).unwrap();
+
+            tick += 1;
+        }
+
+        let mut drawer = renderer.drawer();
+        drawer.set_draw_color(Color::RGB(0, 0, 0));
+        drawer.clear();
+        drawer.present();
+    }
+}

--- a/examples/window-properties.rs
+++ b/examples/window-properties.rs
@@ -39,7 +39,7 @@ pub fn main() {
             let position = props.get_position();
             let size = props.get_size();
             let title = format!("Window - pos({}x{}), size({}x{}): {}", position.0, position.1, size.0, size.1, tick);
-            props.set_title(&title).unwrap();
+            props.set_title(&title);
 
             tick += 1;
         }

--- a/src/sdl2/clipboard.rs
+++ b/src/sdl2/clipboard.rs
@@ -6,8 +6,8 @@ use sys::clipboard as ll;
 
 pub fn set_clipboard_text(text: &String) -> SdlResult<()> {
     unsafe {
-        let buff = CString::new(text.clone()).unwrap();
-        let result = ll::SDL_SetClipboardText(buff.as_ptr());
+        let text = CString::new(text.clone()).unwrap();
+        let result = ll::SDL_SetClipboardText(text.as_ptr());
 
         if result == 0 {
             Err(get_error())
@@ -33,4 +33,3 @@ pub fn get_clipboard_text() -> SdlResult<String> {
 pub fn has_clipboard_text() -> bool {
     unsafe { ll::SDL_HasClipboardText() == 1 }
 }
-

--- a/src/sdl2/controller.rs
+++ b/src/sdl2/controller.rs
@@ -1,9 +1,10 @@
 use libc::{c_int, c_char};
-use std::ffi::{CString, CStr, NulError};
+use std::ffi::{CString, CStr};
 
 use SdlResult;
 use {get_error, clear_error};
 use joystick;
+use util::CStringExt;
 
 use sys::controller as ll;
 use sys::event::{SDL_QUERY, SDL_ENABLE};
@@ -23,16 +24,14 @@ pub enum Axis {
 impl Axis {
     /// Return the Axis from a string description in the same format
     /// used by the game controller mapping strings.
-    pub fn from_string(axis: &str) -> Result<Axis, NulError> {
-        let name_c =
-        match CString::new(axis) {
-            Ok(s) => s.as_ptr(),
-            Err(e) => return Err(e),
+    pub fn from_string(axis: &str) -> Axis {
+        let id = match CString::new(axis) {
+            Ok(axis) => unsafe { ll::SDL_GameControllerGetAxisFromString(axis.as_ptr()) },
+            // string contains a nul byte - it won't match anything.
+            Err(_) => ll::SDL_CONTROLLER_AXIS_INVALID
         };
 
-        let id = unsafe { ll::SDL_GameControllerGetAxisFromString(name_c) };
-
-        Ok(wrap_controller_axis(id as u8))
+        wrap_controller_axis(id as u8)
     }
 
     /// Return a string for a given axis in the same format using by
@@ -82,16 +81,14 @@ pub enum Button {
 impl Button {
     /// Return the Button from a string description in the same format
     /// used by the game controller mapping strings.
-    pub fn from_string(button: &str) -> Result<Button, NulError> {
-        let name_c =
-        match CString::new(button) {
-            Ok(s) => s.as_ptr(),
-            Err(e) => return Err(e),
+    pub fn from_string(button: &str) -> Button {
+        let id = match CString::new(button) {
+            Ok(button) => unsafe { ll::SDL_GameControllerGetButtonFromString(button.as_ptr()) },
+            // string contains a nul byte - it won't match anything.
+            Err(_) => ll::SDL_CONTROLLER_BUTTON_INVALID
         };
 
-        let id = unsafe { ll::SDL_GameControllerGetButtonFromString(name_c) };
-
-        Ok(wrap_controller_button(id as u8))
+        wrap_controller_button(id as u8)
     }
 
     /// Return a string for a given button in the same format using by
@@ -164,9 +161,9 @@ pub enum MappingStatus {
 
 /// Add a new mapping from a mapping string
 pub fn add_mapping(mapping: &str) -> SdlResult<MappingStatus> {
-    let mapping_c = CString::new(mapping).unwrap().as_ptr();
+    let mapping = try!(CString::new(mapping).unwrap_or_sdlresult());
 
-    let result = unsafe { ll::SDL_GameControllerAddMapping(mapping_c) };
+    let result = unsafe { ll::SDL_GameControllerAddMapping(mapping.as_ptr()) };
 
     match result {
         1 => Ok(MappingStatus::Added),

--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -24,6 +24,7 @@ use mouse::{Mouse, MouseState};
 use scancode::ScanCode;
 use get_error;
 use SdlResult;
+use Sdl;
 
 use sys::event as ll;
 
@@ -902,6 +903,30 @@ impl Event {
     }
 }
 
+unsafe fn poll_event() -> Option<Event> {
+    let mut raw = mem::uninitialized();
+    let has_pending = ll::SDL_PollEvent(&mut raw) == 1;
+
+    if has_pending { Some(Event::from_ll(raw)) }
+    else { None }
+}
+
+unsafe fn wait_event() -> Event {
+    let mut raw = mem::uninitialized();
+    let success = ll::SDL_WaitEvent(&mut raw) == 1;
+
+    if success { Event::from_ll(raw) }
+    else { panic!(get_error()) }
+}
+
+unsafe fn wait_event_timeout(timeout: u32) -> Option<Event> {
+    let mut raw = mem::uninitialized();
+    let success = ll::SDL_WaitEventTimeout(&mut raw, timeout as c_int) == 1;
+
+    if success { Some(Event::from_ll(raw)) }
+    else { None }
+}
+
 /// A thread-safe type that encapsulates SDL event-pumping functions.
 pub struct EventPump<'sdl> {
     _sdl:    PhantomData<&'sdl ()>,
@@ -915,11 +940,7 @@ impl<'sdl> EventPump<'sdl> {
     ///
     /// If no events are pending, `None` is returned.
     pub fn poll_event(&mut self) -> Option<Event> {
-        let mut raw = unsafe { mem::uninitialized() };
-        let has_pending = unsafe { ll::SDL_PollEvent(&mut raw) == 1 as c_int };
-
-        if has_pending { Some(Event::from_ll(raw)) }
-        else { None }
+        unsafe { poll_event() }
     }
 
     /// Returns a polling iterator that calls `poll_event()`.
@@ -929,8 +950,7 @@ impl<'sdl> EventPump<'sdl> {
     /// ```no_run
     /// let mut sdl_context = sdl2::init().everything().unwrap();
     ///
-    /// let mut event_pump = sdl_context.event_pump();
-    /// for event in event_pump.poll_iter() {
+    /// for event in sdl_context.event_pump().poll_iter() {
     ///     use sdl2::event::Event;
     ///     match event {
     ///         Event::KeyDown {..} => { /*...*/ },
@@ -940,7 +960,7 @@ impl<'sdl> EventPump<'sdl> {
     /// ```
     pub fn poll_iter(&mut self) -> EventPollIterator {
         EventPollIterator {
-            event_pump: unsafe { EventPump::_unchecked_new() }
+            _marker: PhantomData
         }
     }
 
@@ -951,24 +971,12 @@ impl<'sdl> EventPump<'sdl> {
 
     /// Waits indefinitely for the next available event.
     pub fn wait_event(&mut self) -> Event {
-        unsafe {
-            let mut raw = mem::uninitialized();
-            let success = ll::SDL_WaitEvent(&mut raw) == 1;
-
-            if success { Event::from_ll(raw) }
-            else { panic!(get_error()) }
-        }
+        unsafe { wait_event() }
     }
 
     /// Waits until the specified timeout (in milliseconds) for the next available event.
     pub fn wait_event_timeout(&mut self, timeout: u32) -> Option<Event> {
-        unsafe {
-            let mut raw = mem::uninitialized();
-            let success = ll::SDL_WaitEventTimeout(&mut raw, timeout as c_int) == 1;
-
-            if success { Some(Event::from_ll(raw)) }
-            else { None }
-        }
+        unsafe { wait_event_timeout(timeout) }
     }
 
     /// Returns a waiting iterator that calls `wait_event()`.
@@ -976,7 +984,7 @@ impl<'sdl> EventPump<'sdl> {
     /// Note: The iterator will never terminate.
     pub fn wait_iter(&mut self) -> EventWaitIterator {
         EventWaitIterator {
-            event_pump: unsafe { EventPump::_unchecked_new() }
+            _marker: PhantomData
         }
     }
 
@@ -986,14 +994,14 @@ impl<'sdl> EventPump<'sdl> {
     /// exceeds the specified timeout.
     pub fn wait_timeout_iter(&mut self, timeout: u32) -> EventWaitTimeoutIterator {
         EventWaitTimeoutIterator {
-            event_pump: unsafe { EventPump::_unchecked_new() },
+            _marker: PhantomData,
             timeout: timeout
         }
     }
 
-    /// Internal use only; used by `sdl2::Sdl::event_pump()`
-    #[doc(hidden)]
-    pub unsafe fn _unchecked_new<'a>() -> EventPump<'a> {
+    /// Obtains the SDL event pump.
+    pub fn new(_sdl: &'sdl mut Sdl) -> EventPump<'sdl> {
+        // Called on the main SDL thread.
         EventPump {
             _sdl: PhantomData,
             _nosend: PhantomData,
@@ -1004,38 +1012,36 @@ impl<'sdl> EventPump<'sdl> {
 /// An iterator that calls `EventPump::poll_event()`.
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 pub struct EventPollIterator<'a> {
-    event_pump: EventPump<'a>
+    _marker: PhantomData<&'a ()>
 }
 
 impl<'a> Iterator for EventPollIterator<'a> {
     type Item = Event;
 
-    fn next(&mut self) -> Option<Event> {
-        self.event_pump.poll_event()
-    }
+    fn next(&mut self) -> Option<Event> { unsafe { poll_event() } }
 }
 
 /// An iterator that calls `EventPump::wait_event()`.
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 pub struct EventWaitIterator<'a> {
-    event_pump: EventPump<'a>
+    _marker: PhantomData<&'a ()>
 }
 
 impl<'a> Iterator for EventWaitIterator<'a> {
     type Item = Event;
-    fn next(&mut self) -> Option<Event> { Some(self.event_pump.wait_event()) }
+    fn next(&mut self) -> Option<Event> { unsafe { Some(wait_event()) } }
 }
 
 /// An iterator that calls `EventPump::wait_event_timeout()`.
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 pub struct EventWaitTimeoutIterator<'a> {
-    event_pump: EventPump<'a>,
+    _marker: PhantomData<&'a ()>,
     timeout: u32
 }
 
 impl<'a> Iterator for EventWaitTimeoutIterator<'a> {
     type Item = Event;
-    fn next(&mut self) -> Option<Event> { self.event_pump.wait_event_timeout(self.timeout) }
+    fn next(&mut self) -> Option<Event> { unsafe { wait_event_timeout(self.timeout) } }
 }
 
 /// Removes all events in the event queue that match the specified event type.

--- a/src/sdl2/filesystem.rs
+++ b/src/sdl2/filesystem.rs
@@ -1,6 +1,7 @@
 use std::ffi::{CStr, CString};
 use SdlResult;
 use get_error;
+use util::CStringExt;
 
 use sys::filesystem as ll;
 
@@ -19,9 +20,9 @@ pub fn get_base_path() -> SdlResult<String> {
 
 pub fn get_pref_path(org: &str, app: &str) -> SdlResult<String> {
     let result = unsafe {
-        let org_cstr = CString::new(org).unwrap().as_ptr();
-        let app_cstr = CString::new(app).unwrap().as_ptr();
-        let buf = ll::SDL_GetPrefPath(org_cstr, app_cstr);
+        let org = try!(CString::new(org).unwrap_or_sdlresult());
+        let app = try!(CString::new(app).unwrap_or_sdlresult());
+        let buf = ll::SDL_GetPrefPath(org.as_ptr(), app.as_ptr());
         String::from_utf8_lossy(CStr::from_ptr(buf).to_bytes()).to_string()
     };
 
@@ -31,4 +32,3 @@ pub fn get_pref_path(org: &str, app: &str) -> SdlResult<String> {
         Ok(result)
     }
 }
-

--- a/src/sdl2/joystick.rs
+++ b/src/sdl2/joystick.rs
@@ -263,13 +263,9 @@ pub struct Guid {
 impl Guid {
     /// Create a GUID from a string representation.
     pub fn from_string(guid: &str) -> Result<Guid, NulError> {
-        let guid_c =
-        match CString::new(guid) {
-            Ok(s) => s.as_ptr(),
-            Err(e) => return Err(e),
-        };
+        let guid = try!(CString::new(guid));
 
-        let raw = unsafe { ll::SDL_JoystickGetGUIDFromString(guid_c) };
+        let raw = unsafe { ll::SDL_JoystickGetGUIDFromString(guid.as_ptr()) };
 
         Ok(Guid { raw: raw })
     }

--- a/src/sdl2/keyboard.rs
+++ b/src/sdl2/keyboard.rs
@@ -1,6 +1,6 @@
 use num::FromPrimitive;
 use std::collections::HashMap;
-use std::ffi::{CStr, CString, NulError};
+use std::ffi::{CStr, CString};
 use std::ptr;
 
 use keycode::KeyCode;
@@ -85,15 +85,13 @@ pub fn get_scancode_name(scancode: ScanCode) -> String {
     }
 }
 
-pub fn get_scancode_from_name(name: &str) -> Result<ScanCode, NulError> {
+pub fn get_scancode_from_name(name: &str) -> ScanCode {
     unsafe {
-        let name =
         match CString::new(name) {
-            Ok(s) => s.as_ptr(),
-            Err(e) => return Err(e),
-        };
-        Ok(FromPrimitive::from_isize(ll::SDL_GetScancodeFromName(name) as isize)
-            .unwrap_or(ScanCode::Unknown))
+            Ok(name) => FromPrimitive::from_isize(ll::SDL_GetScancodeFromName(name.as_ptr()) as isize).unwrap_or(ScanCode::Unknown),
+            // string contains a nul byte - it won't match anything.
+            Err(_) => ScanCode::Unknown
+        }
     }
 }
 
@@ -104,15 +102,13 @@ pub fn get_key_name(key: KeyCode) -> String {
     }
 }
 
-pub fn get_key_from_name(name: &str) -> Result<KeyCode, NulError> {
+pub fn get_key_from_name(name: &str) -> KeyCode {
     unsafe {
-        let name =
         match CString::new(name) {
-            Ok(s) => s.as_ptr(),
-            Err(e) => return Err(e),
-        };
-        Ok(FromPrimitive::from_isize(ll::SDL_GetKeyFromName(name) as isize)
-            .unwrap_or(KeyCode::Unknown))
+            Ok(name) => FromPrimitive::from_isize(ll::SDL_GetKeyFromName(name.as_ptr()) as isize).unwrap_or(KeyCode::Unknown),
+            // string contains a nul byte - it won't match anything.
+            Err(_) => KeyCode::Unknown
+        }
     }
 }
 

--- a/src/sdl2/lib.rs
+++ b/src/sdl2/lib.rs
@@ -35,3 +35,5 @@ mod sdl;
 pub mod audio;
 pub mod version;
 pub mod messagebox;
+
+mod util;

--- a/src/sdl2/messagebox.rs
+++ b/src/sdl2/messagebox.rs
@@ -4,6 +4,7 @@ use std::ptr;
 use video::Window;
 use get_error;
 use SdlResult;
+use util::CStringExt;
 
 use sys::messagebox as ll;
 
@@ -17,11 +18,11 @@ bitflags! {
 
 pub fn show_simple_message_box(flags: MessageBoxFlag, title: &str, message: &str, window: Option<&Window>) -> SdlResult<()> {
     let result = unsafe {
-        let title_cstr = CString::new(title).unwrap().as_ptr();
-        let message_cstr = CString::new(message).unwrap().as_ptr();
+        let title = CString::new(title).remove_nul();
+        let message = CString::new(message).remove_nul();
         ll::SDL_ShowSimpleMessageBox(flags.bits(),
-                                     title_cstr,
-                                     message_cstr,
+                                     title.as_ptr(),
+                                     message.as_ptr(),
                                      window.map_or(ptr::null_mut(), |win| win.raw()))
     } == 0;
 

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -28,7 +28,7 @@
 //! None of the draw methods in `RenderDrawer` are expected to fail.
 //! If they do, a panic is raised and the program is aborted.
 
-use event::EventPump;
+use Sdl;
 use video::{Window, WindowProperties, WindowPropertiesGetters};
 use surface;
 use surface::Surface;
@@ -258,20 +258,20 @@ impl<'a> Renderer<'a> {
 
     /// Accesses the Window properties, such as the position, size and title of a Window.
     /// Returns None if the renderer is not associated with a Window.
-    pub fn window_properties<'b>(&'b mut self, event: &'b EventPump) -> Option<WindowProperties<'b>>
+    pub fn window_properties<'b>(&'b mut self, sdl: &'b Sdl) -> Option<WindowProperties<'b>>
     {
         match self.parent.as_mut() {
-            Some(&mut RendererParent::Window(ref mut window)) => Some(window.properties(event)),
+            Some(&mut RendererParent::Window(ref mut window)) => Some(window.properties(sdl)),
             _ => None
         }
     }
 
     /// Accesses the Window getters, such as the position, size and title of a Window.
     /// Returns None if the renderer is not associated with a Window.
-    pub fn window_properties_getters<'b>(&'b self, event: &'b EventPump) -> Option<WindowPropertiesGetters<'b>>
+    pub fn window_properties_getters<'b>(&'b self, sdl: &'b Sdl) -> Option<WindowPropertiesGetters<'b>>
     {
         match self.parent.as_ref() {
-            Some(&RendererParent::Window(ref window)) => Some(window.properties_getters(event)),
+            Some(&RendererParent::Window(ref window)) => Some(window.properties_getters(sdl)),
             _ => None
         }
     }

--- a/src/sdl2/sdl.rs
+++ b/src/sdl2/sdl.rs
@@ -49,8 +49,8 @@ impl Sdl {
     }
 
     /// Obtains the SDL event pump.
-    pub fn event_pump(&self) -> EventPump {
-        unsafe { EventPump::_unchecked_new() }
+    pub fn event_pump(&mut self) -> EventPump {
+        EventPump::new(self)
     }
 
     /// Initializes a new `WindowBuilder`; a convenience method that calls `WindowBuilder::new()`.
@@ -192,10 +192,9 @@ impl InitBuilder {
 ///
 /// # Example
 /// ```no_run
-/// let sdl_context = sdl2::init().everything().unwrap();
+/// let mut sdl_context = sdl2::init().everything().unwrap();
 ///
-/// let mut event_pump = sdl_context.event_pump();
-/// for event in event_pump.poll_iter() {
+/// for event in sdl_context.event_pump().poll_iter() {
 ///     // ...
 /// }
 ///

--- a/src/sdl2/sdl.rs
+++ b/src/sdl2/sdl.rs
@@ -4,6 +4,7 @@ use std::marker::PhantomData;
 use sys::sdl as ll;
 use event::EventPump;
 use video::WindowBuilder;
+use util::CStringExt;
 
 #[derive(Copy, Clone, PartialEq)]
 pub enum Error {
@@ -210,8 +211,8 @@ pub fn get_error() -> String {
 }
 
 pub fn set_error(err: &str) {
-    let buf = CString::new(err).unwrap().as_ptr();
-    unsafe { ll::SDL_SetError(buf); }
+    let err = CString::new(err).remove_nul();
+    unsafe { ll::SDL_SetError(err.as_ptr()); }
 }
 
 pub fn set_error_from_code(err: Error) {

--- a/src/sdl2/util.rs
+++ b/src/sdl2/util.rs
@@ -1,0 +1,45 @@
+use std::ffi::{CString, NulError};
+
+use SdlResult;
+
+pub trait CStringExt {
+    /// Returns an SDL error if the string contains a nul byte.
+    fn unwrap_or_sdlresult(self) -> SdlResult<CString>;
+
+    /// Removes any nul bytes so that they can be displayed in a C string.
+    ///
+    /// * Use this with functions that use the string for display purposes (such as Window titles or error messages).
+    /// * Do not use this with functions that use the string as a lookup value (such as device names).
+    fn remove_nul(self) -> CString;
+}
+
+impl CStringExt for Result<CString, NulError> {
+    fn unwrap_or_sdlresult(self) -> SdlResult<CString> {
+        self.or(Err(format!("argument string cannot contain an interior nul byte")))
+    }
+
+    fn remove_nul(self) -> CString {
+        match self {
+            Ok(value) => value,
+            Err(e) => {
+                let original_vec = e.into_vec();
+                let v = original_vec.into_iter().filter(|&c| c != 0).collect();
+
+                unsafe { CString::from_vec_unchecked(v) }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::CStringExt;
+    use std::ffi::CString;
+
+    #[test]
+    fn test_cstring_ext() {
+        assert!(CString::new("FooBar").unwrap_or_sdlresult().is_ok());
+        assert!(CString::new("Foo\0Bar").unwrap_or_sdlresult().is_err());
+        assert_eq!(CString::new("Foo\0Bar\0").remove_nul(), CString::new("FooBar").unwrap());
+    }
+}

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -1,5 +1,5 @@
 use libc::{c_void, c_int, c_float, uint32_t};
-use std::ffi::{CStr, CString, NulError};
+use std::ffi::{CStr, CString};
 use std::marker::PhantomData;
 use std::mem;
 use std::ops::Deref;
@@ -13,6 +13,7 @@ use pixels;
 use Sdl;
 use SdlResult;
 use num::FromPrimitive;
+use util::CStringExt;
 
 use get_error;
 
@@ -441,7 +442,7 @@ impl WindowBuilder {
     /// Initializes a new `WindowBuilder`.
     pub fn new(_sdl: &Sdl, title: &str, width: u32, height: u32) -> WindowBuilder {
         WindowBuilder {
-            title: CString::new(title).unwrap(),
+            title: CString::new(title).remove_nul(),
             width: width,
             height: height,
             x: WindowPos::PosUndefined,
@@ -703,10 +704,9 @@ impl<'a> WindowProperties<'a> {
         }
     }
 
-    pub fn set_title(&mut self, title: &str) -> Result<(), NulError> {
-        let buff = try!(CString::new(title)).as_ptr();
-        unsafe { ll::SDL_SetWindowTitle(self.raw, buff); }
-        Ok(())
+    pub fn set_title(&mut self, title: &str) {
+        let title = CString::new(title).remove_nul();
+        unsafe { ll::SDL_SetWindowTitle(self.raw, title.as_ptr()); }
     }
 
     pub fn get_title(&self) -> &str {
@@ -921,13 +921,14 @@ pub fn get_video_driver(id: i32) -> String {
     }
 }
 
-pub fn video_init(name: &str) -> Result<bool, NulError> {
-    let buf =
-    match CString::new(name) {
-        Ok(s) => s.as_ptr(),
-        Err(e) => return Err(e),
-    };
-    Ok(unsafe { ll::SDL_VideoInit(buf) == 0 })
+pub fn video_init(name: &str) -> SdlResult<()> {
+    let name = try!(CString::new(name).unwrap_or_sdlresult());
+    let result = unsafe { ll::SDL_VideoInit(name.as_ptr()) };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(get_error())
+    }
 }
 
 pub fn video_quit() {
@@ -1035,10 +1036,11 @@ pub fn disable_screen_saver() {
     unsafe { ll::SDL_DisableScreenSaver() }
 }
 
-pub fn gl_load_library(path: &str) -> SdlResult<()> {
+pub fn gl_load_library<P: AsRef<::std::path::Path>>(path: P) -> SdlResult<()> {
     unsafe {
-        let path = CString::new(path).unwrap().as_ptr();
-        if ll::SDL_GL_LoadLibrary(path) == 0 {
+        // TODO: use OsStr::to_cstring() once it's stable
+        let path = CString::new(path.as_ref().to_str().unwrap()).unwrap();
+        if ll::SDL_GL_LoadLibrary(path.as_ptr()) == 0 {
             Ok(())
         } else {
             Err(get_error())
@@ -1051,23 +1053,19 @@ pub fn gl_unload_library() {
 }
 
 pub fn gl_get_proc_address(procname: &str) -> *const c_void {
-    unsafe {
-        let procname =
-        match CString::new(procname) {
-            Ok(s) => s.as_ptr(),
-            Err(_) => return 0 as *const c_void,
-        };
-        ll::SDL_GL_GetProcAddress(procname)
+    match CString::new(procname) {
+        Ok(procname) => unsafe { ll::SDL_GL_GetProcAddress(procname.as_ptr()) },
+        // string contains a nul byte - it won't match anything.
+        Err(_) => ptr::null()
     }
 }
 
-pub fn gl_extension_supported(extension: &str) -> Result<bool, NulError> {
-    let buff =
+pub fn gl_extension_supported(extension: &str) -> bool {
     match CString::new(extension) {
-        Ok(s) => s.as_ptr(),
-        Err(e) => return Err(e),
-    };
-    Ok(unsafe { ll::SDL_GL_ExtensionSupported(buff) == 1 })
+        Ok(extension) => unsafe { ll::SDL_GL_ExtensionSupported(extension.as_ptr()) != 0 },
+        // string contains a nul byte - it won't match anything.
+        Err(_) => false
+    }
 }
 
 pub unsafe fn gl_get_current_window() -> SdlResult<Window> {

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -6,7 +6,6 @@ use std::ops::Deref;
 use std::ptr;
 use std::vec::Vec;
 
-use event::EventPump;
 use rect::Rect;
 use render::RendererBuilder;
 use surface::Surface;
@@ -566,20 +565,19 @@ impl Window {
     ///
     /// In order to access a Window's properties, it must be guaranteed that the
     /// event loop is not running.
-    /// This is why a reference to the application's `EventPump` is required
-    /// (a shared `EventPump` reference is only obtainable if it's not being mutated).
-    /// Event pumping could otherwise mutate a Window's properties without your consent!
+    /// This is why a reference to the application's SDL context is required
+    /// (a shared `Sdl` reference is only obtainable if the event loop is not running).
+    /// The event loop could otherwise mutate a Window's properties without your consent!
     ///
     /// # Example
     /// ```no_run
     /// let mut sdl_context = sdl2::init().everything().unwrap();
     /// let mut window = sdl_context.window("My SDL window", 800, 600).build().unwrap();
-    /// let mut event_pump = sdl_context.event_pump();
     ///
     /// loop {
     ///     let mut pos = None;
     ///
-    ///     for event in event_pump.poll_iter() {
+    ///     for event in sdl_context.event_pump().poll_iter() {
     ///         use sdl2::event::Event;
     ///         match event {
     ///             Event::MouseMotion { x, y, .. } => { pos = Some((x, y)); },
@@ -589,18 +587,18 @@ impl Window {
     ///
     ///     if let Some((x, y)) = pos {
     ///         // Set the window title
-    ///         window.properties(&event_pump).set_title(&format!("{}, {}", x, y));
+    ///         window.properties(&sdl_context).set_title(&format!("{}, {}", x, y));
     ///     }
     /// }
     /// ```
-    pub fn properties<'a>(&'a mut self, _event: &'a EventPump) -> WindowProperties<'a> {
+    pub fn properties<'a>(&'a mut self, _sdl: &'a Sdl) -> WindowProperties<'a> {
         WindowProperties {
             raw: self.raw,
             _marker: PhantomData
         }
     }
 
-    pub fn properties_getters<'a>(&'a self, _event: &'a EventPump) -> WindowPropertiesGetters<'a> {
+    pub fn properties_getters<'a>(&'a self, _sdl: &'a Sdl) -> WindowPropertiesGetters<'a> {
         WindowPropertiesGetters {
             window_properties: WindowProperties {
                 raw: self.raw,


### PR DESCRIPTION
#413 should be merged first - this updates its example.
Diff excluding the EventPump stuff: https://github.com/AngryLawyer/rust-sdl2/commit/f4d6e65ea38e6182824fb6da6f8550f8b6d468cb

* The expression `CString::new(s).unwrap().as_ptr()` creates a
  dangling pointer; the underlying `CString` value gets dropped
  shortly after the pointer is obtained. The correct method is to let
  the `CString` live longer than the pointer by assigning it to a
  variable, then calling `.as_ptr()` on the variable later.
* Instead of always `unwrap()`ing `CString`s (and risking panics),
  handle NulError in one of two ways:
 * Return an `SdlResult` or "no match" value when used with "getter"
   functions.
 * Remove nuls when used as displayed strings (e.g. Window titles).