### PR TITLE
Replace empty #[repr(C)] structs with c_void wrappers.

### DIFF
--- a/sdl2-sys/src/render.rs
+++ b/sdl2-sys/src/render.rs
@@ -43,10 +43,10 @@ pub const SDL_FLIP_VERTICAL : SDL_RendererFlip = 0x00000002;
 
 #[allow(missing_copy_implementations)]
 #[repr(C)]
-pub struct SDL_Renderer;
+pub struct SDL_Renderer(c_void);
 #[allow(missing_copy_implementations)]
 #[repr(C)]
-pub struct SDL_Texture;
+pub struct SDL_Texture(c_void);
 
 //SDL_blendmode.h
 pub type SDL_BlendMode = c_int;

--- a/sdl2-sys/src/surface.rs
+++ b/sdl2-sys/src/surface.rs
@@ -17,7 +17,7 @@ pub const SDL_DONTFREE: SDL_SurfaceFlag = 0x00000004;
 //SDL_surface.h
 #[allow(missing_copy_implementations)]
 #[repr(C)]
-pub struct SDL_BlitMap;
+pub struct SDL_BlitMap(c_void);
 
 #[allow(missing_copy_implementations)]
 #[repr(C)]

--- a/sdl2-sys/src/video.rs
+++ b/sdl2-sys/src/video.rs
@@ -11,7 +11,7 @@ pub type SDL_bool = c_int;
 //SDL_video.h
 #[allow(missing_copy_implementations)]
 #[repr(C)]
-pub struct SDL_Window;
+pub struct SDL_Window(c_void);
 
 #[allow(missing_copy_implementations)]
 #[repr(C)]


### PR DESCRIPTION
This closes https://github.com/AngryLawyer/rust-sdl2/issues/442. I claim that `c_void` makes sense because these types are only ever used as pointers.