### PR TITLE
Remove the "owned" flag from all types

### DIFF
--- a/sdl2-sys/src/surface.rs
+++ b/sdl2-sys/src/surface.rs
@@ -64,9 +64,9 @@ extern "C" {
     pub fn SDL_ConvertPixels(width: c_int, height: c_int, src_format: uint32_t, src: *const c_void, src_pitch: c_int, dst_format: uint32_t, dst: *mut c_void, dst_pitch: c_int) -> c_int;
     pub fn SDL_FillRect(dst: *mut SDL_Surface, rect: *const SDL_Rect, color: uint32_t) -> c_int;
     pub fn SDL_FillRects(dst: *mut SDL_Surface, rects: *const SDL_Rect, count: c_int, color: uint32_t) -> c_int;
-    pub fn SDL_UpperBlit(src: *mut SDL_Surface, srcrect: *mut SDL_Rect, dst: *mut SDL_Surface, dstrect: *mut SDL_Rect) -> c_int;
+    pub fn SDL_UpperBlit(src: *mut SDL_Surface, srcrect: *const SDL_Rect, dst: *mut SDL_Surface, dstrect: *mut SDL_Rect) -> c_int;
     pub fn SDL_LowerBlit(src: *mut SDL_Surface, srcrect: *mut SDL_Rect, dst: *mut SDL_Surface, dstrect: *mut SDL_Rect) -> c_int;
     pub fn SDL_SoftStretch(src: *mut SDL_Surface, srcrect: *mut SDL_Rect, dst: *mut SDL_Surface, dstrect: *mut SDL_Rect) -> c_int;
-    pub fn SDL_UpperBlitScaled(src: *mut SDL_Surface, srcrect: *mut SDL_Rect, dst: *mut SDL_Surface, dstrect: *mut SDL_Rect) -> c_int;
+    pub fn SDL_UpperBlitScaled(src: *mut SDL_Surface, srcrect: *const SDL_Rect, dst: *mut SDL_Surface, dstrect: *mut SDL_Rect) -> c_int;
     pub fn SDL_LowerBlitScaled(src: *mut SDL_Surface, srcrect: *mut SDL_Rect, dst: *mut SDL_Surface, dstrect: *mut SDL_Rect) -> c_int;
 }

--- a/sdl2-sys/src/surface.rs
+++ b/sdl2-sys/src/surface.rs
@@ -33,7 +33,10 @@ pub struct SDL_Surface {
     pub lock_data: *mut c_void,
     pub clip_rect: SDL_Rect,
     pub map: *mut SDL_BlitMap,
-    pub refcount: c_int
+    pub refcount: c_int,
+
+    // Make the type a DST. The size of the struct could change in later SDL2 releases.
+    pub _unsized: [()]
 }
 
 extern "C" {

--- a/src/sdl2/keyboard/mod.rs
+++ b/src/sdl2/keyboard/mod.rs
@@ -30,12 +30,13 @@ bitflags! {
     }
 }
 
-pub fn get_keyboard_focus() -> Option<Window> {
+pub fn get_focused_window_id() -> Option<u32> {
     let raw = unsafe { ll::SDL_GetKeyboardFocus() };
     if raw == ptr::null_mut() {
         None
     } else {
-        unsafe { Some(Window::from_ll(raw, false)) }
+        let id = unsafe { ::sys::video::SDL_GetWindowID(raw) };
+        Some(id)
     }
 }
 

--- a/src/sdl2/macros.rs
+++ b/src/sdl2/macros.rs
@@ -9,17 +9,6 @@ macro_rules! impl_raw_accessors(
     )
 );
 
