### PR TITLE
Add MSVC install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ http://www.libsdl.org/ (SDL2-devel-2.0.x-mingw.tar.gz).
     > LIBRARY_PATH = C:\your\rust\library\folder
 
 	For Rustup users, this folder will be in
-	> C:\Users\{Your Username}\.multirust\toolchains\\{current toolchain}\lib\rustlib\\{current toolchain}\lib
+	> C:\Users\\{Your Username}\.multirust\toolchains\\{current toolchain}\lib\rustlib\\{current toolchain}\lib
 
   Where current toolchain is likely `stable-x86_64-pc-windows-gnu`.
 
@@ -142,7 +142,7 @@ http://www.libsdl.org/ (SDL2-devel-2.0.x-mingw.tar.gz).
     > LIB = C:\your\rust\library\folder
 
 	For Rustup users, this folder will be in
-	> C:\Users\{Your Username}\.multirust\toolchains\\{current toolchain}\lib\rustlib\\{current toolchain}\lib
+	> C:\Users\\{Your Username}\.multirust\toolchains\\{current toolchain}\lib\rustlib\\{current toolchain}\lib
 
   Where current toolchain is likely `stable-x86_64-pc-windows-msvc`.
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,31 @@ http://www.libsdl.org/ (SDL2-devel-2.0.x-mingw.tar.gz).
 
     into your cargo project, right next to your Cargo.toml.
 
+### Windows (MSVC)
+
+1. Unpack SDL2-devel-2.0.x-VC.zip to a folder of your choosing (You can delete it afterwards).
+2. Copy all lib files from
+    > SDL2-devel-2.0.x-VC\SDL2-2.0.x\lib\x64\
+
+    to (for Rust 1.6 and above)
+    > C:\Program Files\Rust\\**lib**\rustlib\x86_64-pc-windows-msvc\lib
+
+    or to (for Rust versions 1.5 and below)
+    > C:\Program Files\Rust\\**bin**\rustlib\x86_64-pc-windows-msvc\lib
+
+    or to your library folder of choice, and ensure you have a system environment variable of
+    > LIB = C:\your\rust\library\folder
+
+	For Rustup users, this folder will be in
+	> C:\Users\{Your Username}\.multirust\toolchains\{current toolchain}\lib\rustlib\{current toolchain}\lib
+
+  Where current toolchain is likely `stable-x86_64-pc-windows-msvc`.
+
+3. Copy SDL2.dll from
+    > SDL2-devel-2.0.x-VC\SDL2-2.0.x\lib\x64\
+
+    into your cargo project, right next to your Cargo.toml.
+
 # Installation
 
 If you're using [cargo][crates] to manage your project, you can

--- a/README.md
+++ b/README.md
@@ -99,8 +99,6 @@ use_sdl2_mac_framework = ["sdl2/use_mac_framework"]
 ```
 
 ### Windows (MinGW)
-On Windows, make certain you are using the MinGW version of SDL; the native
-version will crash on `sdl2::init`.
 
 1. Download mingw development libraries from
 http://www.libsdl.org/ (SDL2-devel-2.0.x-mingw.tar.gz).
@@ -127,8 +125,9 @@ http://www.libsdl.org/ (SDL2-devel-2.0.x-mingw.tar.gz).
 
 ### Windows (MSVC)
 
-1. Unpack SDL2-devel-2.0.x-VC.zip to a folder of your choosing (You can delete it afterwards).
-2. Copy all lib files from
+1. Download MSVC development libraries from http://www.libsdl.org/ (SDL2-devel-2.0.x-VC.zip).
+2. Unpack SDL2-devel-2.0.x-VC.zip to a folder of your choosing (You can delete it afterwards).
+3. Copy all lib files from
     > SDL2-devel-2.0.x-VC\SDL2-2.0.x\lib\x64\
 
     to (for Rust 1.6 and above)
@@ -145,7 +144,7 @@ http://www.libsdl.org/ (SDL2-devel-2.0.x-mingw.tar.gz).
 
   Where current toolchain is likely `stable-x86_64-pc-windows-msvc`.
 
-3. Copy SDL2.dll from
+4. Copy SDL2.dll from
     > SDL2-devel-2.0.x-VC\SDL2-2.0.x\lib\x64\
 
     into your cargo project, right next to your Cargo.toml.

--- a/README.md
+++ b/README.md
@@ -115,8 +115,10 @@ http://www.libsdl.org/ (SDL2-devel-2.0.x-mingw.tar.gz).
     or to your library folder of choice, and ensure you have a system environment variable of
     > LIBRARY_PATH = C:\your\rust\library\folder
 
-	For Multirust Users, this folder will be in
-	> C:\Users\{Your Username}\AppData\Local\.multirust\toolchains\{current toolchain}\lib\rustlib\x86_64-pc-windows-gnu\lib
+	For Rustup users, this folder will be in
+	> C:\Users\{Your Username}\.multirust\toolchains\\{current toolchain}\lib\rustlib\\{current toolchain}\lib
+
+  Where current toolchain is likely `stable-x86_64-pc-windows-gnu`.
 
 4. Copy SDL2.dll from
     > SDL2-devel-2.0.x-mingw\SDL2-2.0.x\x86_64-w64-mingw32\bin
@@ -140,7 +142,7 @@ http://www.libsdl.org/ (SDL2-devel-2.0.x-mingw.tar.gz).
     > LIB = C:\your\rust\library\folder
 
 	For Rustup users, this folder will be in
-	> C:\Users\{Your Username}\.multirust\toolchains\{current toolchain}\lib\rustlib\{current toolchain}\lib
+	> C:\Users\{Your Username}\.multirust\toolchains\\{current toolchain}\lib\rustlib\\{current toolchain}\lib
 
   Where current toolchain is likely `stable-x86_64-pc-windows-msvc`.
 


### PR DESCRIPTION
I've been using these SDL2 bindings via glium-sdl on Windows. This PR adds instructions to the README.md that work for me. I based the instructions on the minGW instructions. I use rustup so I don't know if the paths are exactly correct for the other installation options but like I said, I based them off the existing windows instructions. I use a `LIB` env variable so I know that part of the instructions is correct.

For me the location involving `AppData` was wrong so I updated that too. I don't know if that means rustup changed the path at some point or what.

Furthermore, I'm not seeing the segfault during init that some folks have seen on Windows. Perhaps because it's all built with msvc or maybe one of the dependencies just handles that case.
