### PR TITLE
add lib locations for windows setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,14 @@ http://www.libsdl.org/ (SDL2-devel-2.0.x-mingw.tar.gz).
 3. Copy all lib files from
     > SDL2-devel-2.0.x-mingw\SDL2-2.0.x\x86_64-w64-mingw32\lib
 
-    inside
-    > C:\Rust\bin\rustlib\x86_64-pc-windows-gnu\lib
+    to (for Rust 1.6 and above) 
+    > C:\Program Files\Rust\\**lib**\rustlib\x86_64-pc-windows-gnu\lib
+
+    or to (for Rust versions 1.5 and below)
+    > C:\Program Files\Rust\\**bin**\rustlib\x86_64-pc-windows-gnu\lib
+    
+    or to your library folder of choice, and ensure you have a system environment variable of
+    > LIBRARY_PATH = C:\your\rust\library\folder
 
 4. Copy SDL2.dll from
     > SDL2-devel-2.0.x-mingw\SDL2-2.0.x\x86_64-w64-mingw32\bin


### PR DESCRIPTION
Found a change in file structure for Rust 1.6 on Windows, and I also tested the files in a folder that wouldn't be changed when updating Rust, with the system environment LIBRARY_PATH variable set.