### PR TITLE
use num-0.1.25 to opt out of unneeded features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,14 @@ name="events"
 harness=false
 
 [dependencies]
-num = "0.1"
 bitflags = "0.6"
 libc = "0.2"
 rand = "0.3"
 lazy_static="0.2"
+
+[dependencies.num]
+version = "0.1.25"
+default-features = false
 
 [dependencies.sdl2-sys]
 


### PR DESCRIPTION
Rust-SDL2 does not use anything from num aside from FromPrimitive/ToPrimitive. Using num-0.1.25 we can opt out of unneeded features like bigints or complex numbers.
This also improves compile times of clean builds.
