### PR TITLE
Move drawer methods into Renderer

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -14,10 +14,9 @@ pub fn main() {
 
     let mut renderer = window.renderer().build().unwrap();
 
-    let mut drawer = renderer.drawer();
-    drawer.set_draw_color(Color::RGB(255, 0, 0));
-    drawer.clear();
-    drawer.present();
+    renderer.set_draw_color(Color::RGB(255, 0, 0));
+    renderer.clear();
+    renderer.present();
 
     let mut running = true;
 

--- a/examples/renderer-texture.rs
+++ b/examples/renderer-texture.rs
@@ -28,11 +28,10 @@ pub fn main() {
         }
     }).unwrap();
 
-    let mut drawer = renderer.drawer();
-    drawer.clear();
-    drawer.copy(&texture, None, Some(Rect::new(100, 100, 256, 256)));
-    drawer.copy_ex(&texture, None, Some(Rect::new(450, 100, 256, 256)), 30.0, None, (false, false));
-    drawer.present();
+    renderer.clear();
+    renderer.copy(&texture, None, Some(Rect::new(100, 100, 256, 256)));
+    renderer.copy_ex(&texture, None, Some(Rect::new(450, 100, 256, 256)), 30.0, None, (false, false));
+    renderer.present();
 
     let mut running = true;
 

--- a/examples/renderer-yuv.rs
+++ b/examples/renderer-yuv.rs
@@ -45,10 +45,9 @@ pub fn main() {
         }
     }).unwrap();
 
-    let mut drawer = renderer.drawer();
-    drawer.clear();
-    drawer.copy(&texture, None, Some(Rect::new(100, 100, 256, 256)));
-    drawer.present();
+    renderer.clear();
+    renderer.copy(&texture, None, Some(Rect::new(100, 100, 256, 256)));
+    renderer.present();
 
     let mut running = true;
 

--- a/examples/window-properties.rs
+++ b/examples/window-properties.rs
@@ -44,9 +44,8 @@ pub fn main() {
             tick += 1;
         }
 
-        let mut drawer = renderer.drawer();
-        drawer.set_draw_color(Color::RGB(0, 0, 0));
-        drawer.clear();
-        drawer.present();
+        renderer.set_draw_color(Color::RGB(0, 0, 0));
+        renderer.clear();
+        renderer.present();
     }
 }

--- a/src/sdl2/macros.rs
+++ b/src/sdl2/macros.rs
@@ -32,3 +32,28 @@ macro_rules! impl_raw_constructor(
         )+
     )
 );
+
+/// Many SDL functions will accept `int` values, even if it doesn't make sense for the values to be negative.
+/// In the cases that SDL doesn't check negativity, passing negative values could be unsafe.
+/// For example, `SDL_JoystickGetButton` uses the index argument to access an array without checking if it's negative,
+/// which could potentially lead to segmentation faults.
+macro_rules! u32_to_int(
+    ($value:expr) => (
+        if $value >= 1<<31 { Err(format!("`{}` is out of bounds.", stringify!($value))) }
+        else { Ok($value as ::libc::c_int) }
+    )
+);
+
+macro_rules! usize_to_int(
+    ($value:expr) => (
+        if $value >= 1<<31 { Err(format!("`{}` is out of bounds.", stringify!($value))) }
+        else { Ok($value as ::libc::c_int) }
+    )
+);
+
+macro_rules! int_to_u32(
+    ($value:expr) => (
+        if $value < 0 { Err(format!("`{}` is out of bounds.", stringify!($value))) }
+        else { Ok($value as u32) }
+    )
+);


### PR DESCRIPTION
Closes #411 

The methods from `RenderDrawer` have been moved into `Renderer`.

As well as with the upcoming "controller" pull request, I'm attempting to convert `i32` (`int`) values into `u32` values wherever negative values don't make sense (such as width, height, counts and indices). This is explained further in src/sdl2/macros.rs.