### PR TITLE
Remove redundant #[link] attributes (fixes #615)

### DIFF
--- a/sdl2-sys/src/sdl.rs
+++ b/sdl2-sys/src/sdl.rs
@@ -1,23 +1,5 @@
 use libc::{c_int, c_uint, c_char, uint32_t};
 
-// Setup linking for all targets.
-#[cfg(target_os="macos")]
-mod mac {
-    #[cfg(any(mac_framework, feature="use_mac_framework"))]
-    #[link(kind="framework", name="SDL2")]
-    extern {}
-
-    #[cfg(not(any(mac_framework, feature="use_mac_framework")))]
-    #[link(name="SDL2")]
-    extern {}
-}
-
-#[cfg(any(target_os="windows", target_os="linux", target_os="freebsd"))]
-mod others {
-    #[link(name="SDL2")]
-    extern {}
-}
-
 pub type SDL_bool = c_int;
 
 pub type SDL_errorcode = c_uint;


### PR DESCRIPTION
The buildscript is sufficient for specifying the link flags in all cases. In newer versions of Rust, the redundant linker flags generate a warning.

Tested on Linux and Windows, with and without `use-pkgconfig` feature. I don't have an OSX system to test on.