### PR TITLE
Check feature use_mac_framework with mac_framework

### DIFF
--- a/src/sdl2/image/mod.rs
+++ b/src/sdl2/image/mod.rs
@@ -33,11 +33,11 @@ use sys;
 // Setup linking for all targets.
 #[cfg(target_os="macos")]
 mod mac {
-    #[cfg(mac_framework)]
+    #[cfg(any(mac_framework, feature="use_mac_framework"))]
     #[link(kind="framework", name="SDL2_image")]
     extern {}
 
-    #[cfg(not(mac_framework))]
+    #[cfg(not(any(mac_framework, feature="use_mac_framework")))]
     #[link(name="SDL2_image")]
     extern {}
 }

--- a/src/sdl2/mixer/mod.rs
+++ b/src/sdl2/mixer/mod.rs
@@ -34,12 +34,12 @@ use ::version::Version;
 // Setup linking for all targets.
 #[cfg(target_os="macos")]
 mod mac {
-    #[cfg(mac_framework)]
+    #[cfg(any(mac_framework, feature="use_mac_framework"))]
     #[link(kind="framework", name="SDL2_mixer")]
     extern "C" {
     }
 
-    #[cfg(not(mac_framework))]
+    #[cfg(not(any(mac_framework, feature="use_mac_framework")))]
     #[link(name="SDL2_mixer")]
     extern "C" {
     }

--- a/src/sdl2/ttf/mod.rs
+++ b/src/sdl2/ttf/mod.rs
@@ -28,11 +28,11 @@ mod context;
 // Setup linking for all targets.
 #[cfg(target_os="macos")]
 mod mac {
-    #[cfg(mac_framework)]
+    #[cfg(any(mac_framework, feature="use_mac_framework"))]
     #[link(kind="framework", name="SDL2_ttf")]
     extern {}
 
-    #[cfg(not(mac_framework))]
+    #[cfg(not(any(mac_framework, feature="use_mac_framework")))]
     #[link(name="SDL2_ttf")]
     extern {}
 }


### PR DESCRIPTION
Hi!

I don't think you can set arbitrary cfg attributes from the command line in cargo (please correct me if I'm wrong), so the only way to conditionally compile some code with command line options to cargo is by using a feature. I noticed the "use_mac_framework" feature already existed, and it was being checked in some places but not others.