### PR TITLE
Added Unknown value to GLProfile

### DIFF
--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -25,6 +25,9 @@ pub enum GLProfile {
     Compatibility,
     /// OpenGL ES profile - only a subset of the base OpenGL functionality is available
     GLES,
+    /// Unknown profile - SDL will tend to return 0 if you ask when no particular profile
+    /// has been defined or requested.
+    Unknown(i32)
 }
 
 trait GLAttrTypeUtil {
@@ -47,6 +50,7 @@ impl GLAttrTypeUtil for GLProfile {
         use self::GLProfile::*;
 
         match self {
+            Unknown(i) => i,
             Core => 1,
             Compatibility => 2,
             GLES => 4,
@@ -59,7 +63,7 @@ impl GLAttrTypeUtil for GLProfile {
             1 => Core,
             2 => Compatibility,
             4 => GLES,
-            _ => panic!("unknown SDL_GLProfile value: {}", value)
+            i => Unknown(i),
         }
     }
 }


### PR DESCRIPTION
SDL will happily return 0 (on Linux) if you ask what profile it will use without explicltly setting one... even after you have already gotten a GL context.  So even if you do something seemingly innocuous such as:

```
        let window = video.window(window_title, screen_width, screen_height).opengl().build();
        let gl = video.gl_attr();
        println!("Got GL {}.{}, profile {:?}",
                 gl.context_major_version(),
                 gl.context_minor_version(),
                 gl.context_profile());
```

the `gl.context_profile()` call can return something unrecognized and panic.