### PR TITLE
Updated to latest bitflags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name    = "sdl2"
 description = "SDL2 bindings for Rust"
 repository = "https://github.com/AngryLawyer/rust-sdl2"
 documentation = "http://angrylawyer.github.io/rust-sdl2/sdl2/"
-version = "0.17.0"
+version = "0.18.0"
 license = "MIT"
 authors = [ "Tony Aldridge <tony@angry-lawyer.com>" ]
 keywords = ["SDL", "windowing", "graphics"]
@@ -21,7 +21,7 @@ harness=false
 
 [dependencies]
 num = "0.1"
-bitflags = "0.3"
+bitflags = "0.5"
 libc = "0.2"
 rand = "0.3"
 lazy_static="0.1"

--- a/src/sdl2/keyboard/mod.rs
+++ b/src/sdl2/keyboard/mod.rs
@@ -13,7 +13,7 @@ pub use self::keycode::Keycode;
 pub use self::scancode::Scancode;
 
 bitflags! {
-    flags Mod: u32 {
+    pub flags Mod: u32 {
         const NOMOD = 0x0000,
         const LSHIFTMOD = 0x0001,
         const RSHIFTMOD = 0x0002,

--- a/src/sdl2/messagebox.rs
+++ b/src/sdl2/messagebox.rs
@@ -8,10 +8,10 @@ use get_error;
 use sys::messagebox as ll;
 
 bitflags! {
-    flags MessageBoxFlag: u32 {
-        const MESSAGEBOX_ERROR = ll::SDL_MESSAGEBOX_ERROR,
-        const MESSAGEBOX_WARNING = ll::SDL_MESSAGEBOX_WARNING,
-        const MESSAGEBOX_INFORMATION = ll::SDL_MESSAGEBOX_INFORMATION
+    pub flags MessageBoxFlag: u32 {
+        const MESSAGEBOX_ERROR = ::sys::messagebox::SDL_MESSAGEBOX_ERROR,
+        const MESSAGEBOX_WARNING = ::sys::messagebox::SDL_MESSAGEBOX_WARNING,
+        const MESSAGEBOX_INFORMATION = ::sys::messagebox::SDL_MESSAGEBOX_INFORMATION
     }
 }
 
@@ -21,8 +21,8 @@ pub enum ShowMessageError {
     SdlError(String),
 }
 
-pub fn show_simple_message_box(flags: MessageBoxFlag, title: &str, 
-        message: &str, window: Option<&WindowRef>) 
+pub fn show_simple_message_box(flags: MessageBoxFlag, title: &str,
+        message: &str, window: Option<&WindowRef>)
         -> Result<(), ShowMessageError> {
     use self::ShowMessageError::*;
     let result = unsafe {


### PR DESCRIPTION
- Bumped to 0.18.0

Replaced “ll” with “::sys::messagebox”, because “ll” does not work.