### PR TITLE
Change parameter for `warp_mouse_in_window` from `Window` to `WindowRef`

### DIFF
--- a/src/sdl2/mouse.rs
+++ b/src/sdl2/mouse.rs
@@ -198,7 +198,7 @@ impl MouseUtil {
         }
     }
 
-    pub fn warp_mouse_in_window(&self, window: &video::Window, x: i32, y: i32) {
+    pub fn warp_mouse_in_window(&self, window: &video::WindowRef, x: i32, y: i32) {
         unsafe { ll::SDL_WarpMouseInWindow(window.raw(), x, y); }
     }
 


### PR DESCRIPTION
This allows the method to be used with the result of `Renderer::window()`.