### PR TITLE
Add missing `#[repr(C)]` to SDL_Keysym

### DIFF
--- a/sdl2-sys/src/keyboard.rs
+++ b/sdl2-sys/src/keyboard.rs
@@ -8,6 +8,7 @@ use sdl::SDL_bool;
 
 // SDL_keyboard.h
 #[derive(Copy, Clone)]
+#[repr(C)]
 pub struct SDL_Keysym {
     pub scancode: SDL_Scancode,
     pub sym: SDL_Keycode,

--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -1298,7 +1298,7 @@ impl Event {
                     window_id: event.windowID,
                     keycode: Keycode::from_i32(event.keysym.sym as i32),
                     scancode: Scancode::from_i32(event.keysym.scancode as i32),
-                    keymod: keyboard::Mod::from_bits_truncate(event.keysym._mod as SDL_Keymod),
+                    keymod: keyboard::Mod::from_bits(event.keysym._mod as SDL_Keymod).unwrap(),
                     repeat: event.repeat != 0
                 }
             }
@@ -1310,7 +1310,7 @@ impl Event {
                     window_id: event.windowID,
                     keycode: Keycode::from_i32(event.keysym.sym as i32),
                     scancode: Scancode::from_i32(event.keysym.scancode as i32),
-                    keymod: keyboard::Mod::from_bits_truncate(event.keysym._mod as SDL_Keymod),
+                    keymod: keyboard::Mod::from_bits(event.keysym._mod as SDL_Keymod).unwrap(),
                     repeat: event.repeat != 0
                 }
             }


### PR DESCRIPTION
This also reverts the change in 9604e85f3db1881654c2d23924fc0b08f7948b94 which just hid the issue.

Sorry about that, should have dug deeper before PR'ing.

The break was most likely caused by https://github.com/rust-lang/rust/pull/37429 recently landing