### PR TITLE
Changes in example loops

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -1,6 +1,7 @@
 extern crate sdl2;
 
 use sdl2::pixels::Color;
+use sdl2::event::Event;
 use sdl2::keyboard::Keycode;
 
 pub fn main() {
@@ -19,16 +20,13 @@ pub fn main() {
     renderer.clear();
     renderer.present();
 
-    let mut running = true;
     let mut event_pump = sdl_context.event_pump().unwrap();
 
-    while running {
+    'running: loop {
         for event in event_pump.poll_iter() {
-            use sdl2::event::Event;
-
             match event {
                 Event::Quit {..} | Event::KeyDown { keycode: Some(Keycode::Escape), .. } => {
-                    running = false
+                    break 'running
                 },
                 _ => {}
             }

--- a/examples/keyboard-state.rs
+++ b/examples/keyboard-state.rs
@@ -1,5 +1,6 @@
 extern crate sdl2;
 
+use sdl2::event::Event;
 use sdl2::keyboard::Keycode;
 use std::collections::HashSet;
 
@@ -12,17 +13,14 @@ pub fn main() {
         .build()
         .unwrap();
 
-    let mut running = true;
     let mut events = sdl_context.event_pump().unwrap();
 
     let mut prev_keys = HashSet::new();
 
-    while running {
+    'running: loop {
         for event in events.poll_iter() {
-            use sdl2::event::Event;
-
             match event {
-                Event::Quit {..} => running = false,
+                Event::Quit {..} => break 'running,
                 _ => ()
             }
         }

--- a/examples/renderer-texture.rs
+++ b/examples/renderer-texture.rs
@@ -2,6 +2,7 @@ extern crate sdl2;
 
 use sdl2::pixels::PixelFormatEnum;
 use sdl2::rect::Rect;
+use sdl2::event::Event;
 use sdl2::keyboard::Keycode;
 
 pub fn main() {
@@ -34,16 +35,13 @@ pub fn main() {
     renderer.copy_ex(&texture, None, Some(Rect::new_unwrap(450, 100, 256, 256)), 30.0, None, (false, false));
     renderer.present();
 
-    let mut running = true;
     let mut event_pump = sdl_context.event_pump().unwrap();
 
-    while running {
+    'running: loop {
         for event in event_pump.poll_iter() {
-            use sdl2::event::Event;
-
             match event {
                 Event::Quit {..} | Event::KeyDown { keycode: Some(Keycode::Escape), .. } => {
-                    running = false
+                    break 'running
                 },
                 _ => {}
             }

--- a/examples/renderer-yuv.rs
+++ b/examples/renderer-yuv.rs
@@ -2,6 +2,7 @@ extern crate sdl2;
 
 use sdl2::pixels::PixelFormatEnum;
 use sdl2::rect::Rect;
+use sdl2::event::Event;
 use sdl2::keyboard::Keycode;
 
 pub fn main() {
@@ -50,16 +51,13 @@ pub fn main() {
     renderer.copy(&texture, None, Some(Rect::new_unwrap(100, 100, 256, 256)));
     renderer.present();
 
-    let mut running = true;
     let mut event_pump = sdl_context.event_pump().unwrap();
 
-    while running {
+    'running: loop {
         for event in event_pump.poll_iter() {
-            use sdl2::event::Event;
-
             match event {
                 Event::Quit {..} | Event::KeyDown { keycode: Some(Keycode::Escape), .. } => {
-                    running = false
+                    break 'running
                 },
                 _ => {}
             }

--- a/examples/window-properties.rs
+++ b/examples/window-properties.rs
@@ -1,6 +1,8 @@
 extern crate sdl2;
 
 use sdl2::pixels::Color;
+use sdl2::event::Event;
+use sdl2::keyboard::Keycode;
 
 pub fn main() {
     let sdl_context = sdl2::init().unwrap();
@@ -13,19 +15,15 @@ pub fn main() {
 
     let mut renderer = window.renderer().present_vsync().build().unwrap();
 
-    let mut running = true;
     let mut tick = 0;
 
     let mut event_pump = sdl_context.event_pump().unwrap();
 
-    while running {
+    'running: loop {
         for event in event_pump.poll_iter() {
-            use sdl2::event::Event;
-            use sdl2::keyboard::Keycode;
-
             match event {
                 Event::Quit {..} | Event::KeyDown { keycode: Some(Keycode::Escape), .. } => {
-                    running = false
+                    break 'running
                 },
                 _ => {}
             }


### PR DESCRIPTION
- Changed 'while' loops into 'loop'-type loops with a lifetime, thus eliminating 'running' variable
- Moved 'use' statements out of the loop (one time is enough)

I think that looks a bit nicer.