### PR TITLE
Remove link to rs-sdl2-examples project

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,9 +149,6 @@ We have some simple example projects included:
 
 > cargo run --example audio-whitenoise
 
-Some additional examples can be found in the
-[rs-sdl2-examples][examples] repo.
-
 # OpenGL
 
 If you want to use OpenGL, you also need the


### PR DESCRIPTION
Hey, I think we can remove the link in the README to my examples project. While I do get the occasional PR to update things when this repo has breaking changes, I don't have the time to maintain it.
For my games I also end up just writing some c platform code to a expose a simpler api, so I don't really follow this project anymore.