### PR TITLE
Fix compilation on arm using Rust 1.5

### DIFF
--- a/src/sdl2/audio.rs
+++ b/src/sdl2/audio.rs
@@ -80,7 +80,7 @@ impl AudioSubsystem {
             let buf = ll::SDL_GetCurrentAudioDriver();
             assert!(!buf.is_null());
 
-            str::from_utf8(CStr::from_ptr(buf).to_bytes()).unwrap()
+            str::from_utf8(CStr::from_ptr(buf as *const _).to_bytes()).unwrap()
         }
     }
 
@@ -100,7 +100,7 @@ impl AudioSubsystem {
             if dev_name.is_null() {
                 Err(get_error())
             } else {
-                Ok(String::from_utf8_lossy(CStr::from_ptr(dev_name).to_bytes()).to_string())
+                Ok(String::from_utf8_lossy(CStr::from_ptr(dev_name as *const _).to_bytes()).to_string())
             }
         }
     }
@@ -221,7 +221,7 @@ impl Iterator for DriverIterator {
                 assert!(!buf.is_null());
                 self.index += 1;
 
-                Some(str::from_utf8(CStr::from_ptr(buf).to_bytes()).unwrap())
+                Some(str::from_utf8(CStr::from_ptr(buf as *const _).to_bytes()).unwrap())
             }
         }
     }

--- a/src/sdl2/clipboard.rs
+++ b/src/sdl2/clipboard.rs
@@ -49,7 +49,7 @@ impl ClipboardUtil {
             if buf.is_null() {
                 Err(get_error())
             } else {
-                Ok(String::from_utf8_lossy(CStr::from_ptr(buf).to_bytes()).into_owned())
+                Ok(String::from_utf8_lossy(CStr::from_ptr(buf as *const _).to_bytes()).into_owned())
             }
         }
     }

