### PR TITLE
change show_simple_message_box to use WindowRef

### DIFF
--- a/src/sdl2/messagebox.rs
+++ b/src/sdl2/messagebox.rs
@@ -2,7 +2,7 @@ use std::ffi::{CString, NulError};
 use std::ptr;
 use libc::c_char;
 
-use video::Window;
+use video::WindowRef;
 use get_error;
 
 use sys::messagebox as ll;

--- a/src/sdl2/messagebox.rs
+++ b/src/sdl2/messagebox.rs
@@ -22,7 +22,7 @@ pub enum ShowMessageError {
 }
 
 pub fn show_simple_message_box(flags: MessageBoxFlag, title: &str, 
-        message: &str, window: Option<&Window>) 
+        message: &str, window: Option<&WindowRef>) 
         -> Result<(), ShowMessageError> {
     use self::ShowMessageError::*;
     let result = unsafe {


### PR DESCRIPTION
currently the function uses an Option<&Window> to specify a parent window. this no longer works with the WindowRef you get out of Renderer.window(); this pull request makes it take an Option<&WindowRef> instead.