### PR TITLE
GL context

### DIFF
--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -1101,6 +1101,17 @@ pub unsafe fn gl_get_current_window() -> SdlResult<Window> {
     }
 }
 
+/// Releases the thread's current OpenGL context, i.e. sets the current OpenGL context to nothing.
+pub fn gl_release_current_context() -> SdlResult<()> {
+    let result = unsafe { ll::SDL_GL_MakeCurrent(ptr::null_mut(), ptr::null()) };
+
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(get_error())
+    }
+}
+
 pub fn gl_set_swap_interval(interval: i32) -> bool {
     unsafe { ll::SDL_GL_SetSwapInterval(interval as c_int) == 0 }
 }


### PR DESCRIPTION
For glium and [`glium_sdl2`](https://github.com/nukep/glium-sdl2) — shameless plug :) —, it's required to check if an OpenGL context is the current one in the thread. Using `context == gl_get_current_context()` doesn't work because the `owned` fields would always be different.

I removed `gl_get_current_context()` to guarantee unique OpenGL context objects that always get deleted, but its functionality lives on in `GLContext::is_current()` and `Window::gl_set_context_to_current()`.