### PR TITLE
Removed #[allow(raw_pointer_derive)] from sdl2-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name    = "sdl2"
 description = "SDL2 bindings for Rust"
 repository = "https://github.com/AngryLawyer/rust-sdl2"
 documentation = "http://angrylawyer.github.io/rust-sdl2/sdl2/"
-version = "0.15.0"
+version = "0.15.1"
 license = "MIT"
 authors = [ "Tony Aldridge <tony@angry-lawyer.com>" ]
 keywords = ["SDL", "windowing", "graphics"]
@@ -29,7 +29,7 @@ lazy_static="0.1"
 [dependencies.sdl2-sys]
 
 path = "sdl2-sys"
-version = "0.8.0"
+version = "0.8.1"
 
 [features]
 

--- a/sdl2-sys/Cargo.toml
+++ b/sdl2-sys/Cargo.toml
@@ -3,7 +3,7 @@
 name = "sdl2-sys"
 description = "Raw SDL2 bindings for Rust, used internally rust-sdl2"
 repository = "https://github.com/AngryLawyer/rust-sdl2"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Tony Aldridge <tony@angry-lawyer.com>"]
 license = "MIT"
 links = "SDL2"

--- a/sdl2-sys/src/audio.rs
+++ b/sdl2-sys/src/audio.rs
@@ -42,7 +42,7 @@ pub struct SDL_AudioSpec {
 }
 pub type SDL_AudioFilter =
     Option<extern "C" fn (arg1: *mut SDL_AudioCVT, arg2: SDL_AudioFormat)>;
-#[allow(dead_code, missing_copy_implementations, raw_pointer_derive)]
+#[allow(dead_code, missing_copy_implementations)]
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct SDL_AudioCVT {


### PR DESCRIPTION
Also bumped patch version on sdl2-sys and sdl2. Now there are no more warnings when compiling on rust stable (1.6)