### PR TITLE
Fix use-after-free in Renderer::fill_rect()

### DIFF
--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -752,7 +752,7 @@ impl<'a> Renderer<'a> {
     /// Errors if drawing fails for any reason (e.g. driver failure)
     pub fn fill_rect<R: Into<Option<Rect>>>(&mut self, rect: R) -> Result<(), String> {
         let result = unsafe {
-            ll::SDL_RenderFillRect(self.raw, rect.into().map(|r|{r.raw()}).unwrap_or(ptr::null()))
+            ll::SDL_RenderFillRect(self.raw, rect.into().as_ref().map(|r|{r.raw()}).unwrap_or(ptr::null()))
         };
         if result != 0 {
             Err(get_error())


### PR DESCRIPTION
The Rect structure was being freed before the raw pointer was passed to
SDL_RenderFillRect(), leading to garbage rect values, which caused SDL
to not actually draw any rectangle (or sometimes, it drew a rectangle
over the entire window).