### PR TITLE
Don't try to build on OS X since `apt-get` asplode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: rust
 sudo: required
+os: linux
 rust:
 - beta
 - nightly


### PR DESCRIPTION
Until there are equiv `brew` commands, this will force testing on Linux only. Should fix the build.