### PR TITLE
Adding documentation links

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@
 name    = "sdl2"
 description = "SDL2 bindings for Rust"
 repository = "https://github.com/AngryLawyer/rust-sdl2"
+documentation = "http://www.rust-ci.org/AngryLawyer/rust-sdl2/doc/sdl2/"
 version = "0.5.0"
 license = "MIT"
 authors = [ "Tony Aldridge <tony@angry-lawyer.com>" ]

--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ Rust-SDL2 uses the MIT license.
 If you want a library compatible with earlier versions of SDL, please see
 [here][early-sdl]
 
+# DOCUMENTATION
+
+* [http://www.rust-ci.org/AngryLawyer/rust-sdl2/doc/sdl2/](http://www.rust-ci.org/AngryLawyer/rust-sdl2/doc/sdl2/)
+
+
 ## Where are SDL_image, SDL_mixer, and SDL_ttf?
 
 These live outside of the repo.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Rust-SDL2 uses the MIT license.
 If you want a library compatible with earlier versions of SDL, please see
 [here][early-sdl]
 
-# DOCUMENTATION
+# Documentation
 
 * [http://www.rust-ci.org/AngryLawyer/rust-sdl2/doc/sdl2/](http://www.rust-ci.org/AngryLawyer/rust-sdl2/doc/sdl2/)
 


### PR DESCRIPTION
Helpful to have a link to the documentation from the Crates page, and GitHub README.