### PR TITLE
Pass the number of bytes instead of the number of samples in AudioQueue::queue

### DIFF
--- a/src/sdl2/audio.rs
+++ b/src/sdl2/audio.rs
@@ -536,7 +536,7 @@ impl<Channel: AudioFormatNum> AudioQueue<Channel> {
 
     /// Adds data to the audio queue.
     pub fn queue(&self, data: &[Channel]) -> bool {
-        let result = unsafe {ll::SDL_QueueAudio(self.device_id.id(), data.as_ptr() as *const c_void, data.len() as u32)};
+        let result = unsafe {ll::SDL_QueueAudio(self.device_id.id(), data.as_ptr() as *const c_void, (data.len() * mem::size_of::<Channel>()) as u32)};
         result == 0
     }
 


### PR DESCRIPTION
According to [the SDL documentation](https://wiki.libsdl.org/SDL_QueueAudio) the third parameter to the `SDL_QueueAudio` takes the number of bytes, not samples.
