### PR TITLE
Removal of the back and forward conversions of `Path` to ref/str

### DIFF
--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -25,9 +25,8 @@ fn main() {
 
     let temp_surface = sdl2::surface::Surface::load_bmp(Path::new("assets/animate.bmp")).unwrap();
     let texture = renderer.create_texture_from_surface(&temp_surface).unwrap();
-    let texture_query  = texture.query();
 
-    let mut center = Point::new(320,240);
+    let center = Point::new(320,240);
     let mut source_rect = Rect::new(0, 0, 128, 82);
     let mut dest_rect = Rect::new(0,0, 128, 82);
     dest_rect.center_on(center);

--- a/src/sdl2/audio.rs
+++ b/src/sdl2/audio.rs
@@ -263,7 +263,7 @@ pub struct AudioSpecWAV {
 
 impl AudioSpecWAV {
     /// Loads a WAVE from the file path.
-    pub fn load_wav<P: AsRef<Path>>(path: P) -> Result<AudioSpecWAV, String> {
+    pub fn load_wav(path: &Path) -> Result<AudioSpecWAV, String> {
         let mut file = try!(RWops::from_file(path, "rb"));
         AudioSpecWAV::load_wav_rw(&mut file)
     }
@@ -494,7 +494,7 @@ impl<Channel: AudioFormatNum> AudioQueue<Channel> {
 
             let iscapture_flag = 0;
             let device_id = ll::SDL_OpenAudioDevice(
-                device_ptr as *const c_char, iscapture_flag, &desired, 
+                device_ptr as *const c_char, iscapture_flag, &desired,
                 &mut obtained, 0
             );
             match device_id {
@@ -583,7 +583,7 @@ impl<CB: AudioCallback> AudioDevice<CB> {
 
             let iscapture_flag = 0;
             let device_id = ll::SDL_OpenAudioDevice(
-                device_ptr as *const c_char, iscapture_flag, &desired, 
+                device_ptr as *const c_char, iscapture_flag, &desired,
                 &mut obtained, 0
             );
             match device_id {

--- a/src/sdl2/controller.rs
+++ b/src/sdl2/controller.rs
@@ -86,7 +86,7 @@ impl GameControllerSubsystem {
     }
 
     /// Add a new mapping from a mapping string
-    pub fn add_mapping(&self, mapping: &str) 
+    pub fn add_mapping(&self, mapping: &str)
             -> Result<MappingStatus, AddMappingError> {
         use self::AddMappingError::*;
         let mapping = match CString::new(mapping) {
@@ -104,7 +104,7 @@ impl GameControllerSubsystem {
     }
 
     /// Load mappings from a file
-    pub fn load_mappings<P: AsRef<Path>>(&self, path: P)
+    pub fn load_mappings(&self, path: &Path)
             -> Result<i32, AddMappingError> {
         use self::AddMappingError::*;
 
@@ -371,7 +371,7 @@ fn c_str_to_string(c_str: *const c_char) -> String {
     if c_str.is_null() {
         String::new()
     } else {
-        unsafe { 
+        unsafe {
             CStr::from_ptr(c_str as *const _).to_str().unwrap().to_owned()
         }
     }
@@ -383,7 +383,7 @@ fn c_str_to_string_or_err(c_str: *const c_char) -> Result<String, String> {
     if c_str.is_null() {
         Err(get_error())
     } else {
-        Ok(unsafe { 
+        Ok(unsafe {
             CStr::from_ptr(c_str as *const _).to_str().unwrap().to_owned()
         })
     }

--- a/src/sdl2/rwops.rs
+++ b/src/sdl2/rwops.rs
@@ -24,9 +24,11 @@ impl<'a> RWops<'a> {
     }
 
     /// Creates an SDL file stream.
-    pub fn from_file<P: AsRef<Path>>(path: P, mode: &str) -> Result<RWops <'static>, String> {
+    pub fn from_file(path: &Path, mode: &str) -> Result<RWops <'static>, String> {
         let raw = unsafe {
-            let path_c = CString::new(path.as_ref().to_str().unwrap()).unwrap();
+            // Path is internally represented as an OsStr, which is UTF-8
+            // conversion to str for SDL2 *shouldn't* need checking
+            let path_c = CString::new(path.as_os_str().to_str().unwrap()).unwrap();
             let mode_c = CString::new(mode).unwrap();
             ll::SDL_RWFromFile(path_c.as_ptr() as *const c_char, mode_c.as_ptr() as *const c_char)
         };

--- a/src/sdl2/surface.rs
+++ b/src/sdl2/surface.rs
@@ -177,7 +177,7 @@ impl<'a> Surface<'a> {
         }
     }
 
-    pub fn load_bmp<P: AsRef<Path>>(path: P) -> Result<Surface<'static>, String> {
+    pub fn load_bmp(path: &Path) -> Result<Surface<'static>, String> {
         let mut file = try!(RWops::from_file(path, "rb"));
         Surface::load_bmp_rw(&mut file)
     }
@@ -306,7 +306,7 @@ impl SurfaceRef {
         else { Err(get_error()) }
     }
 
-    pub fn save_bmp<P: AsRef<Path>>(&self, path: P) -> Result<(), String> {
+    pub fn save_bmp(&self, path: &Path) -> Result<(), String> {
         let mut file = try!(RWops::from_file(path, "wb"));
         self.save_bmp_rw(&mut file)
     }
@@ -514,15 +514,15 @@ impl SurfaceRef {
         }
     }
 
-    // Note: There's no need to implement SDL_ConvertSurfaceFormat, as it 
+    // Note: There's no need to implement SDL_ConvertSurfaceFormat, as it
     // does the same thing as SDL_ConvertSurface but with a slightly different
     // function signature.
 
     /// Performs surface blitting (surface copying).
     ///
     /// Returns the final blit rectangle, if a `dst_rect` was provided.
-    pub fn blit(&self, src_rect: Option<Rect>, 
-            dst: &mut SurfaceRef, dst_rect: Option<Rect>) 
+    pub fn blit(&self, src_rect: Option<Rect>,
+            dst: &mut SurfaceRef, dst_rect: Option<Rect>)
             -> Result<Option<Rect>, String> {
         unsafe {
             let src_rect_ptr = src_rect.as_ref().map(|r| r.raw()).unwrap_or(ptr::null());


### PR DESCRIPTION
Related to issue #433

- `Path` is internally represented as <OsStr>
- `Path` internally handles all platform related tasks
- `OsStr` is UTF-8
- `str` is UTF-8, conversion from `OsStr` to `str` is free

Therefore with `Path` we get free UTF-8 checking and conversions
from platform specific string representation.
- internally with Rust, all `String` and `str` are valid UTF-8
- however, conversion from `OsStr` to `str` may require checking
  UTF-8 validity...

So in theory, this train of conversions should be *fail proof*.
Docs say this about the `OsStr` to `str` conversion;
>Yields a &str slice if the OsStr is valid Unicode.
>This conversion may entail doing a check for UTF-8 validity.

I'm about 99% sure this will be fine anyway.

More [details
here](https://github.com/rust-lang/rfcs/blob/master/text/0517-io-os-reform.md#string-handling)

**All discussion welcome**

**Note**: I seem to be getting a lot of commits due to my editor removing any whitespace at the *end* of any lines on saving.