### PR TITLE
Update with instructions for MSVC

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,9 +123,9 @@ http://www.libsdl.org/ (SDL2-devel-2.0.x-mingw.tar.gz).
 
     into your cargo project, right next to your Cargo.toml.
 
-### Windows (MinGW)
+### Windows (MSVC)
 
-1. Download mingw development libraries from
+1. Download MSVC development libraries from
 http://www.libsdl.org/ (SDL2-devel-2.0.x-VC.zip).
 2. Unpack to a folder of your choosing (You can delete it afterwards).
 3. Copy both all lib files from

--- a/README.md
+++ b/README.md
@@ -99,8 +99,6 @@ use_sdl2_mac_framework = ["sdl2/use_mac_framework"]
 ```
 
 ### Windows (MinGW)
-On Windows, make certain you are using the MinGW version of SDL; the native
-version will crash on `sdl2::init`.
 
 1. Download mingw development libraries from
 http://www.libsdl.org/ (SDL2-devel-2.0.x-mingw.tar.gz).
@@ -122,6 +120,31 @@ http://www.libsdl.org/ (SDL2-devel-2.0.x-mingw.tar.gz).
 
 4. Copy SDL2.dll from
     > SDL2-devel-2.0.x-mingw\SDL2-2.0.x\x86_64-w64-mingw32\bin
+
+    into your cargo project, right next to your Cargo.toml.
+
+### Windows (MinGW)
+
+1. Download mingw development libraries from
+http://www.libsdl.org/ (SDL2-devel-2.0.x-VC.zip).
+2. Unpack to a folder of your choosing (You can delete it afterwards).
+3. Copy both all lib files from
+    > SDL2-devel-2.0.x-VC\SDL2-2.0.x\lib\x64
+
+    to (for Rust 1.6 and above)
+    > C:\Program Files\Rust\\**lib**\rustlib\x86_64-pc-windows-msvc\lib
+
+    or to (for Rust versions 1.5 and below)
+    > C:\Program Files\Rust\\**bin**\rustlib\x86_64-pc-windows-msvc\lib
+
+    or to your library folder of choice, and ensure you have a system environment variable of
+    > LIBRARY_PATH = C:\your\rust\library\folder
+
+	For Multirust Users, this folder will be in
+	> C:\Users\{Your Username}\AppData\Local\.multirust\toolchains\{current toolchain}\lib\rustlib\x86_64-pc-windows-msvc\lib
+
+4. Copy SDL2.dll from
+    > SDL2-devel-2.0.5-VC\SDL2-2.0.5\lib\x64
 
     into your cargo project, right next to your Cargo.toml.
 


### PR DESCRIPTION
The MSVC toolchain can now be used with this package without modification, so I've removed the prior warning and added instructions on how to use the MSVC toolchain.