### PR TITLE
Added a from_read() method to RWops

### DIFF
--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -777,7 +777,8 @@ impl<'a> Renderer<'a> {
     /// # Panics
     /// Panics if drawing fails for any reason (e.g. driver failure),
     /// or if the provided texture does not belong to the renderer.
-    pub fn copy(&mut self, texture: &Texture, src: Option<Rect>, dst: Option<Rect>) {
+    pub fn copy(&mut self, texture: &Texture, src: Option<Rect>, dst: Option<Rect>) 
+            -> Result<(), String> {
         texture.check_renderer();
 
         let ret = unsafe {
@@ -796,7 +797,9 @@ impl<'a> Renderer<'a> {
         };
 
         if ret != 0 {
-            panic!("Error copying texture: {}", get_error())
+            Err(get_error())
+        } else {
+            Ok(())
         }
     }
 

--- a/src/sdl2/rwops.rs
+++ b/src/sdl2/rwops.rs
@@ -59,6 +59,21 @@ impl<'a> RWops<'a> {
         }
     }
 
+    /// Reads a `Read` object into a buffer and then passes it to `RWops.from_bytes`.
+    ///
+    /// The buffer must be provided to this function and must live as long as the
+    /// `RWops`, but the `RWops` does not take ownership of it.
+    pub fn from_read<T>(r: &mut T, buffer: &'a mut Vec<u8>) -> Result<RWops<'a>, String>
+        where T: io::Read + Sized {
+        match r.read_to_end(buffer) {
+            Ok(_size) => RWops::from_bytes(buffer),
+            Err(ioerror) => {
+                let msg = format!("IO error: {}", ioerror);
+                Err(msg)
+            }
+        }
+    }
+
     /// Prepares a read-write memory buffer for use with `RWops`.
     ///
     /// This method can only fail if the buffer size is zero.


### PR DESCRIPTION
The ownership is a little squirrelly but this seems the best way, as far as I can tell.  The other option seems to be to make the RWops object actually hold on to a buffer.  Or just force everyone to implement this from scratch, but the lifetime implications actually get sort of tricky so it'd be nice to have a version for anyone to use.

Addresses issue #535.