### PR TITLE
Don't return garbage events from peek_events

### DIFF
--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -81,7 +81,7 @@ impl ::EventSubsystem {
                 // The only error possible is "Couldn't lock event queue"
                 panic!(get_error());
             } else {
-                events.set_len(max_amount as usize);
+                events.set_len(result as usize);
 
                 events.into_iter().map(|event_raw| {
                     Event::from_ll(event_raw)


### PR DESCRIPTION
SDL_PeepEvents returns the number of events it put in the buffer, which is
usually less than max_amount.