### PR TITLE
Change Color to be a struct rather than an enum

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -21,3 +21,18 @@ sdl2::hint::set_video_minimize_on_focus_lost(bool) -> bool;
 sdl2::hint::set_video_minimize_on_focus_lost_with_priority(bool, sdl2::hint::Hint) -> bool;
 sdl2::hint::get_video_minimize_on_focus_lost() -> bool;
 ```
+
+[PR #629](https://github.com/AngryLawyer/rust-sdl2/pull/629)
+
+* Breaking: Changed Color to be a struct rather than an enum.
+* Takes less space, easier to use, old constructors are still available.
+* Matching is no longer necessary to read the component values.
+* Struct rather than variant construction is required in static initializers.
+
+```rust
+let color = Color { r: 255, g: 0, b: 0, a: 255 };
+let color = Color::RGBA(255, 0, 0, 255);
+let color = Color::RGB(255, 0, 0);
+let (r, g, b) = color.rgb();
+let (r, g, b, a) = color.rgba();
+```

--- a/src/sdl2/gfx/primitives.rs
+++ b/src/sdl2/gfx/primitives.rs
@@ -191,14 +191,7 @@ pub trait ToColor {
 impl ToColor for pixels::Color {
     #[inline]
     fn as_rgba(&self) -> (u8, u8, u8, u8) {
-        match *self {
-            pixels::Color::RGB(r, g, b) => {
-                (r, g, b, 255u8)
-            }
-            pixels::Color::RGBA(r, g, b, a) => {
-                (r, g, b, a)
-            }
-        }
+        self.rgba()
     }
 }
 

--- a/src/sdl2/pixels.rs
+++ b/src/sdl2/pixels.rs
@@ -90,21 +90,28 @@ fn create_palette() {
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-pub enum Color {
-    RGB(u8, u8, u8),
-    RGBA(u8, u8, u8, u8)
+pub struct Color {
+    pub r: u8,
+    pub g: u8,
+    pub b: u8,
+    pub a: u8
 }
 
 impl Color {
+    #[inline]
+    #[allow(non_snake_case)]
+    pub fn RGB(r: u8, g: u8, b: u8) -> Color {
+        Color { r: r, g: g, b: b, a: 0xff }
+    }
+
+    #[inline]
+    #[allow(non_snake_case)]
+    pub fn RGBA(r: u8, g: u8, b: u8, a: u8) -> Color {
+        Color { r: r, g: g, b: b, a: a }
+    }
+
     pub fn to_u32(&self, format: &PixelFormat) -> u32 {
-        match self {
-            &Color::RGB(r, g, b) => {
-                unsafe { ll::SDL_MapRGB(format.raw, r, g, b) }
-            }
-            &Color::RGBA(r, g, b, a) => {
-                unsafe { ll::SDL_MapRGBA(format.raw, r, g, b, a) }
-            }
-        }
+        unsafe { ll::SDL_MapRGBA(format.raw, self.r, self.g, self.b, self.a) }
     }
 
     pub fn from_u32(format: &PixelFormat, pixel: u32) -> Color {
@@ -116,24 +123,20 @@ impl Color {
         Color::RGBA(r, g, b, a)
     }
 
+    #[inline]
     pub fn rgb(&self) -> (u8, u8, u8) {
-        match self {
-            &Color::RGB(r, g, b) => (r, g, b),
-            &Color::RGBA(r, g, b, _) => (r, g, b)
-        }
+        (self.r, self.g, self.b)
     }
 
+    #[inline]
     pub fn rgba(&self) -> (u8, u8, u8, u8) {
-        match self {
-            &Color::RGB(r, g, b) => (r, g, b, 0xff),
-            &Color::RGBA(r, g, b, a) => (r, g, b, a),
-        }
+        (self.r, self.g, self.b, self.a)
     }
 
     // Implemented manually and kept private, because reasons
+    #[inline]
     unsafe fn raw(&self) -> ll::SDL_Color {
-        let (r, g, b, a) = self.rgba();
-        ll::SDL_Color { r: r, g: g, b: b, a: a }
+        ll::SDL_Color { r: self.r, g: self.g, b: self.b, a: self.a }
     }
 }
 

--- a/src/sdl2/pixels.rs
+++ b/src/sdl2/pixels.rs
@@ -135,14 +135,14 @@ impl Color {
 
     // Implemented manually and kept private, because reasons
     #[inline]
-    unsafe fn raw(&self) -> ll::SDL_Color {
+    fn raw(&self) -> ll::SDL_Color {
         ll::SDL_Color { r: self.r, g: self.g, b: self.b, a: self.a }
     }
 }
 
 impl Into<ll::SDL_Color> for Color {
     fn into(self) -> ll::SDL_Color {
-        unsafe { self.raw() }
+        self.raw()
     }
 }
 

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -484,14 +484,8 @@ impl<'a> Renderer<'a> {
 impl<'a> Renderer<'a> {
     /// Sets the color used for drawing operations (Rect, Line and Clear).
     pub fn set_draw_color(&mut self, color: pixels::Color) {
-        let ret = match color {
-            pixels::Color::RGB(r, g, b) => {
-                unsafe { ll::SDL_SetRenderDrawColor(self.raw, r, g, b, 255) }
-            },
-            pixels::Color::RGBA(r, g, b, a) => {
-                unsafe { ll::SDL_SetRenderDrawColor(self.raw, r, g, b, a)  }
-            }
-        };
+        let (r, g, b, a) = color.rgba();
+        let ret = unsafe { ll::SDL_SetRenderDrawColor(self.raw, r, g, b, a) };
         // Should only fail on an invalid renderer
         if ret != 0 { panic!(get_error()) }
     }

--- a/src/sdl2/surface.rs
+++ b/src/sdl2/surface.rs
@@ -370,11 +370,7 @@ impl SurfaceRef {
     }
 
     pub fn set_color_mod(&mut self, color: pixels::Color) {
-        let (r, g, b) = match color {
-            pixels::Color::RGB(r, g, b) => (r, g, b),
-            pixels::Color::RGBA(r, g, b, _) => (r, g, b)
-        };
-
+        let (r, g, b) = color.rgb();
         let result = unsafe { ll::SDL_SetSurfaceColorMod(self.raw(), r, g, b) };
 
         if result != 0 {

--- a/src/sdl2/ttf/font.rs
+++ b/src/sdl2/ttf/font.rs
@@ -9,17 +9,9 @@ use std::marker::PhantomData;
 use ::surface::Surface;
 use ::sys::surface::SDL_Surface;
 use ::get_error;
-use ::pixels::{self,Color};
-use ::sys::pixels::SDL_Color;
+use ::pixels::Color;
 use ::rwops::RWops;
 use super::ffi;
-
-/// Converts a rust-SDL2 color to its C ffi representation.
-#[inline]
-fn color_to_c_color(color: Color) -> SDL_Color {
-    SDL_Color { r: color.r, g: color.g, b: color.b, a: color.a }
-}
-
 
 // Absolute paths are a workaround for https://github.com/rust-lang-nursery/bitflags/issues/39 .
 bitflags! {
@@ -159,7 +151,7 @@ impl<'f,'text> PartialRendering<'f,'text> {
     pub fn solid<'b, T>(self, color: T )
             -> FontResult<Surface<'b>> where T: Into<Color> {
         let source = try!(self.text.convert());
-        let color = color_to_c_color(color.into());
+        let color = color.into().into();
         let raw = unsafe {
             match self.text {
                 RenderableText::Utf8(_) | RenderableText::Char(_) => {
@@ -181,8 +173,8 @@ impl<'f,'text> PartialRendering<'f,'text> {
     pub fn shaded<'b, T>(self, color: T, background: T)
             -> FontResult<Surface<'b>> where T: Into<Color> {
         let source = try!(self.text.convert());
-        let foreground = color_to_c_color(color.into());
-        let background = color_to_c_color(background.into());
+        let foreground = color.into().into();
+        let background = background.into().into();
         let raw = unsafe {
             match self.text {
                 RenderableText::Utf8(_) | RenderableText::Char(_) => {
@@ -204,7 +196,7 @@ impl<'f,'text> PartialRendering<'f,'text> {
     pub fn blended<'b, T>(self, color: T)
             -> FontResult<Surface<'b>> where T: Into<Color> {
         let source = try!(self.text.convert());
-        let color = color_to_c_color(color.into());
+        let color = color.into().into();
         let raw = unsafe {
             match self.text {
                 RenderableText::Utf8(_) | RenderableText::Char(_) => {
@@ -227,7 +219,7 @@ impl<'f,'text> PartialRendering<'f,'text> {
     pub fn blended_wrapped<'b, T>(self, color: T, wrap_max_width: u32)
             -> FontResult<Surface<'b>> where T: Into<Color> {
         let source = try!(self.text.convert());
-        let color = color_to_c_color(color.into());
+        let color = color.into().into();
         let raw = unsafe {
             match self.text {
                 RenderableText::Utf8(_) | RenderableText::Char(_) => {

--- a/src/sdl2/ttf/font.rs
+++ b/src/sdl2/ttf/font.rs
@@ -17,10 +17,7 @@ use super::ffi;
 /// Converts a rust-SDL2 color to its C ffi representation.
 #[inline]
 fn color_to_c_color(color: Color) -> SDL_Color {
-    match color {
-        pixels::Color::RGB(r, g, b)     => SDL_Color { r: r, g: g, b: b, a: 255 },
-        pixels::Color::RGBA(r, g, b, a) => SDL_Color { r: r, g: g, b: b, a: a   }
-    }
+    SDL_Color { r: color.r, g: color.g, b: color.b, a: color.a }
 }
 
 


### PR DESCRIPTION
This reduces the size of the type and eliminates the need to branch to read from it, increasing its usability, and bringing it closer to the conceptual Color type used by most libraries and SDL itself.

This *is* a breaking change, but the `RGB` and `RGBA` constructor functions should make the impact minimal for anybody not manually matching.

I suppose I should make a note about some of the other inconsistencies; `raw()` is private, "because reasons", but `Color` implements `Into<ll::SDL_Color>` meaning the conversion is publicly available as safe anyways, and the `ttf` module seems to independently re-implement this function for no discernible reason. This could perhaps also be improved.