### PR TITLE
Renderer.fill_rect now takes an Option<Rect>.

### DIFF
--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -739,10 +739,11 @@ impl<'a> Renderer<'a> {
 
     /// Fills a rectangle on the current rendering target with the drawing
     /// color.
+    /// Passing None will fill the entire rendering target.
     /// Errors if drawing fails for any reason (e.g. driver failure)
-    pub fn fill_rect(&mut self, rect: Rect) -> Result<(), String> {
+    pub fn fill_rect<R: Into<Option<Rect>>>(&mut self, rect: R) -> Result<(), String> {
         let result = unsafe {
-            ll::SDL_RenderFillRect(self.raw, rect.raw())
+            ll::SDL_RenderFillRect(self.raw, rect.into().map(|r|{r.raw()}).unwrap_or(ptr::null()))
         };
         if result != 0 {
             Err(get_error())


### PR DESCRIPTION
Native SDL2 behavior allows passing of null to fill the entire target.

Unless there's some reasoning not to allow this?