-macro_rules! impl_owned_accessors(
-    ($(($t:ty, $owned:ident)),+) => (
-        $(
-        impl $t {
-            #[inline]
-            pub unsafe fn $owned(&self) -> bool { self.$owned }
-        }
-        )+
-    )
-);
-
 macro_rules! impl_raw_constructor(
     ($(($t:ty, $te:ident ($($r:ident:$rt:ty),+))),+) => (
         $(

--- a/src/sdl2/mouse.rs
+++ b/src/sdl2/mouse.rs
@@ -2,7 +2,7 @@ use std::ptr;
 
 use get_error;
 use SdlResult;
-use surface;
+use surface::SurfaceRef;
 use video;
 
 use sys::mouse as ll;
@@ -52,9 +52,9 @@ impl Cursor {
     }
 
     // TODO: figure out how to pass Surface in here correctly
-    pub fn from_surface(surface: &surface::Surface, hot_x: i32, hot_y: i32) -> SdlResult<Cursor> {
+    pub fn from_surface<S: AsRef<SurfaceRef>>(surface: S, hot_x: i32, hot_y: i32) -> SdlResult<Cursor> {
         unsafe {
-            let raw = ll::SDL_CreateColorCursor(surface.raw(), hot_x, hot_y);
+            let raw = ll::SDL_CreateColorCursor(surface.as_ref().raw(), hot_x, hot_y);
 
             if raw == ptr::null_mut() {
                 Err(get_error())

--- a/src/sdl2/mouse.rs
+++ b/src/sdl2/mouse.rs
@@ -25,17 +25,13 @@ pub enum SystemCursor {
 }
 
 pub struct Cursor {
-    raw: *mut ll::SDL_Cursor,
-    owned: bool
+    raw: *mut ll::SDL_Cursor
 }
 
 impl Drop for Cursor {
+    #[inline]
     fn drop(&mut self) {
-        if self.owned {
-            unsafe {
-                ll::SDL_FreeCursor(self.raw);
-            }
-        }
+        unsafe { ll::SDL_FreeCursor(self.raw) };
     }
 }
 
@@ -50,7 +46,7 @@ impl Cursor {
             if raw == ptr::null_mut() {
                 Err(get_error())
             } else {
-                Ok(Cursor{ raw: raw, owned: true })
+                Ok(Cursor{ raw: raw })
             }
         }
     }
@@ -63,7 +59,7 @@ impl Cursor {
             if raw == ptr::null_mut() {
                 Err(get_error())
             } else {
-                Ok(Cursor{ raw: raw, owned: true })
+                Ok(Cursor{ raw: raw })
             }
         }
     }
@@ -75,7 +71,7 @@ impl Cursor {
             if raw == ptr::null_mut() {
                 Err(get_error())
             } else {
-                Ok(Cursor{ raw: raw, owned: true })
+                Ok(Cursor{ raw: raw })
             }
         }
     }
@@ -186,26 +182,6 @@ pub fn set_relative_mouse_mode(on: bool) {
 
 pub fn get_relative_mouse_mode() -> bool {
     unsafe { ll::SDL_GetRelativeMouseMode() == 1 }
-}
-
-pub fn get_cursor() -> Option<Cursor> {
-    let raw = unsafe { ll::SDL_GetCursor() };
-
-    if raw == ptr::null_mut() {
-        None
-    } else {
-        Some(Cursor { raw: raw, owned: false })
-    }
-}
-
-pub fn get_default_cursor() -> Option<Cursor> {
-    let raw = unsafe { ll::SDL_GetDefaultCursor() };
-
-    if raw == ptr::null_mut() {
-        None
-    } else {
-        Some(Cursor { raw: raw, owned: false })
-    }
 }
 
 pub fn is_cursor_showing() -> bool {

--- a/src/sdl2/mouse.rs
+++ b/src/sdl2/mouse.rs
@@ -148,12 +148,13 @@ pub fn wrap_mouse(bitflags: u8) -> Mouse {
     }
 }
 
-pub fn get_mouse_focus() -> Option<video::Window> {
+pub fn get_focused_window_id() -> Option<u32> {
     let raw = unsafe { ll::SDL_GetMouseFocus() };
     if raw == ptr::null_mut() {
         None
     } else {
-        unsafe { Some(video::Window::from_ll(raw, false)) }
+        let id = unsafe { ::sys::video::SDL_GetWindowID(raw) };
+        Some(id)
     }
 }
 

--- a/src/sdl2/rect.rs
+++ b/src/sdl2/rect.rs
@@ -1,5 +1,6 @@
 use sys::rect as ll;
 use std::mem;
+use std::ptr;
 use std::ops::{BitAnd, BitOr};
 
 use SdlResult;
@@ -83,6 +84,22 @@ impl Into<(i32, i32, u32, u32)> for Rect {
 impl Rect {
     #[inline]
     pub fn raw(&self) -> *const ll::SDL_Rect { &self.raw }
+
+    #[inline]
+    pub fn raw_from_option(v: Option<&Rect>) -> *const ll::SDL_Rect {
+        match v {
+            Some(ref r) => r.raw(),
+            None => ptr::null()
+        }
+    }
+
+    #[inline]
+    pub fn raw_mut_from_option(v: Option<&mut Rect>) -> *mut ll::SDL_Rect {
+        match v {
+            Some(ref r) => r.raw() as *mut _,
+            None => ptr::null_mut()
+        }
+    }
 
     #[inline]
     pub fn raw_slice(slice: &[Rect]) -> *const ll::SDL_Rect {

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -31,7 +31,7 @@
 use Sdl;
 use video::{Window, WindowProperties, WindowPropertiesGetters};
 use surface;
-use surface::Surface;
+use surface::{Surface, SurfaceRef};
 use pixels;
 use pixels::PixelFormatEnum;
 use get_error;
@@ -256,7 +256,7 @@ impl<'a> Renderer<'a> {
     }
 
     #[inline]
-    pub fn get_parent_as_surface(&self) -> Option<&Surface> {
+    pub fn get_parent_as_surface(&self) -> Option<&SurfaceRef> {
         match self.get_parent() {
             &RendererParent::Surface(ref surface) => Some(surface),
             _ => None
@@ -365,8 +365,8 @@ impl<'a> Renderer<'a> {
     /// Creates a texture from an existing surface.
     /// # Remarks
     /// The access hint for the created texture is `TextureAccess::Static`.
-    pub fn create_texture_from_surface(&self, surface: &surface::Surface) -> SdlResult<Texture> {
-        let result = unsafe { ll::SDL_CreateTextureFromSurface(self.raw, surface.raw()) };
+    pub fn create_texture_from_surface<S: AsRef<SurfaceRef>>(&self, surface: S) -> SdlResult<Texture> {
+        let result = unsafe { ll::SDL_CreateTextureFromSurface(self.raw, surface.as_ref().raw()) };
         if result == ptr::null_mut() {
             Err(get_error())
         } else {

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -8,7 +8,7 @@ use std::vec::Vec;
 
 use rect::Rect;
 use render::RendererBuilder;
-use surface::{Surface, SurfaceRef};
+use surface::SurfaceRef;
 use pixels;
 use Sdl;
 use SdlResult;
@@ -720,8 +720,8 @@ impl<'a> WindowProperties<'a> {
         }
     }
 
-    pub fn set_icon(&mut self, icon: &Surface) {
-        unsafe { ll::SDL_SetWindowIcon(self.raw, icon.raw()) }
+    pub fn set_icon<S: AsRef<SurfaceRef>>(&mut self, icon: S) {
+        unsafe { ll::SDL_SetWindowIcon(self.raw, icon.as_ref().raw()) }
     }
 
     //pub fn SDL_SetWindowData(window: *SDL_Window, name: *c_char, userdata: *c_void) -> *c_void; //TODO: Figure out what this does

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -8,7 +8,7 @@ use std::vec::Vec;
 
 use rect::Rect;
 use render::RendererBuilder;
-use surface::Surface;
+use surface::{Surface, SurfaceRef};
 use pixels;
 use Sdl;
 use SdlResult;
@@ -838,13 +838,23 @@ impl<'a> WindowProperties<'a> {
         }
     }
 
-    pub fn get_surface(&mut self) -> SdlResult<Surface> {
+    pub fn get_surface(&self) -> SdlResult<&SurfaceRef> {
         let raw = unsafe { ll::SDL_GetWindowSurface(self.raw) };
 
-        if raw == ptr::null_mut() {
+        if (raw as *mut ()).is_null() {
             Err(get_error())
         } else {
-            unsafe { Ok(Surface::from_ll(raw, false)) } //Docs say that it releases with the window
+            unsafe { Ok(SurfaceRef::from_ll(raw)) }
+        }
+    }
+
+    pub fn get_surface_mut(&mut self) -> SdlResult<&mut SurfaceRef> {
+        let raw = unsafe { ll::SDL_GetWindowSurface(self.raw) };
+
+        if (raw as *mut ()).is_null() {
+            Err(get_error())
+        } else {
+            unsafe { Ok(SurfaceRef::from_ll_mut(raw)) }
         }
     }
 


### PR DESCRIPTION
"owned" has been removed from the remaining types: `Surface`, `Window`, and `Cursor`.

The "owned" flag in these types directly encourages type aliasing and ad-hoc borrowing, which is problematic. Whenever these types can be borrowed, it can be done with saner and much clearer semantics (i.e. with references + lifetimes!).

### `&SurfaceRef`

There's a method, `WindowProperties::get_surface()`, that borrows the window's surface. Because we maintain that `Surface` is solely used for _owned_ surfaces (ones that we free), a new "borrowed surface" type needed to be created: `SurfaceRef`. `SurfaceRef` is a DST whose reference transmutes cleanly to `*mut SDL_Surface`.

```rust
// OLD: fn WindowProperties::get_surface(&mut self) -> SdlResult<Surface>
fn WindowProperties::get_surface(&self) -> SdlResult<&SurfaceRef>
fn WindowProperties::get_surface_mut(&mut self) -> SdlResult<&mut SurfaceRef>
```

Most of `Surface`'s methods have been moved into `SurfaceRef`, but users won't notice this. `Surface` now implements `Deref` and `DerefMut`, so that any methods not in `Surface` will pass through to `SurfaceRef`.


### Removed/fixed functions

The following have all been removed/fixed:
```rust
fn WindowProperties::get_surface(&mut self) -> SdlResult<Surface>;
fn Window::from_id(id: u32) -> SdlResult<Window>;  // no replacement
fn gl_get_current_window() -> SdlResult<Window>;   // now gl_get_current_window_id()
fn get_mouse_focus() -> Option<Window>;            // now get_focused_window_id()
fn get_keyboard_focus() -> Option<Window>;         // now get_focused_window_id()
fn get_cursor() -> Option<Cursor>;                 // no replacement
fn get_default_cursor() -> Option<Cursor>;         // no replacement
```

To users of the library, the above functions appear to be giving us _owned values_. This is a lie. We don't want an API that lies to its users.