### PR TITLE
Add feature flag and instructions to use Mac SDL2 framework

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,4 @@ version = "0.8.1"
 
 default = []
 use-pkgconfig = [ "sdl2-sys/use-pkgconfig" ]
+use_mac_framework = ["sdl2-sys/use_mac_framework"]

--- a/README.md
+++ b/README.md
@@ -70,6 +70,35 @@ Then add the following to your `~/.bash_profile` if not already present.
 
 If you're having issues with either homebrew or macports, [see here][pdev-issue].
 
+#### If you are using the SDL2 framework
+
+You can download and install the SDL2 Mac OS X framework from:
+https://www.libsdl.org/download-2.0.php
+
+To make the `sdl2` crate link with the SDL2 framework, you will need to enable
+the `use_mac_framework` feature.  To build and test the `sdl2` crate with this
+feature, use:
+
+> cargo test --features use_mac_framework
+
+To depend on the `sdl2` crate with this feature enabled, put the following in
+your project's `Cargo.toml` file:
+
+```toml
+[dependencies.sdl2]
+features = ["use_mac_framework"]
+version = ...  # Whichever version you are using
+```
+
+Alternatively, you can re-export the feature in your package by putting the
+following in your `Cargo.toml` file:
+
+```toml
+[features]
+default = []
+use_sdl2_mac_framework = ["sdl2/use_mac_framework"]
+```
+
 ### Windows (MinGW)
 On Windows, make certain you are using the MinGW version of SDL; the native
 version will crash on `sdl2::init`.

--- a/sdl2-sys/Cargo.toml
+++ b/sdl2-sys/Cargo.toml
@@ -25,3 +25,4 @@ optional = true
 default = []
 use-pkgconfig = ["pkg-config"]
 no_std = []
+use_mac_framework = []

--- a/sdl2-sys/build.rs
+++ b/sdl2-sys/build.rs
@@ -3,7 +3,11 @@ extern crate pkg_config;
 
 fn main() {
     if !build_pkgconfig() {
-      println!("cargo:rustc-flags=-l SDL2");
+        if cfg!(feature="use_mac_framework") {
+            println!("cargo:rustc-flags=-l framework=SDL2");
+        } else {
+            println!("cargo:rustc-flags=-l SDL2");
+        }
     }
 }
 

--- a/sdl2-sys/src/sdl.rs
+++ b/sdl2-sys/src/sdl.rs
@@ -3,11 +3,11 @@ use libc::{c_int, c_uint, c_char, uint32_t};
 // Setup linking for all targets.
 #[cfg(target_os="macos")]
 mod mac {
-    #[cfg(mac_framework)]
+    #[cfg(any(mac_framework, feature="use_mac_framework"))]
     #[link(kind="framework", name="SDL2")]
     extern {}
 
-    #[cfg(not(mac_framework))]
+    #[cfg(not(any(mac_framework, feature="use_mac_framework")))]
     #[link(name="SDL2")]
     extern {}
 }


### PR DESCRIPTION
It's currently difficult to use rust-sdl2 and have it link against the Mac framework version of SDL2 (rather than the version installed by MacPorts or Homebrew), especially if you want to build with cargo.  This change adds a `use_mac_framework` feature flag that dependents can easily set or re-export in their `Cargo.toml`, and adds instructions for using it to the README.