### PR TITLE
Check whether joystick is attached before freeing

### DIFF
--- a/src/sdl2/joystick.rs
+++ b/src/sdl2/joystick.rs
@@ -259,7 +259,9 @@ impl Joystick {
 
 impl Drop for Joystick {
     fn drop(&mut self) {
-        unsafe { ll::SDL_JoystickClose(self.raw) }
+        if self.get_attached() {
+            unsafe { ll::SDL_JoystickClose(self.raw) }
+        }
     }
 }
 


### PR DESCRIPTION
Fixes an error `malloc: *** error for object 0xa000000000000000:
pointer being freed was not allocated` when closing window.