### PR TITLE
Issue #463 - added `pub` visibility to `sdl` module

### DIFF
--- a/src/sdl2/lib.rs
+++ b/src/sdl2/lib.rs
@@ -28,7 +28,7 @@ pub mod video;
 pub mod timer;
 pub mod render;
 pub mod rwops;
-mod sdl;
+pub mod sdl;
 pub mod audio;
 pub mod version;
 pub mod messagebox;


### PR DESCRIPTION
Addresses #463; `sdl` module is now exported as `pub`.