### PR TITLE
Removed num dependency from sdl2-sys

### DIFF
--- a/sdl2-sys/Cargo.toml
+++ b/sdl2-sys/Cargo.toml
@@ -14,7 +14,6 @@ name = "sdl2_sys"
 path = "src/lib.rs"
 
 [dependencies]
-num = "0.1"
 libc = "0.2"
 
 [build-dependencies.pkg-config]

--- a/sdl2-sys/src/lib.rs
+++ b/sdl2-sys/src/lib.rs
@@ -2,7 +2,6 @@
 #![cfg_attr(feature = "no_std", no_std)]
 #![allow(non_camel_case_types)]
 
-extern crate num;
 extern crate libc;
 #[cfg(feature = "no_std")]
 extern crate core;

--- a/sdl2-sys/src/video.rs
+++ b/sdl2-sys/src/video.rs
@@ -4,7 +4,6 @@ use surface::SDL_Surface;
 #[cfg(feature = "no_std")]
 use core::prelude::*;
 use libc::{c_void, c_int, c_float, c_char, uint16_t, uint32_t};
-use num::FromPrimitive;
 
 pub type SDL_bool = c_int;
 
@@ -95,6 +94,11 @@ pub enum SDL_GLattr {
     SDL_GL_FRAMEBUFFER_SRGB_CAPABLE = 23
 }
 
+trait FromPrimitive {
+    fn from_i64(n: i64) -> Option<SDL_GLattr>;
+    fn from_u64(n: u64) -> Option<SDL_GLattr>;
+}
+
 impl FromPrimitive for SDL_GLattr {
     fn from_i64(n: i64) -> Option<SDL_GLattr> {
         use self::SDL_GLattr::*;
@@ -128,7 +132,7 @@ impl FromPrimitive for SDL_GLattr {
         })
     }
 
-    fn from_u64(n: u64) -> Option<SDL_GLattr> { FromPrimitive::from_i64(n as i64) }
+    fn from_u64(n: u64) -> Option<SDL_GLattr> { SDL_GLattr::from_i64(n as i64) }
 }
 
 #[derive(Copy, Clone)]


### PR DESCRIPTION
I replaced num::FromPrimitive in /sdl2-sys/src/video.rs with own trait FromPrimitive, then removed num dependency from sdl2-sys.  I also made a minor alteration to the implementation of the trait so as to make the code compile.