### PR TITLE
Add direction field to MouseWheel event

### DIFF
--- a/sdl2-sys/src/event.rs
+++ b/sdl2-sys/src/event.rs
@@ -158,6 +158,7 @@ pub struct SDL_MouseWheelEvent {
     pub which: uint32_t,
     pub x: int32_t,
     pub y: int32_t,
+    pub direction: uint32_t,
 }
 
 #[derive(Copy, Clone)]

--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -1827,7 +1827,7 @@ mod test {
     use super::WindowEventId;
     use super::super::controller::{Button, Axis};
     use super::super::joystick::{HatState};
-    use super::super::mouse::{Mouse, MouseState};
+    use super::super::mouse::{Mouse, MouseState, MouseWheelDirection};
     use super::super::keyboard::{Keycode, Scancode, Mod};
 
     // Tests a round-trip conversion from an Event type to

--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -23,8 +23,7 @@ use keyboard::Mod;
 use sys::keycode::SDL_Keymod;
 use keyboard::Keycode;
 use mouse;
-use mouse::{Mouse, MouseState};
-use mouse::MouseWheelDirection;
+use mouse::{Mouse, MouseState, MouseWheelDirection};
 use keyboard::Scancode;
 use get_error;
 

--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -23,7 +23,8 @@ use keyboard::Mod;
 use sys::keycode::SDL_Keymod;
 use keyboard::Keycode;
 use mouse;
-use mouse::{Mouse, MouseState, MouseWheelDirection};
+use mouse::{Mouse, MouseState};
+use mouse::MouseWheelDirection;
 use keyboard::Scancode;
 use get_error;
 

--- a/src/sdl2/mouse.rs
+++ b/src/sdl2/mouse.rs
@@ -81,6 +81,49 @@ impl Cursor {
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+pub enum MouseWheelDirection {
+    Normal,
+    Flipped,
+    Unknown(u32),
+}
+
+// 0 and 1 are not fixed values in the SDL source code.  This value is defined as an enum which is then cast to a Uint32.
+// The enum in C is defined as such:
+
+/**
+ * \brief Scroll direction types for the Scroll event
+ */
+//typedef enum
+//{
+//    SDL_MOUSEWHEEL_NORMAL,    /**< The scroll direction is normal */
+//    SDL_MOUSEWHEEL_FLIPPED    /**< The scroll direction is flipped / natural */
+//} SDL_MouseWheelDirection;
+
+// Since no value is given in the enum definition these values are auto assigned by the C compiler starting at 0.
+// Normally I would prefer to use the enum rather than hard code what it is implied to represent however
+// the mouse wheel direction value could be descripted equally as well by a bool, so I don't think changes
+// to this enum in the C source code are going to be a problem.
+
+impl MouseWheelDirection {
+    #[inline]
+    pub fn from_ll(direction: u32) -> MouseWheelDirection {
+        match direction {
+            0 => MouseWheelDirection::Normal,
+            1 => MouseWheelDirection::Flipped,
+            _ => MouseWheelDirection::Unknown(direction),
+        }
+    }
+    #[inline]
+    pub fn to_ll(&self) -> u32 {
+        match *self {
+            MouseWheelDirection::Normal => 0,
+            MouseWheelDirection::Flipped => 1,
+            MouseWheelDirection::Unknown(direction) => direction,
+        }
+    }
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 pub enum Mouse {
     Left,
     Middle,


### PR DESCRIPTION
https://github.com/AngryLawyer/rust-sdl2/issues/555 As described here we are missing the direction field from the MouseWheel event in SDL2.  This commit adds that field in.