### PR TITLE
Add primitive conversions for structs in pixels module

### DIFF
--- a/src/sdl2/pixels.rs
+++ b/src/sdl2/pixels.rs
@@ -3,6 +3,7 @@ extern crate rand;
 use num::FromPrimitive;
 
 use sys::pixels as ll;
+use libc;
 
 use get_error;
 
@@ -334,6 +335,12 @@ impl PixelFormatEnum {
             PixelFormatEnum::Index4MSB
                 => panic!("not supported format: {:?}", *self),
         }
+    }
+}
+
+impl Into<ll::SDL_PixelFormatEnum> for PixelFormatEnum {
+    fn into(self) -> ll::SDL_PixelFormatEnum {
+        self as libc::uint32_t
     }
 }
 

--- a/src/sdl2/pixels.rs
+++ b/src/sdl2/pixels.rs
@@ -136,6 +136,18 @@ impl Color {
     }
 }
 
+impl Into<ll::SDL_Color> for Color {
+    fn into(self) -> ll::SDL_Color {
+        unsafe { self.raw() }
+    }
+}
+
+impl From<ll::SDL_Color> for Color {
+    fn from(raw: ll::SDL_Color) -> Color {
+        Color::RGBA(raw.r, raw.g, raw.b, raw.a)
+    }
+}
+
 impl rand::Rand for Color {
     fn rand<R: rand::Rng>(rng: &mut R) -> Color {
         if rng.gen() { Color::RGBA(rng.gen(), rng.gen(), rng.gen(), rng.gen()) }


### PR DESCRIPTION
I did not include conversions to sdl2_sys structs containing pointers, since that could be unsafe.

I also did not include a From<ll::SDL_PixelFormatEnum> for PixelFormatEnum because upstream changes could break code and make conversion not succeed every time.