### PR TITLE
Make `SurfaceRef` 0 bytes

### DIFF
--- a/sdl2-sys/src/surface.rs
+++ b/sdl2-sys/src/surface.rs
@@ -33,10 +33,7 @@ pub struct SDL_Surface {
     pub lock_data: *mut c_void,
     pub clip_rect: SDL_Rect,
     pub map: *mut SDL_BlitMap,
-    pub refcount: c_int,
-
-    // Make the type a DST. The size of the struct could change in later SDL2 releases.
-    pub _unsized: [()]
+    pub refcount: c_int
 }
 
 extern "C" {

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -819,7 +819,7 @@ impl<'a> WindowProperties<'a> {
     pub fn get_surface(&self) -> SdlResult<&SurfaceRef> {
         let raw = unsafe { ll::SDL_GetWindowSurface(self.raw) };
 
-        if (raw as *mut ()).is_null() {
+        if raw.is_null() {
             Err(get_error())
         } else {
             unsafe { Ok(SurfaceRef::from_ll(raw)) }
@@ -829,7 +829,7 @@ impl<'a> WindowProperties<'a> {
     pub fn get_surface_mut(&mut self) -> SdlResult<&mut SurfaceRef> {
         let raw = unsafe { ll::SDL_GetWindowSurface(self.raw) };
 
-        if (raw as *mut ()).is_null() {
+        if raw.is_null() {
             Err(get_error())
         } else {
             unsafe { Ok(SurfaceRef::from_ll_mut(raw)) }


### PR DESCRIPTION
In PR #435, I made `SDL_Surface` a DST. This is actually invalid because the resulting pointer `*mut SDL_Surface` became a fat pointer (i.e. 16 bytes instead of 8 on 64-bit targets).
Unsized types (as opposed to dynamically sized types) in Rust aren't currently possible.

To prevent partial swapping and memory corruption with `std::mem::swap()`, the structure is 0 bytes.
This shouldn't cause any problems, as `SurfaceRef` is always a reference to SDL-owned memory.