### PR TITLE
Remove WindowProperties, implement WindowRef

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,10 @@ Then you need to add this to add this initialization code to establish the
 bindings:
 
 ```rust
-    gl::load_with(sdl2::video::gl_get_proc_address);
+let sdl_context = sdl2::init().unwrap();
+let video_subsystem = sdl_context.video().unwrap();
+
+gl::load_with(|name| video_subsystem.gl_get_proc_address(name));
 ```
 
 Note that these bindings are very raw, and many of the calls will require

--- a/examples/audio-squarewave.rs
+++ b/examples/audio-squarewave.rs
@@ -1,6 +1,6 @@
 extern crate sdl2;
 
-use sdl2::audio::{AudioCallback, AudioDevice, AudioSpecDesired};
+use sdl2::audio::{AudioCallback, AudioSpecDesired};
 
 struct SquareWave {
     phase_inc: f32,
@@ -24,7 +24,8 @@ impl AudioCallback for SquareWave {
 }
 
 fn main() {
-    let _sdl_context = sdl2::init().audio().unwrap();
+    let sdl_context = sdl2::init().unwrap();
+    let audio_subsystem = sdl_context.audio().unwrap();
 
     let desired_spec = AudioSpecDesired {
         freq: Some(44100),
@@ -32,7 +33,7 @@ fn main() {
         samples: None       // default sample size
     };
 
-    let device = AudioDevice::open_playback(None, desired_spec, |spec| {
+    let device = audio_subsystem.open_playback(None, desired_spec, |spec| {
         // Show obtained AudioSpec
         println!("{:?}", spec);
 
@@ -48,7 +49,7 @@ fn main() {
     device.resume();
 
     // Play for 2 seconds
-    sdl2::timer::delay(2000);
+    std::thread::sleep_ms(2000);
 
     // Device is automatically closed when dropped
 }

--- a/examples/audio-whitenoise.rs
+++ b/examples/audio-whitenoise.rs
@@ -1,7 +1,7 @@
 extern crate sdl2;
 extern crate rand;
 
-use sdl2::audio::{AudioCallback, AudioDevice, AudioSpecDesired};
+use sdl2::audio::{AudioCallback, AudioSpecDesired};
 
 struct MyCallback {
     volume: f32
@@ -21,7 +21,8 @@ impl AudioCallback for MyCallback {
 }
 
 fn main() {
-    let _sdl_context = sdl2::init().audio().unwrap();
+    let sdl_context = sdl2::init().unwrap();
+    let audio_subsystem = sdl_context.audio().unwrap();
 
     let desired_spec = AudioSpecDesired {
         freq: Some(44100),
@@ -30,7 +31,7 @@ fn main() {
     };
 
     // None: use default device
-    let mut device = AudioDevice::open_playback(None, desired_spec, |spec| {
+    let mut device = audio_subsystem.open_playback(None, desired_spec, |spec| {
         // Show obtained AudioSpec
         println!("{:?}", spec);
 
@@ -41,7 +42,7 @@ fn main() {
     device.resume();
 
     // Play for 1 second
-    sdl2::timer::delay(1000);
+    std::thread::sleep_ms(1000);
 
     {
         // Acquire a lock. This lets us read and modify callback data.
@@ -51,7 +52,7 @@ fn main() {
     }
 
     // Play for another second
-    sdl2::timer::delay(1000);
+    std::thread::sleep_ms(1000);
 
     // Device is automatically closed when dropped
 }

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -4,9 +4,10 @@ use sdl2::pixels::Color;
 use sdl2::keyboard::Keycode;
 
 pub fn main() {
-    let mut sdl_context = sdl2::init().video().unwrap();
+    let sdl_context = sdl2::init().unwrap();
+    let video_subsystem = sdl_context.video().unwrap();
 
-    let window = sdl_context.window("rust-sdl2 demo: Video", 800, 600)
+    let window = video_subsystem.window("rust-sdl2 demo: Video", 800, 600)
         .position_centered()
         .opengl()
         .build()
@@ -19,9 +20,10 @@ pub fn main() {
     renderer.present();
 
     let mut running = true;
+    let mut event_pump = sdl_context.event_pump().unwrap();
 
     while running {
-        for event in sdl_context.event_pump().poll_iter() {
+        for event in event_pump.poll_iter() {
             use sdl2::event::Event;
 
             match event {

--- a/examples/game_controller.rs
+++ b/examples/game_controller.rs
@@ -1,13 +1,11 @@
 extern crate sdl2;
 
-use sdl2::{joystick, controller};
-use sdl2::controller::GameController;
-
 fn main() {
-    let mut sdl_context = sdl2::init().game_controller().unwrap();
+    let sdl_context = sdl2::init().unwrap();
+    let game_controller_subsystem = sdl_context.game_controller().unwrap();
 
     let available =
-        match joystick::num_joysticks() {
+        match game_controller_subsystem.num_joysticks() {
             Ok(n)  => n,
             Err(e) => panic!("can't enumerate joysticks: {}", e),
         };
@@ -19,10 +17,10 @@ fn main() {
     // Iterate over all available joysticks and look for game
     // controllers.
     for id in 0..available {
-        if controller::is_game_controller(id) {
+        if game_controller_subsystem.is_game_controller(id) {
             println!("Attempting to open controller {}", id);
 
-            match GameController::open(id) {
+            match game_controller_subsystem.open(id) {
                 Ok(c) => {
                     // We managed to find and open a game controller,
                     // exit the loop
@@ -46,7 +44,7 @@ fn main() {
 
     println!("Controller mapping: {}", controller.mapping());
 
-    for event in sdl_context.event_pump().wait_iter() {
+    for event in sdl_context.event_pump().unwrap().wait_iter() {
         use sdl2::event::Event;
 
         match event {

--- a/examples/joystick.rs
+++ b/examples/joystick.rs
@@ -1,12 +1,11 @@
 extern crate sdl2;
 
-use sdl2::joystick::{Joystick, num_joysticks};
-
 fn main() {
-    let mut sdl_context = sdl2::init().joystick().unwrap();
+    let sdl_context = sdl2::init().unwrap();
+    let joystick_subsystem = sdl_context.joystick().unwrap();
 
     let available =
-        match num_joysticks() {
+        match joystick_subsystem.num_joysticks() {
             Ok(n)  => n,
             Err(e) => panic!("can't enumerate joysticks: {}", e),
         };
@@ -18,7 +17,7 @@ fn main() {
     // Iterate over all available joysticks and stop once we manage to
     // open one.
     for id in 0..available {
-        match Joystick::open(id) {
+        match joystick_subsystem.open(id) {
             Ok(c) => {
                 println!("Success: opened \"{}\"", c.name());
                 joystick = Some(c);
@@ -32,7 +31,7 @@ fn main() {
         panic!("Couldn't open any joystick");
     };
 
-    for event in sdl_context.event_pump().wait_iter() {
+    for event in sdl_context.event_pump().unwrap().wait_iter() {
         use sdl2::event::Event;
 
         match event {

--- a/examples/keyboard-state.rs
+++ b/examples/keyboard-state.rs
@@ -4,19 +4,21 @@ use sdl2::keyboard::Keycode;
 use std::collections::HashSet;
 
 pub fn main() {
-    let mut sdl_context = sdl2::init().video().unwrap();
+    let sdl_context = sdl2::init().unwrap();
+    let video_subsystem = sdl_context.video().unwrap();
 
-    let _window = sdl_context.window("Keyboard", 800, 600)
+    let _window = video_subsystem.window("Keyboard", 800, 600)
         .position_centered()
         .build()
         .unwrap();
 
     let mut running = true;
+    let mut events = sdl_context.event_pump().unwrap();
 
     let mut prev_keys = HashSet::new();
 
     while running {
-        for event in sdl_context.event_pump().poll_iter() {
+        for event in events.poll_iter() {
             use sdl2::event::Event;
 
             match event {
@@ -26,7 +28,7 @@ pub fn main() {
         }
 
         // Create a set of pressed Keys.
-        let keys = sdl_context.keyboard_state().pressed_scancodes().filter_map(Keycode::from_scancode).collect();
+        let keys = events.keyboard_state().pressed_scancodes().filter_map(Keycode::from_scancode).collect();
 
         // Get the difference between the new and old sets.
         let new_keys = &keys - &prev_keys;
@@ -38,6 +40,6 @@ pub fn main() {
 
         prev_keys = keys;
 
-        sdl2::timer::delay(100);
+        std::thread::sleep_ms(100);
     }
 }

--- a/examples/renderer-texture.rs
+++ b/examples/renderer-texture.rs
@@ -5,9 +5,10 @@ use sdl2::rect::Rect;
 use sdl2::keyboard::Keycode;
 
 pub fn main() {
-    let mut sdl_context = sdl2::init().video().unwrap();
+    let sdl_context = sdl2::init().unwrap();
+    let video_subsystem = sdl_context.video().unwrap();
 
-    let window = sdl_context.window("rust-sdl2 demo: Video", 800, 600)
+    let window = video_subsystem.window("rust-sdl2 demo: Video", 800, 600)
         .position_centered()
         .opengl()
         .build()
@@ -34,9 +35,10 @@ pub fn main() {
     renderer.present();
 
     let mut running = true;
+    let mut event_pump = sdl_context.event_pump().unwrap();
 
     while running {
-        for event in sdl_context.event_pump().poll_iter() {
+        for event in event_pump.poll_iter() {
             use sdl2::event::Event;
 
             match event {

--- a/examples/renderer-yuv.rs
+++ b/examples/renderer-yuv.rs
@@ -5,9 +5,10 @@ use sdl2::rect::Rect;
 use sdl2::keyboard::Keycode;
 
 pub fn main() {
-    let mut sdl_context = sdl2::init().video().unwrap();
+    let sdl_context = sdl2::init().unwrap();
+    let video_subsystem = sdl_context.video().unwrap();
 
-    let window = sdl_context.window("rust-sdl2 demo: Video", 800, 600)
+    let window = video_subsystem.window("rust-sdl2 demo: Video", 800, 600)
         .position_centered()
         .opengl()
         .build()
@@ -50,9 +51,10 @@ pub fn main() {
     renderer.present();
 
     let mut running = true;
+    let mut event_pump = sdl_context.event_pump().unwrap();
 
     while running {
-        for event in sdl_context.event_pump().poll_iter() {
+        for event in event_pump.poll_iter() {
             use sdl2::event::Event;
 
             match event {

--- a/examples/window-properties.rs
+++ b/examples/window-properties.rs
@@ -3,9 +3,10 @@ extern crate sdl2;
 use sdl2::pixels::Color;
 
 pub fn main() {
-    let mut sdl_context = sdl2::init().video().unwrap();
+    let sdl_context = sdl2::init().unwrap();
+    let video_subsystem = sdl_context.video().unwrap();
 
-    let window = sdl_context.window("rust-sdl2 demo: Window", 800, 600)
+    let window = video_subsystem.window("rust-sdl2 demo: Window", 800, 600)
         .resizable()
         .build()
         .unwrap();
@@ -15,8 +16,10 @@ pub fn main() {
     let mut running = true;
     let mut tick = 0;
 
+    let mut event_pump = sdl_context.event_pump().unwrap();
+
     while running {
-        for event in sdl_context.event_pump().poll_iter() {
+        for event in event_pump.poll_iter() {
             use sdl2::event::Event;
             use sdl2::keyboard::Keycode;
 
@@ -30,11 +33,11 @@ pub fn main() {
 
         {
             // Update the window title.
-            // &sdl_context is needed to safely access the Window and to ensure that the event loop
+            // &event_pump is needed to safely access the Window and to ensure that the event loop
             // isn't running (which could mutate the Window).
 
-            // Note: if you don't use renderer: window.properties(&sdl_context);
-            let mut props = renderer.window_properties(&sdl_context).unwrap();
+            // Note: if you don't use renderer: window.properties(&event_pump);
+            let mut props = renderer.window_properties(&event_pump).unwrap();
 
             let position = props.get_position();
             let size = props.get_size();

--- a/examples/window-properties.rs
+++ b/examples/window-properties.rs
@@ -33,16 +33,12 @@ pub fn main() {
 
         {
             // Update the window title.
-            // &event_pump is needed to safely access the Window and to ensure that the event loop
-            // isn't running (which could mutate the Window).
+            let mut window = renderer.window_mut().unwrap();
 
-            // Note: if you don't use renderer: window.properties(&event_pump);
-            let mut props = renderer.window_properties(&event_pump).unwrap();
-
-            let position = props.get_position();
-            let size = props.get_size();
+            let position = window.get_position();
+            let size = window.get_size();
             let title = format!("Window - pos({}x{}), size({}x{}): {}", position.0, position.1, size.0, size.1, tick);
-            props.set_title(&title);
+            window.set_title(&title);
 
             tick += 1;
         }

--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -24,7 +24,6 @@ use mouse::{Mouse, MouseState};
 use keyboard::Scancode;
 use get_error;
 use SdlResult;
-use Sdl;
 
 use sys::event as ll;
 
@@ -1001,44 +1000,7 @@ unsafe fn wait_event_timeout(timeout: u32) -> Option<Event> {
     else { None }
 }
 
-static mut IS_EVENT_PUMP_ALIVE: bool = false;
-
-/// A thread-safe type that encapsulates SDL event-pumping functions.
-pub struct EventPump<'sdl> {
-    _sdl:    PhantomData<&'sdl ()>,
-
-    // Prevents the event pump from moving to other threads.
-    // SDL events can only be pumped on the main thread.
-    _nosend: PhantomData<*mut ()>
-}
-
-impl<'sdl> EventPump<'sdl> {
-    /// Obtains the SDL event pump.
-    #[inline]
-    pub fn new(_sdl: &'sdl Sdl) -> SdlResult<EventPump<'sdl>> {
-        // Called on the main SDL thread.
-
-        unsafe {
-            if IS_EVENT_PUMP_ALIVE {
-                Err(format!("an `EventPump` instance is already alive - there can only be one `EventPump` in use at a time."))
-            } else {
-                // Initialize the events subsystem, just in case none of the other subsystems have done it yet.
-                let result = ::sys::sdl::SDL_InitSubSystem(::sys::sdl::SDL_INIT_EVENTS);
-
-                if result == 0 {
-                    IS_EVENT_PUMP_ALIVE = true;
-
-                    Ok(EventPump {
-                        _sdl: PhantomData,
-                        _nosend: PhantomData,
-                    })
-                } else {
-                    Err(get_error())
-                }
-            }
-        }
-    }
-
+impl ::EventPump {
     /// Query if an event type is enabled.
     pub fn is_event_enabled(&self, event_type: EventType) -> bool {
         let result = unsafe { ll::SDL_EventState(event_type as u32, ll::SDL_QUERY) };
@@ -1127,19 +1089,6 @@ impl<'sdl> EventPump<'sdl> {
     #[inline]
     pub fn keyboard_state(&self) -> ::keyboard::KeyboardState {
         ::keyboard::KeyboardState::new(self)
-    }
-}
-
-impl<'sdl> Drop for EventPump<'sdl> {
-    #[inline]
-    fn drop(&mut self) {
-        // Called on the main SDL thread.
-
-        unsafe {
-            assert!(IS_EVENT_PUMP_ALIVE);
-            ::sys::sdl::SDL_QuitSubSystem(::sys::sdl::SDL_INIT_EVENTS);
-            IS_EVENT_PUMP_ALIVE = false;
-        }
     }
 }
 

--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -28,6 +28,83 @@ use Sdl;
 
 use sys::event as ll;
 
+impl ::EventSubsystem {
+    /// Removes all events in the event queue that match the specified event type.
+    pub fn flush_event(&self, event_type: EventType) {
+        unsafe { ll::SDL_FlushEvent(event_type as uint32_t) };
+    }
+
+    /// Removes all events in the event queue that match the specified type range.
+    pub fn flush_events(&self, min_type: u32, max_type: u32) {
+        unsafe { ll::SDL_FlushEvents(min_type, max_type) };
+    }
+
+    /// Reads the events at the front of the event queue, until the maximum amount
+    /// of events is read.
+    ///
+    /// The events will _not_ be removed from the queue.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use sdl2::event::Event;
+    ///
+    /// let sdl_context = sdl2::init().unwrap();
+    /// let event_subsystem = sdl_context.event().unwrap();
+    ///
+    /// // Read up to 1024 events
+    /// let events: Vec<Event> = event_subsystem.peek_events(1024);
+    ///
+    /// // Print each one
+    /// for event in events {
+    ///     println!("{:?}", event);
+    /// }
+    /// ```
+    pub fn peek_events<B>(&self, max_amount: u32) -> B
+    where B: FromIterator<Event>
+    {
+        unsafe {
+            let mut events = Vec::with_capacity(max_amount as usize);
+
+            let result = {
+                let events_ptr = events.as_mut_ptr();
+
+                ll::SDL_PeepEvents(
+                    events_ptr,
+                    max_amount as c_int,
+                    ll::SDL_PEEKEVENT,
+                    ll::SDL_FIRSTEVENT,
+                    ll::SDL_LASTEVENT
+                )
+            };
+
+            if result < 0 {
+                // The only error possible is "Couldn't lock event queue"
+                panic!(get_error());
+            } else {
+                events.set_len(max_amount as usize);
+
+                events.into_iter().map(|event_raw| {
+                    Event::from_ll(event_raw)
+                }).collect()
+            }
+        }
+    }
+
+    /// Pushes an event to the event queue.
+    pub fn push_event(&self, event: Event) -> SdlResult<()> {
+        match event.to_ll() {
+            Some(mut raw_event) => {
+                let ok = unsafe { ll::SDL_PushEvent(&mut raw_event) == 1 };
+                if ok { Ok(()) }
+                else { Err(get_error()) }
+            },
+            None => {
+                Err(format!("Cannot push unsupported event type to the queue"))
+            }
+        }
+    }
+}
+
 /// Types of events that can be delivered.
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 #[repr(u32)]
@@ -1099,76 +1176,4 @@ pub struct EventWaitTimeoutIterator<'a> {
 impl<'a> Iterator for EventWaitTimeoutIterator<'a> {
     type Item = Event;
     fn next(&mut self) -> Option<Event> { unsafe { wait_event_timeout(self.timeout) } }
-}
-
-/// Removes all events in the event queue that match the specified event type.
-pub fn flush_event(event_type: EventType) {
-    unsafe { ll::SDL_FlushEvent(event_type as uint32_t) };
-}
-
-/// Removes all events in the event queue that match the specified type range.
-pub fn flush_events(min_type: u32, max_type: u32) {
-    unsafe { ll::SDL_FlushEvents(min_type, max_type) };
-}
-
-/// Reads the events at the front of the event queue, until the maximum amount
-/// of events is read.
-///
-/// The events will _not_ be removed from the queue.
-///
-/// # Example
-/// ```no_run
-/// use sdl2::event::{Event, peek_events};
-///
-/// // Read up to 1024 events
-/// let events: Vec<Event> = peek_events(1024);
-///
-/// // Print each one
-/// for event in events {
-///     println!("{:?}", event);
-/// }
-/// ```
-pub fn peek_events<B>(max_amount: u32) -> B
-where B: FromIterator<Event>
-{
-    unsafe {
-        let mut events = Vec::with_capacity(max_amount as usize);
-
-        let result = {
-            let events_ptr = events.as_mut_ptr();
-
-            ll::SDL_PeepEvents(
-                events_ptr,
-                max_amount as c_int,
-                ll::SDL_PEEKEVENT,
-                ll::SDL_FIRSTEVENT,
-                ll::SDL_LASTEVENT
-            )
-        };
-
-        if result < 0 {
-            // The only error possible is "Couldn't lock event queue"
-            panic!(get_error());
-        } else {
-            events.set_len(max_amount as usize);
-
-            events.into_iter().map(|event_raw| {
-                Event::from_ll(event_raw)
-            }).collect()
-        }
-    }
-}
-
-/// Pushes an event to the event queue.
-pub fn push_event(event: Event) -> SdlResult<()> {
-    match event.to_ll() {
-        Some(mut raw_event) => {
-            let ok = unsafe { ll::SDL_PushEvent(&mut raw_event) == 1 };
-            if ok { Ok(()) }
-            else { Err(get_error()) }
-        },
-        None => {
-            Err(format!("Cannot push unsupported event type to the queue"))
-        }
-    }
 }

--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -711,7 +711,7 @@ impl Event {
                     timestamp: event.timestamp,
                     window_id: event.windowID,
                     which: event.which,
-                    mouse_btn: mouse::wrap_mouse(event.button),
+                    mouse_btn: mouse::Mouse::from_ll(event.button),
                     x: event.x,
                     y: event.y
                 }
@@ -723,7 +723,7 @@ impl Event {
                     timestamp: event.timestamp,
                     window_id: event.windowID,
                     which: event.which,
-                    mouse_btn: mouse::wrap_mouse(event.button),
+                    mouse_btn: mouse::Mouse::from_ll(event.button),
                     x: event.x,
                     y: event.y
                 }

--- a/src/sdl2/joystick.rs
+++ b/src/sdl2/joystick.rs
@@ -36,43 +36,48 @@ impl JoystickSubsystem {
             })
         }
     }
-}
+    
+    /// Return the name of the joystick at index `id`
+    pub fn name_for_index(&self, id: u32) -> SdlResult<String> {
+        let id = try!(u32_to_int!(id));
+        let name = unsafe { ll::SDL_JoystickNameForIndex(id) };
 
-/// Get the GUID for the joystick number `id`
-pub fn get_device_guid(id: i32) -> SdlResult<Guid> {
-    let raw = unsafe { ll::SDL_JoystickGetDeviceGUID(id) };
-
-    let guid = Guid { raw: raw };
-
-    if guid.is_zero() {
-        Err(get_error())
-    } else {
-        Ok(guid)
+        c_str_to_string_or_err(name)
     }
-}
 
-/// If state is `true` joystick events are processed, otherwise
-/// they're ignored.
-pub fn set_event_state(state: bool) {
-    unsafe { ll::SDL_JoystickEventState(state as i32) };
-}
+    /// Get the GUID for the joystick number `id`
+    pub fn get_device_guid(&self, id: u32) -> SdlResult<Guid> {
+        let id = try!(u32_to_int!(id));
 
-/// Return `true` if joystick events are processed.
-pub fn get_event_state() -> bool {
-    unsafe { ll::SDL_JoystickEventState(SDL_QUERY as i32)
-             == SDL_ENABLE as i32 }
-}
+        let raw = unsafe { ll::SDL_JoystickGetDeviceGUID(id) };
 
-/// Return the name of the joystick at index `id`
-pub fn name_for_index(id: i32) -> SdlResult<String> {
-    let name = unsafe { ll::SDL_JoystickNameForIndex(id) };
+        let guid = Guid { raw: raw };
 
-    c_str_to_string_or_err(name)
-}
+        if guid.is_zero() {
+            Err(get_error())
+        } else {
+            Ok(guid)
+        }
+    }
 
-/// Force joystick update when not using the event loop
-pub fn update() {
-    unsafe { ll::SDL_JoystickUpdate() };
+    /// If state is `true` joystick events are processed, otherwise
+    /// they're ignored.
+    pub fn set_event_state(&self, state: bool) {
+        unsafe { ll::SDL_JoystickEventState(state as i32) };
+    }
+
+    /// Return `true` if joystick events are processed.
+    pub fn get_event_state(&self) -> bool {
+        unsafe { ll::SDL_JoystickEventState(SDL_QUERY as i32)
+                 == SDL_ENABLE as i32 }
+    }
+
+    /// Force joystick update when not using the event loop
+    #[inline]
+    pub fn update(&self) {
+        unsafe { ll::SDL_JoystickUpdate() };
+    }
+
 }
 
 /// Wrapper around the SDL_Joystick object

--- a/src/sdl2/keyboard/mod.rs
+++ b/src/sdl2/keyboard/mod.rs
@@ -2,7 +2,7 @@ use num::{ToPrimitive, FromPrimitive};
 use std::ptr;
 use std::marker::PhantomData;
 
-use event::EventPump;
+use EventPump;
 use rect::Rect;
 use video::Window;
 
@@ -55,7 +55,7 @@ impl<'a> KeyboardState<'a> {
     /// ```no_run
     /// use sdl2::keyboard::Scancode;
     ///
-    /// fn is_a_pressed(e: &sdl2::event::EventPump) -> bool {
+    /// fn is_a_pressed(e: &sdl2::EventPump) -> bool {
     ///     e.keyboard_state().is_scancode_pressed(Scancode::A)
     /// }
     /// ```
@@ -79,11 +79,11 @@ impl<'a> KeyboardState<'a> {
     /// use sdl2::keyboard::Scancode;
     /// use std::collections::HashSet;
     ///
-    /// fn pressed_scancode_set(e: &sdl2::event::EventPump) -> HashSet<Scancode> {
+    /// fn pressed_scancode_set(e: &sdl2::EventPump) -> HashSet<Scancode> {
     ///     e.keyboard_state().pressed_scancodes().collect()
     /// }
     ///
-    /// fn pressed_keycode_set(e: &sdl2::event::EventPump) -> HashSet<Keycode> {
+    /// fn pressed_keycode_set(e: &sdl2::EventPump) -> HashSet<Keycode> {
     ///     e.keyboard_state().pressed_scancodes()
     ///         .filter_map(Keycode::from_scancode)
     ///         .collect()

--- a/src/sdl2/keyboard/mod.rs
+++ b/src/sdl2/keyboard/mod.rs
@@ -1,7 +1,7 @@
 use num::{ToPrimitive, FromPrimitive};
 use std::ptr;
 
-use Sdl;
+use event::EventPump;
 use rect::Rect;
 use video::Window;
 
@@ -40,12 +40,12 @@ pub fn get_focused_window_id() -> Option<u32> {
     }
 }
 
-pub struct KeyboardState<'sdl> {
-    keyboard_state: &'sdl [u8]
+pub struct KeyboardState<'a> {
+    keyboard_state: &'a [u8]
 }
 
-impl<'sdl> KeyboardState<'sdl> {
-    pub fn new(_sdl: &Sdl) -> KeyboardState {
+impl<'a> KeyboardState<'a> {
+    pub fn new(_e: &'a EventPump) -> KeyboardState<'a> {
         let keyboard_state = unsafe {
             let mut count = 0;
             let state_ptr = ll::SDL_GetKeyboardState(&mut count);
@@ -64,8 +64,8 @@ impl<'sdl> KeyboardState<'sdl> {
     /// ```no_run
     /// use sdl2::keyboard::Scancode;
     ///
-    /// fn is_a_pressed(sdl_context: &mut sdl2::Sdl) -> bool {
-    ///     sdl_context.keyboard_state().is_scancode_pressed(Scancode::A)
+    /// fn is_a_pressed(e: &sdl2::event::EventPump) -> bool {
+    ///     e.keyboard_state().is_scancode_pressed(Scancode::A)
     /// }
     /// ```
     pub fn is_scancode_pressed(&self, scancode: Scancode) -> bool {
@@ -88,12 +88,12 @@ impl<'sdl> KeyboardState<'sdl> {
     /// use sdl2::keyboard::Scancode;
     /// use std::collections::HashSet;
     ///
-    /// fn pressed_scancode_set(sdl_context: &sdl2::Sdl) -> HashSet<Scancode> {
-    ///     sdl_context.keyboard_state().pressed_scancodes().collect()
+    /// fn pressed_scancode_set(e: &sdl2::event::EventPump) -> HashSet<Scancode> {
+    ///     e.keyboard_state().pressed_scancodes().collect()
     /// }
     ///
-    /// fn pressed_keycode_set(sdl_context: &sdl2::Sdl) -> HashSet<Keycode> {
-    ///     sdl_context.keyboard_state().pressed_scancodes()
+    /// fn pressed_keycode_set(e: &sdl2::event::EventPump) -> HashSet<Keycode> {
+    ///     e.keyboard_state().pressed_scancodes()
     ///         .filter_map(Keycode::from_scancode)
     ///         .collect()
     /// }

--- a/src/sdl2/mouse.rs
+++ b/src/sdl2/mouse.rs
@@ -1,4 +1,3 @@
-use std::marker::PhantomData;
 use std::ptr;
 
 use get_error;
@@ -148,31 +147,28 @@ impl MouseState {
     }
 }
 
-impl ::VideoSubsystem {
+impl ::Sdl {
     #[inline]
     pub fn mouse(&self) -> MouseUtil {
         MouseUtil {
-            _marker: PhantomData
+            _sdldrop: self.sdldrop()
         }
     }
 }
 
-/// Mouse utility functions. Access with `VideoSubsystem::mouse()`.
-///
-/// These functions require the video subsystem to be initialized and are not thread-safe.
+/// Mouse utility functions. Access with `Sdl::mouse()`.
 ///
 /// ```no_run
 /// let sdl_context = sdl2::init().unwrap();
-/// let video_subsystem = sdl_context.video().unwrap();
 ///
 /// // Hide the cursor
-/// video_subsystem.mouse().show_cursor(false);
+/// sdl_context.mouse().show_cursor(false);
 /// ```
-pub struct MouseUtil<'video> {
-    _marker: PhantomData<&'video ()>
+pub struct MouseUtil {
+    _sdldrop: ::std::rc::Rc<::SdlDrop>
 }
 
-impl<'video> MouseUtil<'video> {
+impl MouseUtil {
     /// Gets the id of the window which currently has mouse focus.
     pub fn get_focused_window_id(&self) -> Option<u32> {
         let raw = unsafe { ll::SDL_GetMouseFocus() };

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -28,7 +28,7 @@
 //! None of the draw methods in `Renderer` are expected to fail.
 //! If they do, a panic is raised and the program is aborted.
 
-use Sdl;
+use event::EventPump;
 use video::{Window, WindowProperties, WindowPropertiesGetters};
 use surface;
 use surface::{Surface, SurfaceRef};
@@ -265,10 +265,10 @@ impl<'a> Renderer<'a> {
 
     /// Accesses the Window properties, such as the position, size and title of a Window.
     /// Returns None if the renderer is not associated with a Window.
-    pub fn window_properties<'b>(&'b mut self, sdl: &'b Sdl) -> Option<WindowProperties<'b>>
+    pub fn window_properties<'b>(&'b mut self, e: &'b EventPump) -> Option<WindowProperties<'b>>
     {
         match self.parent.as_mut() {
-            Some(&mut RendererParent::Window(ref mut window)) => Some(window.properties(sdl)),
+            Some(&mut RendererParent::Window(ref mut window)) => Some(window.properties(e)),
             _ => None
         }
     }

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -75,7 +75,7 @@ impl FromPrimitive for TextureAccess {
 /// or the current render context.
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub struct RendererInfo {
-    pub name: String,
+    pub name: &'static str,
     pub flags: u32,
     pub texture_formats: Vec<pixels::PixelFormatEnum>,
     pub max_texture_width: u32,
@@ -108,12 +108,17 @@ impl FromPrimitive for BlendMode {
 
 impl RendererInfo {
     pub unsafe fn from_ll(info: &ll::SDL_RendererInfo) -> RendererInfo {
+        use std::str;
+
         let texture_formats: Vec<pixels::PixelFormatEnum> = info.texture_formats[0..(info.num_texture_formats as usize)].iter().map(|&format| {
             FromPrimitive::from_i64(format as i64).unwrap()
         }).collect();
 
+        // The driver name is always a static string, compiled into SDL2.
+        let name = str::from_utf8(CStr::from_ptr(info.name).to_bytes()).unwrap();
+
         RendererInfo {
-            name: String::from_utf8_lossy(CStr::from_ptr(info.name).to_bytes()).to_string(),
+            name: name,
             flags: info.flags,
             texture_formats: texture_formats,
             max_texture_width: info.max_texture_width as u32,
@@ -1205,24 +1210,48 @@ impl Texture {
     pub unsafe fn raw(&self) -> *mut ll::SDL_Texture { self.raw }
 }
 
+#[derive(Copy, Clone)]
+pub struct DriverIterator {
+    length: i32,
+    index: i32
+}
 
-pub fn get_num_render_drivers() -> SdlResult<u32> {
-    let result = unsafe { ll::SDL_GetNumRenderDrivers() };
-    if result > 0 {
-        Ok(result as u32)
-    } else {
-        Err(get_error())
+impl Iterator for DriverIterator {
+    type Item = RendererInfo;
+
+    #[inline]
+    fn next(&mut self) -> Option<RendererInfo> {
+        if self.index >= self.length {
+            None
+        } else {
+            let mut out = unsafe { mem::uninitialized() };
+            let result = unsafe { ll::SDL_GetRenderDriverInfo(self.index, &mut out) == 0 };
+            assert!(result, 0);
+            self.index += 1;
+
+            unsafe { Some(RendererInfo::from_ll(&out)) }
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let l = self.length as usize;
+        (l, Some(l))
     }
 }
 
-pub fn get_render_driver_info(index: u32) -> SdlResult<RendererInfo> {
-    let mut out = unsafe { mem::uninitialized() };
-    let index = try!(u32_to_int!(index));
-    let result = unsafe { ll::SDL_GetRenderDriverInfo(index, &mut out) == 0 };
-    if result {
-        unsafe { Ok(RendererInfo::from_ll(&out)) }
-    } else {
-        Err(get_error())
+impl ExactSizeIterator for DriverIterator { }
+
+/// Gets an iterator of all render drivers compiled into the SDL2 library.
+#[inline]
+pub fn drivers() -> DriverIterator {
+    // This function is thread-safe and doesn't require the video subsystem to be initialized.
+    // The list of drivers are read-only and statically compiled into SDL2, varying by platform.
+
+    // SDL_GetNumRenderDrivers can never return a negative value.
+    DriverIterator {
+        length: unsafe { ll::SDL_GetNumRenderDrivers() },
+        index: 0
     }
 }
 

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -28,7 +28,7 @@
 //! None of the draw methods in `Renderer` are expected to fail.
 //! If they do, a panic is raised and the program is aborted.
 
-use event::EventPump;
+use EventPump;
 use video::{Window, WindowProperties, WindowPropertiesGetters};
 use surface;
 use surface::{Surface, SurfaceRef};

--- a/src/sdl2/sdl.rs
+++ b/src/sdl2/sdl.rs
@@ -187,7 +187,7 @@ subsystem!(HapticSubsystem, ll::SDL_INIT_HAPTIC, nosync);
 subsystem!(JoystickSubsystem, ll::SDL_INIT_JOYSTICK, nosync);
 subsystem!(VideoSubsystem, ll::SDL_INIT_VIDEO, nosync);
 // Timers can be added on other threads.
-subsystem!(TimerSubsystem, ll::SDL_INIT_VIDEO, sync);
+subsystem!(TimerSubsystem, ll::SDL_INIT_TIMER, sync);
 // The event queue can be read from other threads.
 subsystem!(EventSubsystem, ll::SDL_INIT_EVENTS, sync);
 

--- a/src/sdl2/sdl.rs
+++ b/src/sdl2/sdl.rs
@@ -101,10 +101,17 @@ impl Sdl {
     pub fn event_pump(&self) -> SdlResult<EventPump> {
         EventPump::new(self)
     }
+
+    #[inline]
+    #[doc(hidden)]
+    pub fn sdldrop(&self) -> Rc<SdlDrop> {
+        self.sdldrop.clone()
+    }
 }
 
 /// When SDL is no longer in use (the refcount in an `Rc<SdlDrop>` reaches 0), the library is quit.
-struct SdlDrop;
+#[doc(hidden)]
+pub struct SdlDrop;
 
 impl Drop for SdlDrop {
     #[inline]

--- a/src/sdl2/sdl.rs
+++ b/src/sdl2/sdl.rs
@@ -1,10 +1,8 @@
 use std::ffi::{CStr, CString};
-use std::marker::PhantomData;
+use std::rc::Rc;
 
 use sys::sdl as ll;
 use event::EventPump;
-use keyboard::KeyboardState;
-use video::WindowBuilder;
 use util::CStringExt;
 
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
@@ -39,33 +37,78 @@ static IS_SDL_CONTEXT_ALIVE: AtomicBool = ATOMIC_BOOL_INIT;
 /// This guarantees that the only way to call event-pumping functions is on
 /// the main thread.
 pub struct Sdl {
-    _nosyncsend: PhantomData<*mut ()>
+    sdldrop: Rc<SdlDrop>
 }
 
 impl Sdl {
-    /// Returns the mask of the specified subsystems which have previously been initialized.
-    pub fn was_init(&self, flags: u32) -> u32 {
+    #[inline]
+    pub fn new() -> SdlResult<Sdl> {
         unsafe {
-            ll::SDL_WasInit(flags)
+            use std::sync::atomic::Ordering;
+
+            // Atomically switch the `IS_SDL_CONTEXT_ALIVE` global to true
+            let was_alive = IS_SDL_CONTEXT_ALIVE.swap(true, Ordering::Relaxed);
+
+            if was_alive {
+                Err(format!("Cannot have more than one `Sdl` in use at the same time"))
+            } else {
+                // Initialize SDL without any explicit subsystems (flags = 0).
+                if ll::SDL_Init(0) == 0 {
+                    Ok(Sdl {
+                        sdldrop: Rc::new(SdlDrop)
+                    })
+                } else {
+                    IS_SDL_CONTEXT_ALIVE.swap(false, Ordering::Relaxed);
+                    Err(get_error())
+                }
+            }
         }
     }
 
+    /// Initializes the audio subsystem.
+    #[inline]
+    pub fn audio(&self) -> SdlResult<AudioSubsystem> { AudioSubsystem::new(self) }
+
+    /// Initializes the event subsystem.
+    #[inline]
+    pub fn event(&self) -> SdlResult<EventSubsystem> { EventSubsystem::new(self) }
+
+    /// Initializes the joystick subsystem.
+    #[inline]
+    pub fn joystick(&self) -> SdlResult<JoystickSubsystem> { JoystickSubsystem::new(self) }
+
+    /// Initializes the haptic subsystem.
+    #[inline]
+    pub fn haptic(&self) -> SdlResult<HapticSubsystem> { HapticSubsystem::new(self) }
+
+    /// Initializes the game controller subsystem.
+    #[inline]
+    pub fn game_controller(&self) -> SdlResult<GameControllerSubsystem> { GameControllerSubsystem::new(self) }
+
+    /// Initializes the timer subsystem.
+    #[inline]
+    pub fn timer(&self) -> SdlResult<TimerSubsystem> { TimerSubsystem::new(self) }
+
+    /// Initializes the video subsystem.
+    #[inline]
+    pub fn video(&self) -> SdlResult<VideoSubsystem> { VideoSubsystem::new(self) }
+
     /// Obtains the SDL event pump.
-    pub fn event_pump(&mut self) -> EventPump {
+    ///
+    /// At most one `EventPump` is allowed to be alive during the program's execution.
+    /// If this function is called while an `EventPump` instance is alive, the function will return
+    /// an error.
+    #[inline]
+    pub fn event_pump(&self) -> SdlResult<EventPump> {
         EventPump::new(self)
-    }
-
-    pub fn keyboard_state(&self) -> KeyboardState {
-        KeyboardState::new(self)
-    }
-
-    /// Initializes a new `WindowBuilder`; a convenience method that calls `WindowBuilder::new()`.
-    pub fn window(&self, title: &str, width: u32, height: u32) -> WindowBuilder {
-        WindowBuilder::new(self, title, width, height)
     }
 }
 
-impl Drop for Sdl {
+/// When SDL is no longer in use (the refcount in an `Rc<SdlDrop>` reaches 0), the library is quit.
+struct SdlDrop;
+
+impl Drop for SdlDrop {
+    #[inline]
     fn drop(&mut self) {
         use std::sync::atomic::Ordering;
 
@@ -76,137 +119,94 @@ impl Drop for Sdl {
     }
 }
 
-/// A RAII value representing initalized SDL subsystems. See `sdl2::Sdl::init_subsystem()`.
-///
-/// Subsystem initialization is ref-counted. Once `Subsystem::drop()` is called,
-/// the specified subsystems' ref-counts are decremented via `SDL_QuitSubSystem`.
-pub struct Subsystem<'sdl> {
-    flags: u32,
-    _marker: PhantomData<&'sdl Sdl>
-}
+// No subsystem can implement `Send` because the destructor, `SDL_QuitSubSystem`,
+// utilizes non-atomic reference counting and should thus be called on a single thread.
+// Some subsystems have functions designed to be thread-safe, such as adding a timer or accessing
+// the event queue. These subsystems implement `Sync`.
 
-impl<'sdl> Drop for Subsystem<'sdl> {
-    fn drop(&mut self) {
-        unsafe { ll::SDL_QuitSubSystem(self.flags); }
-    }
-}
+macro_rules! subsystem {
+    ($name:ident, $flag:expr) => (
+        impl $name {
+            #[inline]
+            fn new(sdl: &Sdl) -> SdlResult<$name> {
+                let result = unsafe { ll::SDL_InitSubSystem($flag) };
 
-/// The type that allows you to build the SDL2 context.
-pub struct InitBuilder {
-    flags: u32
-}
-
-impl InitBuilder {
-    /// Initializes a new `InitBuilder`.
-    pub fn new() -> InitBuilder {
-        InitBuilder { flags: 0 }
-    }
-
-    /// Builds the SDL2 context.
-    pub fn build(&self) -> SdlResult<Sdl> {
-        unsafe {
-            use std::sync::atomic::Ordering;
-
-            // Atomically switch the `IS_SDL_CONTEXT_ALIVE` global to true
-            let was_alive = IS_SDL_CONTEXT_ALIVE.swap(true, Ordering::Relaxed);
-
-            if was_alive {
-                Err(format!("Cannot have more than one `Sdl` in use at the same time"))
-            } else {
-                if ll::SDL_Init(self.flags) == 0 {
-                    Ok(Sdl {
-                        _nosyncsend: PhantomData
+                if result == 0 {
+                    Ok($name {
+                        _subsystem_drop: Rc::new(SubsystemDrop {
+                            _sdldrop: sdl.sdldrop.clone(),
+                            flag: $flag
+                        })
                     })
                 } else {
-                    IS_SDL_CONTEXT_ALIVE.swap(false, Ordering::Relaxed);
                     Err(get_error())
                 }
             }
         }
-    }
-
-    /// Builds the SDL2 context. Convenience method for `.build().unwrap()`.
-    ///
-    /// Panics if there was an error initializing SDL2.
-    pub fn unwrap(&self) -> Sdl { self.build().unwrap() }
-
-    /// Builds an SDL2 subsystem. Requires SDL2 to have already been initialized.
-    pub fn build_subsystem(&self, _sdl: &Sdl) -> SdlResult<Subsystem> {
-        unsafe {
-            if ll::SDL_InitSubSystem(self.flags) == 0 {
-                Ok(Subsystem {
-                    flags: self.flags,
-                    _marker: PhantomData
-                })
-            } else {
-                Err(get_error())
-            }
+    );
+    ($name:ident, $flag:expr, nosync) => (
+        #[derive(Clone)]
+        pub struct $name {
+            /// Subsystems cannot be moved or (usually) used on non-main threads.
+            /// Luckily, Rc restricts use to the main thread.
+            _subsystem_drop: Rc<SubsystemDrop>
         }
-    }
 
-    /// Initializes every subsystem.
-    pub fn everything(&mut self) -> &mut InitBuilder {
-        self.flags |= ll::SDL_INIT_EVERYTHING as u32;
-        self
-    }
+        subsystem!($name, $flag);
+    );
+    ($name:ident, $flag:expr, sync) => (
+        pub struct $name {
+            /// Subsystems cannot be moved or (usually) used on non-main threads.
+            /// Luckily, Rc restricts use to the main thread.
+            _subsystem_drop: Rc<SubsystemDrop>
+        }
+        unsafe impl Sync for $name {}
 
-    /// Initializes the timer subsystem.
-    pub fn timer(&mut self) -> &mut InitBuilder {
-        self.flags |= ll::SDL_INIT_TIMER as u32;
-        self
-    }
+        subsystem!($name, $flag);
+    )
+}
 
-    /// Initializes the audio subsystem.
-    pub fn audio(&mut self) -> &mut InitBuilder {
-        self.flags |= ll::SDL_INIT_AUDIO as u32;
-        self
-    }
+/// When a subsystem is no longer in use (the refcount in an `Rc<SubsystemDrop>` reaches 0),
+/// the subsystem is quit.
+#[derive(Clone)]
+struct SubsystemDrop {
+    _sdldrop: Rc<SdlDrop>,
+    flag: ll::SDL_InitFlag
+}
 
-    /// Initializes the video subsystem.
-    pub fn video(&mut self) -> &mut InitBuilder {
-        self.flags |= ll::SDL_INIT_VIDEO as u32;
-        self
-    }
-
-    /// Initializes the joystick subsystem.
-    pub fn joystick(&mut self) -> &mut InitBuilder {
-        self.flags |= ll::SDL_INIT_JOYSTICK as u32;
-        self
-    }
-
-    /// Initializes the haptic (force feedback) subsystem.
-    pub fn haptic(&mut self) -> &mut InitBuilder {
-        self.flags |= ll::SDL_INIT_HAPTIC as u32;
-        self
-    }
-
-    /// Initializes the controller subsystem.
-    pub fn game_controller(&mut self) -> &mut InitBuilder {
-        self.flags |= ll::SDL_INIT_GAMECONTROLLER as u32;
-        self
-    }
-
-    /// Initializes the events subsystem.
-    pub fn events(&mut self) -> &mut InitBuilder {
-        self.flags |= ll::SDL_INIT_EVENTS as u32;
-        self
+impl Drop for SubsystemDrop {
+    #[inline]
+    fn drop(&mut self) {
+        unsafe { ll::SDL_QuitSubSystem(self.flag); }
     }
 }
+
+subsystem!(AudioSubsystem, ll::SDL_INIT_AUDIO, nosync);
+subsystem!(GameControllerSubsystem, ll::SDL_INIT_GAMECONTROLLER, nosync);
+subsystem!(HapticSubsystem, ll::SDL_INIT_HAPTIC, nosync);
+subsystem!(JoystickSubsystem, ll::SDL_INIT_JOYSTICK, nosync);
+subsystem!(VideoSubsystem, ll::SDL_INIT_VIDEO, nosync);
+// Timers can be added on other threads.
+subsystem!(TimerSubsystem, ll::SDL_INIT_VIDEO, sync);
+// The event queue can be read from other threads.
+subsystem!(EventSubsystem, ll::SDL_INIT_EVENTS, sync);
 
 /// Initializes the SDL library.
 /// This must be called before using any other SDL function.
 ///
 /// # Example
 /// ```no_run
-/// let mut sdl_context = sdl2::init().everything().unwrap();
+/// let sdl_context = sdl2::init().unwrap();
+/// let mut event_pump = sdl_context.event_pump().unwrap();
 ///
-/// for event in sdl_context.event_pump().poll_iter() {
+/// for event in event_pump.poll_iter() {
 ///     // ...
 /// }
 ///
 /// // SDL_Quit() is called here as `sdl_context` is dropped.
 /// ```
-pub fn init() -> InitBuilder { InitBuilder::new() }
+#[inline]
+pub fn init() -> SdlResult<Sdl> { Sdl::new() }
 
 pub fn get_error() -> String {
     unsafe {

--- a/src/sdl2/timer.rs
+++ b/src/sdl2/timer.rs
@@ -26,22 +26,30 @@ impl TimerSubsystem {
             }
         }
     }
-}
 
-pub fn get_ticks() -> u32 {
-    unsafe { ll::SDL_GetTicks() }
-}
+    /// Gets the number of milliseconds elapsed since the timer subsystem was initialized.
+    ///
+    /// It's recommended that you use another library for timekeeping, such as `time`.
+    pub fn get_ticks(&mut self) -> u32 {
+        // Google says this is probably not thread-safe (TODO: prove/disprove this).
+        unsafe { ll::SDL_GetTicks() }
+    }
 
-pub fn get_performance_counter() -> u64 {
-    unsafe { ll::SDL_GetPerformanceCounter() }
-}
+    /// Sleeps the current thread for the specified amount of milliseconds.
+    ///
+    /// It's recommended that you use `std::thread::sleep_ms()` instead.
+    pub fn delay(&mut self, ms: u32) {
+        // Google says this is probably not thread-safe (TODO: prove/disprove this).
+        unsafe { ll::SDL_Delay(ms) }
+    }
 
-pub fn get_performance_frequency() -> u64 {
-    unsafe { ll::SDL_GetPerformanceFrequency() }
-}
+    pub fn get_performance_counter(&self) -> u64 {
+        unsafe { ll::SDL_GetPerformanceCounter() }
+    }
 
-pub fn delay(ms: u32) {
-    unsafe { ll::SDL_Delay(ms) }
+    pub fn get_performance_frequency(&self) -> u64 {
+        unsafe { ll::SDL_GetPerformanceFrequency() }
+    }
 }
 
 pub type TimerCallback<'a> = Box<FnMut() -> u32+'a+Sync>;
@@ -98,7 +106,7 @@ fn test_timer_runs_multiple_times() {
         } else { 0 }
     }));
 
-    delay(250);                         // tick the timer at least 10 times w/ 200ms of "buffer"
+    ::std::thread::sleep_ms(250);              // tick the timer at least 10 times w/ 200ms of "buffer"
     let num = local_num.lock().unwrap(); // read the number back
     assert_eq!(*num, 9);                 // it should have incremented at least 10 times...
 }
@@ -117,7 +125,7 @@ fn test_timer_runs_at_least_once() {
         *flag = true; 0
     }));
 
-    delay(50);
+    ::std::thread::sleep_ms(50);
     let flag = local_flag.lock().unwrap();
     assert_eq!(*flag, true);
 }
@@ -139,12 +147,12 @@ fn test_timer_can_be_recreated() {
     }));
 
     // reclaim closure after timer runs
-    delay(50);
+    ::std::thread::sleep_ms(50);
     let closure = timer_1.into_inner();
 
     // create a second timer and increment again
     let _timer_2 = timer_subsystem.add_timer(20, closure);
-    delay(50);
+    ::std::thread::sleep_ms(50);
 
     // check that timer was incremented twice
     let num = local_num.lock().unwrap();

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -11,7 +11,7 @@ use render::RendererBuilder;
 use surface::SurfaceRef;
 use pixels;
 use VideoSubsystem;
-use event::EventPump;
+use EventPump;
 use SdlResult;
 use num::FromPrimitive;
 use util::CStringExt;

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -1133,3 +1133,51 @@ impl<'a> WindowProperties<'a> {
         }
     }
 }
+
+#[derive(Copy, Clone)]
+pub struct DriverIterator {
+    length: i32,
+    index: i32
+}
+
+impl Iterator for DriverIterator {
+    type Item = &'static str;
+
+    #[inline]
+    fn next(&mut self) -> Option<&'static str> {
+        if self.index >= self.length {
+            None
+        } else {
+            use std::str;
+
+            unsafe {
+                let buf = ll::SDL_GetVideoDriver(self.index);
+                assert!(!buf.is_null());
+                self.index += 1;
+
+                Some(str::from_utf8(CStr::from_ptr(buf).to_bytes()).unwrap())
+            }
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let l = self.length as usize;
+        (l, Some(l))
+    }
+}
+
+impl ExactSizeIterator for DriverIterator { }
+
+/// Gets an iterator of all video drivers compiled into the SDL2 library.
+#[inline]
+pub fn drivers() -> DriverIterator {
+    // This function is thread-safe and doesn't require the video subsystem to be initialized.
+    // The list of drivers are read-only and statically compiled into SDL2, varying by platform.
+
+    // SDL_GetNumVideoDrivers can never return a negative value.
+    DriverIterator {
+        length: unsafe { ll::SDL_GetNumVideoDrivers() },
+        index: 0
+    }
+}


### PR DESCRIPTION
This is built on top of PR #441. Here's the relevant commit for this PR: https://github.com/AngryLawyer/rust-sdl2/commit/5d8e866739bfc33e10cbe7d2b896669a4d5e6d46

So, `WindowProperties` is overkill for most use cases. I realized that it can be eliminated and still meet the safety criteria for `get_surface()` (i.e. the event loop can't run and the window can't mutate because it would reallocate the surface).

```rust
// Old
window.properties(&event_pump).set_title("Hello!");
let s = window.properties(&event_pump).get_surface();

// New
window.set_title("Hello!");
let s = window.get_surface(&event_pump);
```

`Renderer` needed a method to access the underlying window, so I implemented `WindowRef` in a similar fashion to `SurfaceRef` in #435. It's not an option to expose `&mut Window` because all mutable references can be exchanged with another value (with `std::mem::swap` or similar).