--- a/src/sdl2/controller.rs
+++ b/src/sdl2/controller.rs
@@ -286,7 +286,7 @@ fn c_str_to_string(c_str: *const c_char) -> String {
     if c_str.is_null() {
         String::new()
     } else {
-        let bytes = unsafe { CStr::from_ptr(c_str).to_bytes() };
+        let bytes = unsafe { CStr::from_ptr(c_str as *const _).to_bytes() };
 
         String::from_utf8_lossy(bytes).to_string()
     }
@@ -298,7 +298,7 @@ fn c_str_to_string_or_err(c_str: *const c_char) -> SdlResult<String> {
     if c_str.is_null() {
         Err(get_error())
     } else {
-        let bytes = unsafe { CStr::from_ptr(c_str).to_bytes() };
+        let bytes = unsafe { CStr::from_ptr(c_str as *const _).to_bytes() };
 
         Ok(String::from_utf8_lossy(bytes).to_string())
     }

--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -937,7 +937,7 @@ impl Event {
             EventType::DropFile => {
                 let ref event = *raw.drop();
 
-                let buf = CStr::from_ptr(event.file).to_bytes();
+                let buf = CStr::from_ptr(event.file as *const _).to_bytes();
                 let text = String::from_utf8_lossy(buf).to_string();
                 ll::SDL_free(event.file as *mut c_void);
 

--- a/src/sdl2/filesystem.rs
+++ b/src/sdl2/filesystem.rs
@@ -9,7 +9,7 @@ use sys::filesystem as ll;
 pub fn base_path() -> SdlResult<String> {
     let result = unsafe {
         let buf = ll::SDL_GetBasePath();
-        String::from_utf8_lossy(CStr::from_ptr(buf).to_bytes()).to_string()
+        String::from_utf8_lossy(CStr::from_ptr(buf as *const _).to_bytes()).to_string()
     };
 
     if result.len() == 0 {
@@ -24,7 +24,7 @@ pub fn pref_path(org: &str, app: &str) -> SdlResult<String> {
         let org = try!(CString::new(org).unwrap_or_sdlresult());
         let app = try!(CString::new(app).unwrap_or_sdlresult());
         let buf = ll::SDL_GetPrefPath(org.as_ptr() as *const c_char, app.as_ptr() as *const c_char);
-        String::from_utf8_lossy(CStr::from_ptr(buf).to_bytes()).to_string()
+        String::from_utf8_lossy(CStr::from_ptr(buf as *const _).to_bytes()).to_string()
     };
 
     if result.len() == 0 {

--- a/src/sdl2/hint.rs
+++ b/src/sdl2/hint.rs
@@ -28,7 +28,7 @@ pub fn get(name: &str) -> Option<String> {
         if res == ptr::null_mut() {
             None
         } else {
-            Some(str::from_utf8(CStr::from_ptr(res).to_bytes()).unwrap().to_owned())
+            Some(str::from_utf8(CStr::from_ptr(res as *const _).to_bytes()).unwrap().to_owned())
         }
     }
 }

--- a/src/sdl2/joystick.rs
+++ b/src/sdl2/joystick.rs
@@ -381,7 +381,7 @@ fn c_str_to_string(c_str: *const c_char) -> String {
     if c_str.is_null() {
         String::new()
     } else {
-        let bytes = unsafe { CStr::from_ptr(c_str).to_bytes() };
+        let bytes = unsafe { CStr::from_ptr(c_str as *const _).to_bytes() };
 
         String::from_utf8_lossy(bytes).to_string()
     }
@@ -393,7 +393,7 @@ fn c_str_to_string_or_err(c_str: *const c_char) -> SdlResult<String> {
     if c_str.is_null() {
         Err(get_error())
     } else {
-        let bytes = unsafe { CStr::from_ptr(c_str).to_bytes() };
+        let bytes = unsafe { CStr::from_ptr(c_str as *const _).to_bytes() };
 
         Ok(String::from_utf8_lossy(bytes).to_string())
     }

--- a/src/sdl2/keyboard/keycode.rs
+++ b/src/sdl2/keyboard/keycode.rs
@@ -549,7 +549,7 @@ impl Keycode {
         // Knowing this, we must always return a new string.
         unsafe {
             let buf = ::sys::keyboard::SDL_GetKeyName(self as i32);
-            String::from_utf8_lossy(CStr::from_ptr(buf).to_bytes()).to_string()
+            String::from_utf8_lossy(CStr::from_ptr(buf as *const _).to_bytes()).to_string()
         }
     }
 }

--- a/src/sdl2/keyboard/scancode.rs
+++ b/src/sdl2/keyboard/scancode.rs
@@ -559,7 +559,7 @@ impl Scancode {
         // Knowing this, we can always return a string slice.
         unsafe {
             let buf = ::sys::keyboard::SDL_GetScancodeName(self as u32);
-            ::std::str::from_utf8(CStr::from_ptr(buf).to_bytes()).unwrap()
+            ::std::str::from_utf8(CStr::from_ptr(buf as *const _).to_bytes()).unwrap()
         }
     }
 }

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -115,7 +115,7 @@ impl RendererInfo {
         }).collect();
 
         // The driver name is always a static string, compiled into SDL2.
-        let name = str::from_utf8(CStr::from_ptr(info.name).to_bytes()).unwrap();
+        let name = str::from_utf8(CStr::from_ptr(info.name as *const _).to_bytes()).unwrap();
 
         RendererInfo {
             name: name,

--- a/src/sdl2/sdl.rs
+++ b/src/sdl2/sdl.rs
@@ -310,7 +310,7 @@ pub fn init() -> SdlResult<Sdl> { Sdl::new() }
 pub fn get_error() -> ErrorMessage {
     unsafe {
         let err = ll::SDL_GetError();
-        ErrorMessage(String::from_utf8_lossy(CStr::from_ptr(err).to_bytes()).to_string())
+        ErrorMessage(String::from_utf8_lossy(CStr::from_ptr(err as *const _).to_bytes()).to_string())
     }
 }
 

--- a/src/sdl2/version.rs
+++ b/src/sdl2/version.rs
@@ -44,7 +44,7 @@ pub fn version() -> Version {
 pub fn revision() -> String {
     unsafe {
         let rev = ll::SDL_GetRevision();
-        String::from_utf8_lossy(CStr::from_ptr(rev).to_bytes()).to_string()
+        String::from_utf8_lossy(CStr::from_ptr(rev as *const _).to_bytes()).to_string()
     }
 }
 

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -476,7 +476,7 @@ impl VideoSubsystem {
             let buf = ll::SDL_GetCurrentVideoDriver();
             assert!(!buf.is_null());
 
-            str::from_utf8(CStr::from_ptr(buf).to_bytes()).unwrap()
+            str::from_utf8(CStr::from_ptr(buf as *const _).to_bytes()).unwrap()
         }
     }
 
@@ -492,7 +492,7 @@ impl VideoSubsystem {
     pub fn display_name(&self, display_index: i32) -> String {
         unsafe {
             let display = ll::SDL_GetDisplayName(display_index as c_int);
-            String::from_utf8_lossy(CStr::from_ptr(display).to_bytes()).to_string()
+            String::from_utf8_lossy(CStr::from_ptr(display as *const _).to_bytes()).to_string()
         }
     }
 
@@ -949,7 +949,7 @@ impl WindowRef {
             let buf = ll::SDL_GetWindowTitle(self.raw());
 
             // The window title must be encoded in UTF-8.
-            str::from_utf8(CStr::from_ptr(buf).to_bytes()).unwrap()
+            str::from_utf8(CStr::from_ptr(buf as *const _).to_bytes()).unwrap()
         }
     }
 
@@ -1177,7 +1177,7 @@ impl Iterator for DriverIterator {
                 assert!(!buf.is_null());
                 self.index += 1;
 
-                Some(str::from_utf8(CStr::from_ptr(buf).to_bytes()).unwrap())
+                Some(str::from_utf8(CStr::from_ptr(buf as *const _).to_bytes()).unwrap())
             }
         }
     }


### PR DESCRIPTION
Compiles using 1.5 and 1.6; both handle the rs-sdl2-examples just fine. That's all I know :)