### PR TITLE
Controller stuff

### DIFF
--- a/src/sdl2/controller.rs
+++ b/src/sdl2/controller.rs
@@ -1,4 +1,4 @@
-use libc::{c_int, c_char};
+use libc::c_char;
 use std::ffi::{CString, CStr};
 
 use SdlResult;
@@ -12,7 +12,6 @@ use sys::event::{SDL_QUERY, SDL_ENABLE};
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 #[repr(i32)]
 pub enum Axis {
-    Invalid      = ll::SDL_CONTROLLER_AXIS_INVALID,
     LeftX        = ll::SDL_CONTROLLER_AXIS_LEFTX,
     LeftY        = ll::SDL_CONTROLLER_AXIS_LEFTY,
     RightX       = ll::SDL_CONTROLLER_AXIS_RIGHTX,
@@ -24,14 +23,14 @@ pub enum Axis {
 impl Axis {
     /// Return the Axis from a string description in the same format
     /// used by the game controller mapping strings.
-    pub fn from_string(axis: &str) -> Axis {
+    pub fn from_string(axis: &str) -> Option<Axis> {
         let id = match CString::new(axis) {
             Ok(axis) => unsafe { ll::SDL_GameControllerGetAxisFromString(axis.as_ptr()) },
             // string contains a nul byte - it won't match anything.
             Err(_) => ll::SDL_CONTROLLER_AXIS_INVALID
         };
 
-        wrap_controller_axis(id as u8)
+        Axis::from_ll(id)
     }
 
     /// Return a string for a given axis in the same format using by
@@ -43,24 +42,24 @@ impl Axis {
 
         c_str_to_string(string)
     }
-}
 
-pub fn wrap_controller_axis(bitflags: u8) -> Axis {
-    match bitflags as c_int {
-        ll::SDL_CONTROLLER_AXIS_LEFTX        => Axis::LeftX,
-        ll::SDL_CONTROLLER_AXIS_LEFTY        => Axis::LeftY,
-        ll::SDL_CONTROLLER_AXIS_RIGHTX       => Axis::RightX,
-        ll::SDL_CONTROLLER_AXIS_RIGHTY       => Axis::RightY,
-        ll::SDL_CONTROLLER_AXIS_TRIGGERLEFT  => Axis::TriggerLeft,
-        ll::SDL_CONTROLLER_AXIS_TRIGGERRIGHT => Axis::TriggerRight,
-        _ => panic!("unhandled controller axis")
+    pub fn from_ll(bitflags: ll::SDL_GameControllerAxis) -> Option<Axis> {
+        Some(match bitflags {
+            ll::SDL_CONTROLLER_AXIS_INVALID      => return None,
+            ll::SDL_CONTROLLER_AXIS_LEFTX        => Axis::LeftX,
+            ll::SDL_CONTROLLER_AXIS_LEFTY        => Axis::LeftY,
+            ll::SDL_CONTROLLER_AXIS_RIGHTX       => Axis::RightX,
+            ll::SDL_CONTROLLER_AXIS_RIGHTY       => Axis::RightY,
+            ll::SDL_CONTROLLER_AXIS_TRIGGERLEFT  => Axis::TriggerLeft,
+            ll::SDL_CONTROLLER_AXIS_TRIGGERRIGHT => Axis::TriggerRight,
+            _ => panic!("unhandled controller axis")
+        })
     }
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 #[repr(i32)]
 pub enum Button {
-    Invalid       = ll::SDL_CONTROLLER_BUTTON_INVALID,
     A             = ll::SDL_CONTROLLER_BUTTON_A,
     B             = ll::SDL_CONTROLLER_BUTTON_B,
     X             = ll::SDL_CONTROLLER_BUTTON_X,
@@ -81,14 +80,14 @@ pub enum Button {
 impl Button {
     /// Return the Button from a string description in the same format
     /// used by the game controller mapping strings.
-    pub fn from_string(button: &str) -> Button {
+    pub fn from_string(button: &str) -> Option<Button> {
         let id = match CString::new(button) {
             Ok(button) => unsafe { ll::SDL_GameControllerGetButtonFromString(button.as_ptr()) },
             // string contains a nul byte - it won't match anything.
             Err(_) => ll::SDL_CONTROLLER_BUTTON_INVALID
         };
 
-        wrap_controller_button(id as u8)
+        Button::from_ll(id)
     }
 
     /// Return a string for a given button in the same format using by
@@ -100,26 +99,27 @@ impl Button {
 
         c_str_to_string(string)
     }
-}
 
-pub fn wrap_controller_button(bitflags: u8) -> Button {
-    match bitflags as c_int {
-        ll::SDL_CONTROLLER_BUTTON_A             => Button::A,
-        ll::SDL_CONTROLLER_BUTTON_B             => Button::B,
-        ll::SDL_CONTROLLER_BUTTON_X             => Button::X,
-        ll::SDL_CONTROLLER_BUTTON_Y             => Button::Y,
-        ll::SDL_CONTROLLER_BUTTON_BACK          => Button::Back,
-        ll::SDL_CONTROLLER_BUTTON_GUIDE         => Button::Guide,
-        ll::SDL_CONTROLLER_BUTTON_START         => Button::Start,
-        ll::SDL_CONTROLLER_BUTTON_LEFTSTICK     => Button::LeftStick,
-        ll::SDL_CONTROLLER_BUTTON_RIGHTSTICK    => Button::RightStick,
-        ll::SDL_CONTROLLER_BUTTON_LEFTSHOULDER  => Button::LeftShoulder,
-        ll::SDL_CONTROLLER_BUTTON_RIGHTSHOULDER => Button::RightShoulder,
-        ll::SDL_CONTROLLER_BUTTON_DPAD_UP       => Button::DPadUp,
-        ll::SDL_CONTROLLER_BUTTON_DPAD_DOWN     => Button::DPadDown,
-        ll::SDL_CONTROLLER_BUTTON_DPAD_LEFT     => Button::DPadLeft,
-        ll::SDL_CONTROLLER_BUTTON_DPAD_RIGHT    => Button::DPadRight,
-        _ => panic!("unhandled controller button")
+    pub fn from_ll(bitflags: ll::SDL_GameControllerButton) -> Option<Button> {
+        Some(match bitflags {
+            ll::SDL_CONTROLLER_BUTTON_INVALID       => return None,
+            ll::SDL_CONTROLLER_BUTTON_A             => Button::A,
+            ll::SDL_CONTROLLER_BUTTON_B             => Button::B,
+            ll::SDL_CONTROLLER_BUTTON_X             => Button::X,
+            ll::SDL_CONTROLLER_BUTTON_Y             => Button::Y,
+            ll::SDL_CONTROLLER_BUTTON_BACK          => Button::Back,
+            ll::SDL_CONTROLLER_BUTTON_GUIDE         => Button::Guide,
+            ll::SDL_CONTROLLER_BUTTON_START         => Button::Start,
+            ll::SDL_CONTROLLER_BUTTON_LEFTSTICK     => Button::LeftStick,
+            ll::SDL_CONTROLLER_BUTTON_RIGHTSTICK    => Button::RightStick,
+            ll::SDL_CONTROLLER_BUTTON_LEFTSHOULDER  => Button::LeftShoulder,
+            ll::SDL_CONTROLLER_BUTTON_RIGHTSHOULDER => Button::RightShoulder,
+            ll::SDL_CONTROLLER_BUTTON_DPAD_UP       => Button::DPadUp,
+            ll::SDL_CONTROLLER_BUTTON_DPAD_DOWN     => Button::DPadDown,
+            ll::SDL_CONTROLLER_BUTTON_DPAD_LEFT     => Button::DPadLeft,
+            ll::SDL_CONTROLLER_BUTTON_DPAD_RIGHT    => Button::DPadRight,
+            _ => panic!("unhandled controller button")
+        })
     }
 }
 

--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -728,7 +728,7 @@ impl Event {
 
             EventType::ControllerAxisMotion => {
                 let ref event = *raw.caxis();
-                let axis = controller::wrap_controller_axis(event.axis);
+                let axis = controller::Axis::from_ll(event.axis as ::sys::controller::SDL_GameControllerAxis).unwrap();
 
                 Event::ControllerAxisMotion {
                     timestamp: event.timestamp,
@@ -739,7 +739,7 @@ impl Event {
             }
             EventType::ControllerButtonDown => {
                 let ref event = *raw.cbutton();
-                let button = controller::wrap_controller_button(event.button);
+                let button = controller::Button::from_ll(event.button as ::sys::controller::SDL_GameControllerButton).unwrap();
 
                 Event::ControllerButtonDown {
                     timestamp: event.timestamp,
@@ -749,7 +749,7 @@ impl Event {
             }
             EventType::ControllerButtonUp => {
                 let ref event = *raw.cbutton();
-                let button = controller::wrap_controller_button(event.button);
+                let button = controller::Button::from_ll(event.button as ::sys::controller::SDL_GameControllerButton).unwrap();
 
                 Event::ControllerButtonUp {
                     timestamp: event.timestamp,

--- a/src/sdl2/joystick.rs
+++ b/src/sdl2/joystick.rs
@@ -88,41 +88,46 @@ impl Joystick {
         unsafe { ll::SDL_JoystickGetAttached(self.raw) != 0 }
     }
 
-    pub fn get_instance_id(&self) -> SdlResult<i32> {
+    pub fn get_instance_id(&self) -> i32 {
         let result = unsafe { ll::SDL_JoystickInstanceID(self.raw) };
 
         if result < 0 {
-            Err(get_error())
+            // Should only fail if the joystick is NULL.
+            panic!(get_error())
         } else {
-            Ok(result)
+            result
         }
     }
 
     /// Retreive the joystick's GUID
-    pub fn get_guid(&self) -> SdlResult<Guid> {
+    pub fn get_guid(&self) -> Guid {
         let raw = unsafe { ll::SDL_JoystickGetGUID(self.raw) };
 
         let guid = Guid { raw: raw };
 
         if guid.is_zero() {
-            Err(get_error())
+            // Should only fail if the joystick is NULL.
+            panic!(get_error())
         } else {
-            Ok(guid)
+            guid
         }
     }
 
     /// Retreive the number of axes for this joystick
-    pub fn get_num_axis(&self) -> SdlResult<i32> {
+    pub fn get_num_axes(&self) -> i32 {
         let result = unsafe { ll::SDL_JoystickNumAxes(self.raw) };
 
         if result < 0 {
-            Err(get_error())
+            // Should only fail if the joystick is NULL.
+            panic!(get_error())
         } else {
-            Ok(result)
+            result
         }
     }
 
-    /// Get the position of the given `axis`
+    /// Gets the position of the given `axis`.
+    ///
+    /// The function will fail if the joystick doesn't have the provided axis.
     pub fn get_axis(&self, axis: i32) -> SdlResult<i16> {
         // This interface is a bit messed up: 0 is a valid position
         // but can also mean that an error occured. As far as I can
@@ -146,24 +151,26 @@ impl Joystick {
     }
 
     /// Retreive the number of buttons for this joystick
-    pub fn get_num_buttons(&self) -> SdlResult<i32> {
+    pub fn get_num_buttons(&self) -> i32 {
         let result = unsafe { ll::SDL_JoystickNumButtons(self.raw) };
 
         if result < 0 {
-            Err(get_error())
+            // Should only fail if the joystick is NULL.
+            panic!(get_error())
         } else {
-            Ok(result)
+            result
         }
     }
 
     /// Return `Ok(true)` if `button` is pressed.
+    ///
+    /// The function will fail if the joystick doesn't have the provided button.
     pub fn get_button(&self, button: i32) -> SdlResult<bool> {
         // Same deal as get_axis, 0 can mean both unpressed or
         // error...
         clear_error();
 
-        let pressed =
-            unsafe { ll::SDL_JoystickGetButton(self.raw, button) };
+        let pressed = unsafe { ll::SDL_JoystickGetButton(self.raw, button) };
 
         match pressed {
             1 => Ok(true),
@@ -183,13 +190,14 @@ impl Joystick {
     }
 
     /// Retreive the number of balls for this joystick
-    pub fn get_num_balls(&self) -> SdlResult<i32> {
+    pub fn get_num_balls(&self) -> i32 {
         let result = unsafe { ll::SDL_JoystickNumBalls(self.raw) };
 
         if result < 0 {
-            Err(get_error())
+            // Should only fail if the joystick is NULL.
+            panic!(get_error())
         } else {
-            Ok(result)
+            result
         }
     }
 
@@ -212,13 +220,14 @@ impl Joystick {
     }
 
     /// Retreive the number of balls for this joystick
-    pub fn get_num_hats(&self) -> SdlResult<i32> {
+    pub fn get_num_hats(&self) -> i32 {
         let result = unsafe { ll::SDL_JoystickNumHats(self.raw) };
 
         if result < 0 {
-            Err(get_error())
+            // Should only fail if the joystick is NULL.
+            panic!(get_error())
         } else {
-            Ok(result)
+            result
         }
     }
 

--- a/src/sdl2/joystick.rs
+++ b/src/sdl2/joystick.rs
@@ -114,27 +114,28 @@ impl Joystick {
     }
 
     /// Retreive the number of axes for this joystick
-    pub fn get_num_axes(&self) -> i32 {
+    pub fn get_num_axes(&self) -> u32 {
         let result = unsafe { ll::SDL_JoystickNumAxes(self.raw) };
 
         if result < 0 {
             // Should only fail if the joystick is NULL.
             panic!(get_error())
         } else {
-            result
+            result as u32
         }
     }
 
     /// Gets the position of the given `axis`.
     ///
     /// The function will fail if the joystick doesn't have the provided axis.
-    pub fn get_axis(&self, axis: i32) -> SdlResult<i16> {
+    pub fn get_axis(&self, axis: u32) -> SdlResult<i16> {
         // This interface is a bit messed up: 0 is a valid position
         // but can also mean that an error occured. As far as I can
         // tell the only way to know if an error happened is to see if
         // get_error() returns a non-empty string.
         clear_error();
 
+        let axis = try!(u32_to_int!(axis));
         let pos = unsafe { ll::SDL_JoystickGetAxis(self.raw, axis) };
 
         if pos != 0 {
@@ -151,25 +152,26 @@ impl Joystick {
     }
 
     /// Retreive the number of buttons for this joystick
-    pub fn get_num_buttons(&self) -> i32 {
+    pub fn get_num_buttons(&self) -> u32 {
         let result = unsafe { ll::SDL_JoystickNumButtons(self.raw) };
 
         if result < 0 {
             // Should only fail if the joystick is NULL.
             panic!(get_error())
         } else {
-            result
+            result as u32
         }
     }
 
     /// Return `Ok(true)` if `button` is pressed.
     ///
     /// The function will fail if the joystick doesn't have the provided button.
-    pub fn get_button(&self, button: i32) -> SdlResult<bool> {
+    pub fn get_button(&self, button: u32) -> SdlResult<bool> {
         // Same deal as get_axis, 0 can mean both unpressed or
         // error...
         clear_error();
 
+        let button = try!(u32_to_int!(button));
         let pressed = unsafe { ll::SDL_JoystickGetButton(self.raw, button) };
 
         match pressed {
@@ -190,27 +192,25 @@ impl Joystick {
     }
 
     /// Retreive the number of balls for this joystick
-    pub fn get_num_balls(&self) -> i32 {
+    pub fn get_num_balls(&self) -> u32 {
         let result = unsafe { ll::SDL_JoystickNumBalls(self.raw) };
 
         if result < 0 {
             // Should only fail if the joystick is NULL.
             panic!(get_error())
         } else {
-            result
+            result as u32
         }
     }
 
     /// Return a pair `(dx, dy)` containing the difference in axis
     /// position since the last poll
-    pub fn get_ball(&self, ball: i32) -> SdlResult<(i32, i32)> {
+    pub fn get_ball(&self, ball: u32) -> SdlResult<(i32, i32)> {
         let mut dx = 0;
         let mut dy = 0;
 
-        let result =
-            unsafe {
-                ll::SDL_JoystickGetBall(self.raw, ball, &mut dx, &mut dy)
-            };
+        let ball = try!(u32_to_int!(ball));
+        let result = unsafe { ll::SDL_JoystickGetBall(self.raw, ball, &mut dx, &mut dy) };
 
         if result == 0 {
             Ok((dx, dy))
@@ -220,24 +220,25 @@ impl Joystick {
     }
 
     /// Retreive the number of balls for this joystick
-    pub fn get_num_hats(&self) -> i32 {
+    pub fn get_num_hats(&self) -> u32 {
         let result = unsafe { ll::SDL_JoystickNumHats(self.raw) };
 
         if result < 0 {
             // Should only fail if the joystick is NULL.
             panic!(get_error())
         } else {
-            result
+            result as u32
         }
     }
 
     /// Return the position of `hat` for this joystick
-    pub fn get_hat(&self, hat: i32) -> SdlResult<HatState> {
+    pub fn get_hat(&self, hat: u32) -> SdlResult<HatState> {
         // Guess what? This function as well uses 0 to report an error
         // but 0 is also a valid value (HatState::Centered). So we
         // have to use the same hack as `get_axis`...
         clear_error();
 
+        let hat = try!(u32_to_int!(hat));
         let result = unsafe { ll::SDL_JoystickGetHat(self.raw, hat) };
 
         let state = HatState::from_raw(result as u8);

--- a/src/sdl2/macros.rs
+++ b/src/sdl2/macros.rs
@@ -32,3 +32,28 @@ macro_rules! impl_raw_constructor(
         )+
     )
 );
+
+/// Many SDL functions will accept `int` values, even if it doesn't make sense for the values to be negative.
+/// In the cases that SDL doesn't check negativity, passing negative values could be unsafe.
+/// For example, `SDL_JoystickGetButton` uses the index argument to access an array without checking if it's negative,
+/// which could potentially lead to segmentation faults.
+macro_rules! u32_to_int(
+    ($value:expr) => (
+        if $value >= 1<<31 { Err(format!("`{}` is out of bounds.", stringify!($value))) }
+        else { Ok($value as ::libc::c_int) }
+    )
+);
+
+macro_rules! usize_to_int(
+    ($value:expr) => (
+        if $value >= 1<<31 { Err(format!("`{}` is out of bounds.", stringify!($value))) }
+        else { Ok($value as ::libc::c_int) }
+    )
+);
+
+macro_rules! int_to_u32(
+    ($value:expr) => (
+        if $value < 0 { Err(format!("`{}` is out of bounds.", stringify!($value))) }
+        else { Ok($value as u32) }
+    )
+);


### PR DESCRIPTION
Throughout the library, I'd like to replace all "non-value" enum variants (the "Nones", "Invalids", etc.) with `Option::None`.
Constants such as `SDL_CONTROLLER_AXIS_INVALID` exist to communicate errors to the caller, yet they aren't polymorphic to the other variants; `Axis::Invalid` must be ignored or treated differently from the other axes because it doesn't indicate a "real" axis. This is basically a rewording of the "null" problem.

`-> SdlResult<T>` is changed to `-> T` for functions that cannot fail.

As well as with the "renderer" pull request, I'm attempting to convert i32 (int) values into u32 values wherever negative values don't make sense (such as width, height, counts and indices). This is explained further in src/sdl2/macros.rs.