### PR TITLE
Split renderer

### DIFF
--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -14,17 +14,18 @@ fn main() {
     let window = video_subsystem.window("SDL2", 640, 480)
         .position_centered().build().unwrap();
 
-    let mut renderer = window.renderer()
+    let mut canvas = window.into_canvas()
         .accelerated().build().unwrap();
+    let texture_creator = canvas.texture_creator();
 
-    renderer.set_draw_color(sdl2::pixels::Color::RGBA(0,0,0,255));
+    canvas.set_draw_color(sdl2::pixels::Color::RGBA(0,0,0,255));
 
     let mut timer = sdl_context.timer().unwrap();
 
     let mut event_pump = sdl_context.event_pump().unwrap();
 
     let temp_surface = sdl2::surface::Surface::load_bmp(Path::new("assets/animate.bmp")).unwrap();
-    let texture = renderer.create_texture_from_surface(&temp_surface).unwrap();
+    let texture = texture_creator.create_texture_from_surface(&temp_surface).unwrap();
     
     let center = Point::new(320,240);
     let mut source_rect = Rect::new(0, 0, 128, 82);
@@ -45,9 +46,9 @@ fn main() {
         let ticks = timer.ticks();
 
         source_rect.set_x((128 * ((ticks / 100) % 6) ) as i32);
-        renderer.clear();
-        renderer.copy_ex(&texture, Some(source_rect), Some(dest_rect), 10.0, None, true, false).unwrap();
-        renderer.present();
+        canvas.clear();
+        canvas.copy_ex(&texture, Some(source_rect), Some(dest_rect), 10.0, None, true, false).unwrap();
+        canvas.present();
 
         std::thread::sleep(Duration::from_millis(100));
     }

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -14,11 +14,11 @@ pub fn main() {
         .build()
         .unwrap();
 
-    let mut renderer = window.renderer().build().unwrap();
+    let mut canvas = window.into_canvas().build().unwrap();
 
-    renderer.set_draw_color(Color::RGB(255, 0, 0));
-    renderer.clear();
-    renderer.present();
+    canvas.set_draw_color(Color::RGB(255, 0, 0));
+    canvas.clear();
+    canvas.present();
     let mut event_pump = sdl_context.event_pump().unwrap();
 
     'running: loop {

--- a/examples/game-of-life.rs
+++ b/examples/game-of-life.rs
@@ -1,0 +1,241 @@
+extern crate sdl2;
+
+use sdl2::rect::{Point, Rect};
+use sdl2::pixels::Color;
+use sdl2::event::Event;
+use sdl2::mouse::MouseButton;
+use sdl2::keyboard::Keycode;
+use sdl2::video::{Window, WindowContext};
+use sdl2::render::{Canvas, Texture, TextureCreator};
+use game_of_life::{SQUARE_SIZE, PLAYGROUND_WIDTH, PLAYGROUND_HEIGHT};
+
+mod game_of_life {
+    pub const SQUARE_SIZE: u32 = 16;
+    pub const PLAYGROUND_WIDTH: u32 = 49;
+    pub const PLAYGROUND_HEIGHT: u32 = 40;
+
+    #[derive(Copy, Clone)]
+    pub enum State {
+        Paused,
+        Playing,
+    }
+
+    pub struct GameOfLife {
+        playground: [bool; (PLAYGROUND_WIDTH*PLAYGROUND_HEIGHT) as usize],
+        state: State,
+    }
+
+    impl GameOfLife {
+        pub fn new() -> GameOfLife {
+            let mut playground = [false; (PLAYGROUND_WIDTH * PLAYGROUND_HEIGHT) as usize];
+
+            // let's make a nice default pattern !
+            for i in 1..(PLAYGROUND_HEIGHT-1) {
+                playground[(1 + i* PLAYGROUND_WIDTH) as usize] = true;
+                playground[((PLAYGROUND_WIDTH-2) + i* PLAYGROUND_WIDTH) as usize] = true;
+            }
+            for j in 2..(PLAYGROUND_WIDTH-2) {
+                playground[(1*PLAYGROUND_WIDTH + j) as usize] = true;
+                playground[((PLAYGROUND_HEIGHT-2)*PLAYGROUND_WIDTH + j) as usize] = true;
+            }
+
+            GameOfLife {
+                playground: playground,
+                state: State::Paused,
+            }
+        }
+
+        pub fn get(&self, x: i32, y: i32) -> Option<bool> {
+            if x >= 0 && y >= 0 &&
+               (x as u32) < PLAYGROUND_WIDTH && (y as u32) < PLAYGROUND_HEIGHT {
+                Some(self.playground[(x as u32 + (y as u32)* PLAYGROUND_WIDTH) as usize])
+            } else {
+                None
+            }
+        }
+
+        pub fn get_mut<'a>(&'a mut self, x: i32, y: i32) -> Option<&'a mut bool> {
+            if x >= 0 && y >= 0 &&
+               (x as u32) < PLAYGROUND_WIDTH && (y as u32) < PLAYGROUND_HEIGHT {
+                Some(&mut self.playground[(x as u32 + (y as u32)* PLAYGROUND_WIDTH) as usize])
+            } else {
+                None
+            }
+        }
+
+        pub fn toggle_state(&mut self) {
+            self.state = match self.state {
+                State::Paused => State::Playing,
+                State::Playing => State::Paused,
+            }
+        }
+
+        pub fn state(&self) -> State {
+            self.state
+        }
+
+        pub fn update(&mut self) {
+            let mut new_playground = self.playground;
+            for (u, mut square) in new_playground.iter_mut().enumerate() {
+                let u = u as u32;
+                let x = u % PLAYGROUND_WIDTH;
+                let y = u / PLAYGROUND_WIDTH;
+                let mut count : u32 = 0;
+                for i in -1..2 {
+                    for j in -1..2 {
+                        if !(i == 0 && j == 0) {
+                            let peek_x : i32 = (x as i32) + i;
+                            let peek_y : i32 = (y as i32) + j;
+                            match self.get(peek_x, peek_y) {
+                                Some(true) => {
+                                    count += 1;
+                                },
+                                _ => {},
+                            }
+                        }
+                    }
+                }
+                if count > 3 || count < 2 {
+                    *square = false;
+                } else if count == 3 {
+                    *square = true;
+                } else if count == 2 {
+                    *square = *square;
+                }
+            }
+            self.playground = new_playground;
+        }
+    }
+
+
+
+    impl<'a> IntoIterator for &'a GameOfLife {
+        type Item = &'a bool;
+        type IntoIter = ::std::slice::Iter<'a, bool>;
+        fn into_iter(self) -> ::std::slice::Iter<'a, bool> {
+            self.playground.iter()
+        }
+    }
+}
+
+fn dummy_texture<'a>(canvas: &mut Canvas<Window>, texture_creator: &'a TextureCreator<WindowContext>) -> Texture<'a>{
+    let mut square_texture : Texture =
+        texture_creator.create_texture_target(None, SQUARE_SIZE, SQUARE_SIZE).unwrap();
+    {
+        // let's change the texture we just created
+        let mut texture_canvas = canvas.with_target(&mut square_texture).unwrap();
+        texture_canvas.set_draw_color(Color::RGB(0, 0, 0));
+        texture_canvas.clear();
+        for i in 0..SQUARE_SIZE {
+            for j in 0..SQUARE_SIZE {
+                // drawing pixel by pixel isn't very effective, but we only do it once and store
+                // the texture afterwards so it's still alright!
+                if (i+j) % 7 == 0 {
+                    // this doesn't mean anything, there was some trial and serror to find
+                    // something that wasn't too ugly
+                    texture_canvas.set_draw_color(Color::RGB(192, 192, 192));
+                    texture_canvas.draw_point(Point::new(i as i32, j as i32)).unwrap();
+                }
+                if (i+j*2) % 5 == 0 {
+                    texture_canvas.set_draw_color(Color::RGB(64, 64, 64));
+                    texture_canvas.draw_point(Point::new(i as i32, j as i32)).unwrap();
+                }
+            }
+        }
+    }
+    square_texture
+}
+
+pub fn main() {
+    let sdl_context = sdl2::init().unwrap();
+    let video_subsystem = sdl_context.video().unwrap();
+    
+    // the window is the representation of a window in your operating system,
+    // however you can only manipulate properties of that window, like its size, whether it's
+    // fullscreen, ... but you cannot change its content without using a Canvas or using the
+    // `surface()` method.
+    let window = video_subsystem
+        .window("rust-sdl2 demo: Game of Life",
+                SQUARE_SIZE*PLAYGROUND_WIDTH,
+                SQUARE_SIZE*PLAYGROUND_HEIGHT)
+        .position_centered()
+        .build()
+        .unwrap();
+
+    // the canvas allows us to both manipulate the property of the window and to change its content
+    // via hardware or software rendering. See CanvasBuilder for more info.
+    let mut canvas = window.into_canvas()
+        .target_texture()
+        .present_vsync()
+        .build().unwrap();
+
+    println!("Using SDL_Renderer \"{}\"", canvas.info().name);
+    canvas.set_draw_color(Color::RGB(0, 0, 0));
+    // clears the canvas with the color we set in `set_draw_color`.
+    canvas.clear();
+    // However the canvas has not been updated to the window yet, everything has been processed to
+    // an internal buffer, but if we want our buffer to be displayed on the window, we need to call
+    // `present`. We need to call this everytime we want to render a new frame on the window.
+    canvas.present();
+
+    // this struct manages textures. For lifetime reasons, the canvas cannot directly create
+    // textures, you have to create a `TextureCreator` instead.
+    let texture_creator : TextureCreator<_> = canvas.texture_creator();
+
+    // Create a "target" texture so that we can use our Renderer with it later
+    let square_texture = dummy_texture(&mut canvas, &texture_creator);
+    let mut game = game_of_life::GameOfLife::new();
+
+    let mut event_pump = sdl_context.event_pump().unwrap();
+    let mut frame : u32 = 0;
+    'running: loop {
+        // get the inputs here
+        for event in event_pump.poll_iter() {
+            match event {
+                Event::Quit {..} | Event::KeyDown { keycode: Some(Keycode::Escape), .. } => {
+                    break 'running
+                },
+                Event::KeyDown { keycode: Some(Keycode::Space), repeat: false, .. } => {
+                    game.toggle_state();
+                },
+                Event::MouseButtonDown { x, y, mouse_btn: MouseButton::Left, .. } => {
+                    let x = (x as u32) / SQUARE_SIZE;
+                    let y = (y as u32) / SQUARE_SIZE;
+                    match game.get_mut(x as i32, y as i32) {
+                        Some(mut square) => {*square = !(*square);},
+                        None => {panic!()}
+                    };
+                },
+                _ => {}
+            }
+        }
+
+        // update the game loop here
+        if frame >= 29 {
+            game.update();
+            frame = 0;
+        }
+
+        canvas.set_draw_color(Color::RGB(0, 0, 0));
+        canvas.clear();
+        for (i, unit) in (&game).into_iter().enumerate() {
+            let i = i as u32;
+            match *unit {
+                true => {
+                    canvas.copy(&square_texture,
+                                None,
+                                Rect::new(((i % PLAYGROUND_WIDTH) * SQUARE_SIZE) as i32,
+                                          ((i / PLAYGROUND_WIDTH) * SQUARE_SIZE) as i32,
+                                          SQUARE_SIZE,
+                                          SQUARE_SIZE)).unwrap();
+                },
+                false => {},
+            }
+        }
+        canvas.present();
+        match game.state() {
+            game_of_life::State::Playing => { frame += 1; },
+            _ => {}
+        };
+    }
+}

--- a/examples/gfx_demo.rs
+++ b/examples/gfx_demo.rs
@@ -17,7 +17,6 @@ macro_rules! rect(
 );
 
 fn main() {
-
     let sdl_context = sdl2::init().unwrap();
     let video_subsys = sdl_context.video().unwrap();
     let window = video_subsys.window("rust-sdl2_gfx: draw line & FPSManager", SCREEN_WIDTH, SCREEN_HEIGHT)
@@ -26,11 +25,11 @@ fn main() {
         .build()
         .unwrap();
 
-    let mut renderer = window.renderer().build().unwrap();
+    let mut canvas = window.into_canvas().build().unwrap();
 
-    renderer.set_draw_color(pixels::Color::RGB(0, 0, 0));
-    renderer.clear();
-    renderer.present();
+    canvas.set_draw_color(pixels::Color::RGB(0, 0, 0));
+    canvas.clear();
+    canvas.present();
 
     let mut lastx = 0;
     let mut lasty = 0;
@@ -50,20 +49,20 @@ fn main() {
                     } else if keycode == Keycode::Space {
                         println!("space down");
                         for i in 0..400 {
-                            renderer.pixel(i as i16, i as i16, 0xFF000FFu32).unwrap();
+                            canvas.pixel(i as i16, i as i16, 0xFF000FFu32).unwrap();
                         }
-                        renderer.present();
+                        canvas.present();
 
                     }
                 }
 
                 Event::MouseButtonDown {x, y, ..} => {
                     let color = pixels::Color::RGB(x as u8, y as u8, 255);
-                    let _ = renderer.line(lastx, lasty, x as i16, y as i16, color);
+                    let _ = canvas.line(lastx, lasty, x as i16, y as i16, color);
                     lastx = x as i16;
                     lasty = y as i16;
                     println!("mouse btn down at ({},{})", x, y);
-                    renderer.present();
+                    canvas.present();
                 }
 
                 _ => {}

--- a/examples/image_demo.rs
+++ b/examples/image_demo.rs
@@ -16,11 +16,12 @@ pub fn run(png: &Path) {
       .build()
       .unwrap();
 
-    let mut renderer = window.renderer().software().build().unwrap();
-    let texture = renderer.load_texture(png).unwrap();
+    let mut canvas = window.into_canvas().software().build().unwrap();
+    let texture_creator = canvas.texture_creator();
+    let texture = texture_creator.load_texture(png).unwrap();
 
-    renderer.copy(&texture, None, None).expect("Render failed");
-    renderer.present();
+    canvas.copy(&texture, None, None).expect("Render failed");
+    canvas.present();
 
     'mainloop: loop {
         for event in sdl_context.event_pump().unwrap().poll_iter() {

--- a/examples/message-box.rs
+++ b/examples/message-box.rs
@@ -15,11 +15,11 @@ pub fn main() {
         .build()
         .unwrap();
 
-    let mut renderer = window.renderer().build().unwrap();
+    let mut canvas = window.into_canvas().build().unwrap();
 
-    renderer.set_draw_color(Color::RGB(255, 0, 0));
-    renderer.clear();
-    renderer.present();
+    canvas.set_draw_color(Color::RGB(255, 0, 0));
+    canvas.clear();
+    canvas.present();
     let mut event_pump = sdl_context.event_pump().unwrap();
 
     'running: loop {
@@ -30,7 +30,7 @@ pub fn main() {
                         show_simple_message_box(MESSAGEBOX_ERROR,
                                                 "Some title",
                                                 "Some information inside the window",
-                                                renderer.window());
+                                                canvas.window());
                     match res {
                         Ok(_) => {}
                         Err(ShowMessageError::SdlError(string)) => {

--- a/examples/renderer-target.rs
+++ b/examples/renderer-target.rs
@@ -1,0 +1,53 @@
+extern crate sdl2;
+
+use sdl2::event::Event;
+use sdl2::keyboard::Keycode;
+use sdl2::pixels::{Color, PixelFormatEnum};
+use sdl2::rect::{Point, Rect};
+
+fn main() {
+    let sdl_context = sdl2::init().unwrap();
+    let video_subsystem = sdl_context.video().unwrap();
+    let window = video_subsystem
+        .window("rust-sdl2 resource-manager demo", 800, 600)
+        .position_centered()
+        .build()
+        .unwrap();
+    let mut canvas = window.into_canvas().software().build().unwrap();
+    let creator = canvas.texture_creator();
+    let mut texture = creator
+        .create_texture_target(PixelFormatEnum::RGBA8888, 400, 300)
+        .unwrap();
+
+    let mut angle = 0.0;
+
+    'mainloop: loop {
+        for event in sdl_context.event_pump().unwrap().poll_iter() {
+            match event {
+                Event::Quit { .. } => break 'mainloop,
+                Event::KeyDown { keycode: Some(Keycode::Escape), .. } => break 'mainloop,
+                _ => {}
+            }
+        }
+        angle = (angle + 0.5) % 360.;
+        {
+            let mut target = canvas.with_target(&mut texture).unwrap();
+            target.clear();
+            target.set_draw_color(Color::RGBA(255, 0, 0, 255));
+            target.fill_rect(Rect::new(0, 0, 400, 300)).unwrap();
+        } // <- drops the `target` so that the `canvas` can be used again
+        canvas.set_draw_color(Color::RGBA(0, 0, 0, 255));
+        let dst = Some(Rect::new(0, 0, 400, 300));
+        canvas.clear();
+        canvas
+            .copy_ex(&texture,
+                     None,
+                     dst,
+                     angle,
+                     Some(Point::new(400, 300)),
+                     false,
+                     false)
+            .unwrap();
+        canvas.present();
+    }
+}

--- a/examples/renderer-texture.rs
+++ b/examples/renderer-texture.rs
@@ -15,9 +15,10 @@ pub fn main() {
         .build()
         .unwrap();
 
-    let mut renderer = window.renderer().build().unwrap();
+    let mut canvas = window.into_canvas().build().unwrap();
+    let texture_creator = canvas.texture_creator();
 
-    let mut texture = renderer.create_texture_streaming(
+    let mut texture = texture_creator.create_texture_streaming(
         PixelFormatEnum::RGB24, 256, 256).unwrap();
     // Create a red-green gradient
     texture.with_lock(None, |buffer: &mut [u8], pitch: usize| {
@@ -31,11 +32,11 @@ pub fn main() {
         }
     }).unwrap();
 
-    renderer.clear();
-    renderer.copy(&texture, None, Some(Rect::new(100, 100, 256, 256))).unwrap();
-    renderer.copy_ex(&texture, None, 
+    canvas.clear();
+    canvas.copy(&texture, None, Some(Rect::new(100, 100, 256, 256))).unwrap();
+    canvas.copy_ex(&texture, None,
         Some(Rect::new(450, 100, 256, 256)), 30.0, None, false, false).unwrap();
-    renderer.present();
+    canvas.present();
 
     let mut event_pump = sdl_context.event_pump().unwrap();
 

--- a/examples/renderer-yuv.rs
+++ b/examples/renderer-yuv.rs
@@ -15,9 +15,10 @@ pub fn main() {
         .build()
         .unwrap();
 
-    let mut renderer = window.renderer().build().unwrap();
+    let mut canvas = window.into_canvas().build().unwrap();
+    let texture_creator = canvas.texture_creator();
 
-    let mut texture = renderer.create_texture_streaming(
+    let mut texture = texture_creator.create_texture_streaming(
         PixelFormatEnum::IYUV, 256, 256).unwrap();
     // Create a U-V gradient
     texture.with_lock(None, |buffer: &mut [u8], pitch: usize| {
@@ -48,9 +49,9 @@ pub fn main() {
         }
     }).unwrap();
 
-    renderer.clear();
-    renderer.copy(&texture, None, Some(Rect::new(100, 100, 256, 256))).unwrap();
-    renderer.present();
+    canvas.clear();
+    canvas.copy(&texture, None, Some(Rect::new(100, 100, 256, 256))).unwrap();
+    canvas.present();
 
     let mut event_pump = sdl_context.event_pump().unwrap();
 

--- a/examples/resource_manager.rs
+++ b/examples/resource_manager.rs
@@ -1,0 +1,153 @@
+extern crate sdl2;
+
+use sdl2::event::Event;
+use sdl2::image::{LoadTexture, INIT_PNG, INIT_JPG};
+use sdl2::keyboard::Keycode;
+use sdl2::pixels::Color;
+use sdl2::render::{TextureCreator, Texture};
+use sdl2::ttf::{Font, Sdl2TtfContext};
+
+use std::env;
+use std::borrow::Borrow;
+use std::collections::HashMap;
+use std::hash::Hash;
+use std::rc::Rc;
+
+fn main() {
+    let args: Vec<_> = env::args().collect();
+
+    if args.len() < 3 {
+        println!("Usage: cargo run /path/to/image.(png|jpg) /path/to/font.(ttf|ttc|fon)")
+    } else {
+        let image_path = &args[1];
+        let font_path = &args[2];
+
+        let sdl_context = sdl2::init().unwrap();
+        let video_subsystem = sdl_context.video().unwrap();
+        let font_context = sdl2::ttf::init().unwrap();
+        let _image_context = sdl2::image::init(INIT_PNG | INIT_JPG).unwrap();
+        let window = video_subsystem
+            .window("rust-sdl2 resource-manager demo", 800, 600)
+            .position_centered()
+            .build()
+            .unwrap();
+        let mut canvas = window.into_canvas().software().build().unwrap();
+        let texture_creator = canvas.texture_creator();
+        let mut texture_manager = TextureManager::new(&texture_creator);
+        let mut font_manager = FontManager::new(&font_context);
+        let details = FontDetails {
+            path: font_path.clone(),
+            size: 32,
+        };
+
+        'mainloop: loop {
+            for event in sdl_context.event_pump().unwrap().poll_iter() {
+                match event {
+                    Event::Quit { .. } => break 'mainloop,
+                    Event::KeyDown { keycode: Some(Keycode::Escape), .. } => break 'mainloop,
+                    _ => {}
+                }
+            }
+            // will load the image texture + font only once
+            let texture = texture_manager.load(image_path).unwrap();
+            let font = font_manager.load(&details).unwrap();
+
+            // not recommended to create a texture from the font each iteration
+            // but it is the simplest thing to do for this example
+            let surface = font.render("Hello Rust!")
+                .blended(Color::RGBA(255, 0, 0, 255))
+                .unwrap();
+            let font_texture = texture_creator
+                .create_texture_from_surface(&surface)
+                .unwrap();
+
+            //draw all
+            canvas.clear();
+            canvas.copy(&texture, None, None).unwrap();
+            canvas.copy(&font_texture, None, None).unwrap();
+            canvas.present();
+        }
+    }
+}
+
+type TextureManager<'l, T> = ResourceManager<'l, String, Texture<'l>, TextureCreator<T>>;
+type FontManager<'l> = ResourceManager<'l, FontDetails, Font<'l, 'static>, Sdl2TtfContext>;
+
+// Generic struct to cache any resource loaded by a ResourceLoader
+pub struct ResourceManager<'l, K, R, L>
+    where K: Hash + Eq,
+          L: 'l + ResourceLoader<'l, R>
+{
+    loader: &'l L,
+    cache: HashMap<K, Rc<R>>,
+}
+
+impl<'l, K, R, L> ResourceManager<'l, K, R, L>
+    where K: Hash + Eq,
+          L: ResourceLoader<'l, R>
+{
+    pub fn new(loader: &'l L) -> Self {
+        ResourceManager {
+            cache: HashMap::new(),
+            loader: loader,
+        }
+    }
+
+    // Generics magic to allow a HashMap to use String as a key
+    // while allowing it to use &str for gets
+    pub fn load<D>(&mut self, details: &D) -> Result<Rc<R>, String>
+        where L: ResourceLoader<'l, R, Args = D>,
+              D: Eq + Hash + ?Sized,
+              K: Borrow<D> + for<'a> From<&'a D>
+    {
+        self.cache
+            .get(details)
+            .cloned()
+            .map_or_else(|| {
+                             let resource = Rc::new(self.loader.load(details)?);
+                             self.cache.insert(details.into(), resource.clone());
+                             Ok(resource)
+                         },
+                         Ok)
+    }
+}
+
+// TextureCreator knows how to load Textures
+impl<'l, T> ResourceLoader<'l, Texture<'l>> for TextureCreator<T> {
+    type Args = str;
+    fn load(&'l self, path: &str) -> Result<Texture, String> {
+        println!("LOADED A TEXTURE");
+        self.load_texture(path)
+    }
+}
+
+// Font Context knows how to load Fonts
+impl<'l> ResourceLoader<'l, Font<'l, 'static>> for Sdl2TtfContext {
+    type Args = FontDetails;
+    fn load(&'l self, details: &FontDetails) -> Result<Font<'l, 'static>, String> {
+        println!("LOADED A FONT");
+        self.load_font(&details.path, details.size)
+    }
+}
+
+// Generic trait to Load any Resource Kind
+pub trait ResourceLoader<'l, R> {
+    type Args: ?Sized;
+    fn load(&'l self, data: &Self::Args) -> Result<R, String>;
+}
+
+// Information needed to load a Font
+#[derive(PartialEq, Eq, Hash)]
+pub struct FontDetails {
+    pub path: String,
+    pub size: u16,
+}
+
+impl<'a> From<&'a FontDetails> for FontDetails {
+    fn from(details: &'a FontDetails) -> FontDetails {
+        FontDetails {
+            path: details.path.clone(),
+            size: details.size,
+        }
+    }
+}

--- a/examples/ttf_demo.rs
+++ b/examples/ttf_demo.rs
@@ -54,19 +54,20 @@ fn run(font_path: &Path) {
         .build()
         .unwrap();
 
-    let mut renderer = window.renderer().build().unwrap();
+    let mut canvas = window.into_canvas().build().unwrap();
+    let texture_creator = canvas.texture_creator();
 
     // Load a font
     let mut font = ttf_context.load_font(font_path, 128).unwrap();
     font.set_style(sdl2::ttf::STYLE_BOLD);
     
-    // render a surface, and convert it to a texture bound to the renderer
+    // render a surface, and convert it to a texture bound to the canvas
     let surface = font.render("Hello Rust!")
         .blended(Color::RGBA(255, 0, 0, 255)).unwrap();
-    let mut texture = renderer.create_texture_from_surface(&surface).unwrap();
+    let mut texture = texture_creator.create_texture_from_surface(&surface).unwrap();
 
-    renderer.set_draw_color(Color::RGBA(195, 217, 255, 255));
-    renderer.clear();
+    canvas.set_draw_color(Color::RGBA(195, 217, 255, 255));
+    canvas.clear();
 
     let TextureQuery { width, height, .. } = texture.query();
 
@@ -74,8 +75,8 @@ fn run(font_path: &Path) {
     let padding = 64;
     let target = get_centered_rect(width, height, SCREEN_WIDTH - padding, SCREEN_HEIGHT - padding);
 
-    renderer.copy(&mut texture, None, Some(target)).unwrap();
-    renderer.present();
+    canvas.copy(&mut texture, None, Some(target)).unwrap();
+    canvas.present();
 
     'mainloop: loop {
         for event in sdl_context.event_pump().unwrap().poll_iter() {

--- a/examples/window-properties.rs
+++ b/examples/window-properties.rs
@@ -14,7 +14,7 @@ pub fn main() {
         .build()
         .unwrap();
 
-    let mut renderer = window.renderer().present_vsync().build().unwrap();
+    let mut canvas = window.into_canvas().present_vsync().build().unwrap();
 
     let mut tick = 0;
 
@@ -31,7 +31,7 @@ pub fn main() {
 
         {
             // Update the window title.
-            let mut window = renderer.window_mut().unwrap();
+            let mut window = canvas.window_mut();
 
             let position = window.position();
             let size = window.size();
@@ -46,8 +46,8 @@ pub fn main() {
             tick += 1;
         }
 
-        renderer.set_draw_color(Color::RGB(0, 0, 0));
-        renderer.clear();
-        renderer.present();
+        canvas.set_draw_color(Color::RGB(0, 0, 0));
+        canvas.clear();
+        canvas.present();
     }
 }

--- a/examples/window-properties.rs
+++ b/examples/window-properties.rs
@@ -8,7 +8,8 @@ pub fn main() {
     let sdl_context = sdl2::init().unwrap();
     let video_subsystem = sdl_context.video().unwrap();
 
-    let window = video_subsystem.window("rust-sdl2 demo: Window", 800, 600)
+    let window = video_subsystem
+        .window("rust-sdl2 demo: Window", 800, 600)
         .resizable()
         .build()
         .unwrap();
@@ -22,10 +23,8 @@ pub fn main() {
     'running: loop {
         for event in event_pump.poll_iter() {
             match event {
-                Event::Quit {..}
-                | Event::KeyDown { keycode: Some(Keycode::Escape), .. } => {
-                    break 'running
-                },
+                Event::Quit { .. } |
+                Event::KeyDown { keycode: Some(Keycode::Escape), .. } => break 'running,
                 _ => {}
             }
         }
@@ -36,7 +35,12 @@ pub fn main() {
 
             let position = window.position();
             let size = window.size();
-            let title = format!("Window - pos({}x{}), size({}x{}): {}", position.0, position.1, size.0, size.1, tick);
+            let title = format!("Window - pos({}x{}), size({}x{}): {}",
+                                position.0,
+                                position.1,
+                                size.0,
+                                size.1,
+                                tick);
             window.set_title(&title).unwrap();
 
             tick += 1;

--- a/src/sdl2/gfx/primitives.rs
+++ b/src/sdl2/gfx/primitives.rs
@@ -6,7 +6,7 @@ use std::ptr;
 use std::ffi::CString;
 use num::traits::ToPrimitive;
 use libc::{c_void, c_int, c_char};
-use render::Renderer;
+use render::Canvas;
 use surface::Surface;
 use pixels;
 use get_error;
@@ -698,7 +698,7 @@ pub trait DrawRenderer {
     fn string<C: ToColor>(&self, x: i16, y: i16, s: &str, color: C) -> Result<(), String>;
 }
 
-impl<'a> DrawRenderer for Renderer<'a> {
+impl<T, TC> DrawRenderer for Canvas<T, TC> {
     fn pixel<C: ToColor>(&self, x: i16, y: i16, color: C) -> Result<(), String> {
         let ret = unsafe { ll::pixelColor(self.raw(), x, y, color.as_u32()) };
         if ret == 0 { Ok(()) } else { Err(get_error()) }

--- a/src/sdl2/gfx/primitives.rs
+++ b/src/sdl2/gfx/primitives.rs
@@ -698,7 +698,7 @@ pub trait DrawRenderer {
     fn string<C: ToColor>(&self, x: i16, y: i16, s: &str, color: C) -> Result<(), String>;
 }
 
-impl<T, TC> DrawRenderer for Canvas<T, TC> {
+impl<T> DrawRenderer for Canvas<T> where T: ::render::RenderTarget {
     fn pixel<C: ToColor>(&self, x: i16, y: i16, color: C) -> Result<(), String> {
         let ret = unsafe { ll::pixelColor(self.raw(), x, y, color.as_u32()) };
         if ret == 0 { Ok(()) } else { Err(get_error()) }

--- a/src/sdl2/gfx/primitives.rs
+++ b/src/sdl2/gfx/primitives.rs
@@ -6,10 +6,10 @@ use std::ptr;
 use std::ffi::CString;
 use num::traits::ToPrimitive;
 use libc::{c_void, c_int, c_char};
-use ::render::Renderer;
-use ::surface::Surface;
-use ::pixels;
-use ::get_error;
+use render::Renderer;
+use surface::Surface;
+use pixels;
+use get_error;
 
 #[allow(dead_code)]
 mod ll {
@@ -19,162 +19,492 @@ mod ll {
     use sys::render::SDL_Renderer;
     use sys::surface::SDL_Surface;
     extern "C" {
-        pub fn pixelColor(renderer: *const SDL_Renderer, x: int16_t, y: int16_t,
-                          color: uint32_t) -> c_int;
-        pub fn pixelRGBA(renderer: *const SDL_Renderer, x: int16_t, y: int16_t,
-                         r: uint8_t, g: uint8_t, b: uint8_t, a: uint8_t) -> c_int;
-        pub fn hlineColor(renderer: *const SDL_Renderer, x1: int16_t, x2: int16_t,
-                          y: int16_t, color: uint32_t) -> c_int;
-        pub fn hlineRGBA(renderer: *const SDL_Renderer, x1: int16_t, x2: int16_t,
-                         y: int16_t, r: uint8_t, g: uint8_t, b: uint8_t, a: uint8_t) ->
-            c_int;
-        pub fn vlineColor(renderer: *const SDL_Renderer, x: int16_t, y1: int16_t,
-                          y2: int16_t, color: uint32_t) -> c_int;
-        pub fn vlineRGBA(renderer: *const SDL_Renderer, x: int16_t, y1: int16_t,
-                         y2: int16_t, r: uint8_t, g: uint8_t, b: uint8_t, a: uint8_t) ->
-            c_int;
-        pub fn rectangleColor(renderer: *const SDL_Renderer, x1: int16_t, y1: int16_t,
-                              x2: int16_t, y2: int16_t, color: uint32_t) -> c_int;
-        pub fn rectangleRGBA(renderer: *const SDL_Renderer, x1: int16_t, y1: int16_t,
-                             x2: int16_t, y2: int16_t, r: uint8_t, g: uint8_t, b: uint8_t,
-                             a: uint8_t) -> c_int;
-        pub fn roundedRectangleColor(renderer: *const SDL_Renderer, x1: int16_t,
-                                     y1: int16_t, x2: int16_t, y2: int16_t,
-                                     rad: int16_t, color: uint32_t) -> c_int;
-        pub fn roundedRectangleRGBA(renderer: *const SDL_Renderer, x1: int16_t,
-                                    y1: int16_t, x2: int16_t, y2: int16_t,
-                                    rad: int16_t, r: uint8_t, g: uint8_t, b: uint8_t,
-                                    a: uint8_t) -> c_int;
-        pub fn boxColor(renderer: *const SDL_Renderer, x1: int16_t, y1: int16_t,
-                        x2: int16_t, y2: int16_t, color: uint32_t) -> c_int;
-        pub fn boxRGBA(renderer: *const SDL_Renderer, x1: int16_t, y1: int16_t,
-                       x2: int16_t, y2: int16_t, r: uint8_t, g: uint8_t, b: uint8_t,
-                       a: uint8_t) -> c_int;
-        pub fn roundedBoxColor(renderer: *const SDL_Renderer, x1: int16_t,
-                               y1: int16_t, x2: int16_t, y2: int16_t, rad: int16_t,
-                               color: uint32_t) -> c_int;
-        pub fn roundedBoxRGBA(renderer: *const SDL_Renderer, x1: int16_t, y1: int16_t,
-                              x2: int16_t, y2: int16_t, rad: int16_t, r: uint8_t,
-                              g: uint8_t, b: uint8_t, a: uint8_t) -> c_int;
-        pub fn lineColor(renderer: *const SDL_Renderer, x1: int16_t, y1: int16_t,
-                         x2: int16_t, y2: int16_t, color: uint32_t) -> c_int;
-        pub fn lineRGBA(renderer: *const SDL_Renderer, x1: int16_t, y1: int16_t,
-                        x2: int16_t, y2: int16_t, r: uint8_t, g: uint8_t, b: uint8_t,
-                        a: uint8_t) -> c_int;
-        pub fn aalineColor(renderer: *const SDL_Renderer, x1: int16_t, y1: int16_t,
-                           x2: int16_t, y2: int16_t, color: uint32_t) -> c_int;
-        pub fn aalineRGBA(renderer: *const SDL_Renderer, x1: int16_t, y1: int16_t,
-                          x2: int16_t, y2: int16_t, r: uint8_t, g: uint8_t, b: uint8_t,
-                          a: uint8_t) -> c_int;
-        pub fn thickLineColor(renderer: *const SDL_Renderer, x1: int16_t, y1: int16_t,
-                              x2: int16_t, y2: int16_t, width: uint8_t, color: uint32_t)
+        pub fn pixelColor(renderer: *const SDL_Renderer,
+                          x: int16_t,
+                          y: int16_t,
+                          color: uint32_t)
+                          -> c_int;
+        pub fn pixelRGBA(renderer: *const SDL_Renderer,
+                         x: int16_t,
+                         y: int16_t,
+                         r: uint8_t,
+                         g: uint8_t,
+                         b: uint8_t,
+                         a: uint8_t)
+                         -> c_int;
+        pub fn hlineColor(renderer: *const SDL_Renderer,
+                          x1: int16_t,
+                          x2: int16_t,
+                          y: int16_t,
+                          color: uint32_t)
+                          -> c_int;
+        pub fn hlineRGBA(renderer: *const SDL_Renderer,
+                         x1: int16_t,
+                         x2: int16_t,
+                         y: int16_t,
+                         r: uint8_t,
+                         g: uint8_t,
+                         b: uint8_t,
+                         a: uint8_t)
+                         -> c_int;
+        pub fn vlineColor(renderer: *const SDL_Renderer,
+                          x: int16_t,
+                          y1: int16_t,
+                          y2: int16_t,
+                          color: uint32_t)
+                          -> c_int;
+        pub fn vlineRGBA(renderer: *const SDL_Renderer,
+                         x: int16_t,
+                         y1: int16_t,
+                         y2: int16_t,
+                         r: uint8_t,
+                         g: uint8_t,
+                         b: uint8_t,
+                         a: uint8_t)
+                         -> c_int;
+        pub fn rectangleColor(renderer: *const SDL_Renderer,
+                              x1: int16_t,
+                              y1: int16_t,
+                              x2: int16_t,
+                              y2: int16_t,
+                              color: uint32_t)
                               -> c_int;
-        pub fn thickLineRGBA(renderer: *const SDL_Renderer, x1: int16_t, y1: int16_t,
-                             x2: int16_t, y2: int16_t, width: uint8_t, r: uint8_t,
-                             g: uint8_t, b: uint8_t, a: uint8_t) -> c_int;
-        pub fn circleColor(renderer: *const SDL_Renderer, x: int16_t, y: int16_t,
-                           rad: int16_t, color: uint32_t) -> c_int;
-        pub fn circleRGBA(renderer: *const SDL_Renderer, x: int16_t, y: int16_t,
-                          rad: int16_t, r: uint8_t, g: uint8_t, b: uint8_t, a: uint8_t) ->
-            c_int;
-        pub fn arcColor(renderer: *const SDL_Renderer, x: int16_t, y: int16_t,
-                        rad: int16_t, start: int16_t, end: int16_t, color: uint32_t) ->
-            c_int;
-        pub fn arcRGBA(renderer: *const SDL_Renderer, x: int16_t, y: int16_t,
-                       rad: int16_t, start: int16_t, end: int16_t, r: uint8_t,
-                       g: uint8_t, b: uint8_t, a: uint8_t) -> c_int;
-        pub fn aacircleColor(renderer: *const SDL_Renderer, x: int16_t, y: int16_t,
-                             rad: int16_t, color: uint32_t) -> c_int;
-        pub fn aacircleRGBA(renderer: *const SDL_Renderer, x: int16_t, y: int16_t,
-                            rad: int16_t, r: uint8_t, g: uint8_t, b: uint8_t, a: uint8_t)
+        pub fn rectangleRGBA(renderer: *const SDL_Renderer,
+                             x1: int16_t,
+                             y1: int16_t,
+                             x2: int16_t,
+                             y2: int16_t,
+                             r: uint8_t,
+                             g: uint8_t,
+                             b: uint8_t,
+                             a: uint8_t)
+                             -> c_int;
+        pub fn roundedRectangleColor(renderer: *const SDL_Renderer,
+                                     x1: int16_t,
+                                     y1: int16_t,
+                                     x2: int16_t,
+                                     y2: int16_t,
+                                     rad: int16_t,
+                                     color: uint32_t)
+                                     -> c_int;
+        pub fn roundedRectangleRGBA(renderer: *const SDL_Renderer,
+                                    x1: int16_t,
+                                    y1: int16_t,
+                                    x2: int16_t,
+                                    y2: int16_t,
+                                    rad: int16_t,
+                                    r: uint8_t,
+                                    g: uint8_t,
+                                    b: uint8_t,
+                                    a: uint8_t)
+                                    -> c_int;
+        pub fn boxColor(renderer: *const SDL_Renderer,
+                        x1: int16_t,
+                        y1: int16_t,
+                        x2: int16_t,
+                        y2: int16_t,
+                        color: uint32_t)
+                        -> c_int;
+        pub fn boxRGBA(renderer: *const SDL_Renderer,
+                       x1: int16_t,
+                       y1: int16_t,
+                       x2: int16_t,
+                       y2: int16_t,
+                       r: uint8_t,
+                       g: uint8_t,
+                       b: uint8_t,
+                       a: uint8_t)
+                       -> c_int;
+        pub fn roundedBoxColor(renderer: *const SDL_Renderer,
+                               x1: int16_t,
+                               y1: int16_t,
+                               x2: int16_t,
+                               y2: int16_t,
+                               rad: int16_t,
+                               color: uint32_t)
+                               -> c_int;
+        pub fn roundedBoxRGBA(renderer: *const SDL_Renderer,
+                              x1: int16_t,
+                              y1: int16_t,
+                              x2: int16_t,
+                              y2: int16_t,
+                              rad: int16_t,
+                              r: uint8_t,
+                              g: uint8_t,
+                              b: uint8_t,
+                              a: uint8_t)
+                              -> c_int;
+        pub fn lineColor(renderer: *const SDL_Renderer,
+                         x1: int16_t,
+                         y1: int16_t,
+                         x2: int16_t,
+                         y2: int16_t,
+                         color: uint32_t)
+                         -> c_int;
+        pub fn lineRGBA(renderer: *const SDL_Renderer,
+                        x1: int16_t,
+                        y1: int16_t,
+                        x2: int16_t,
+                        y2: int16_t,
+                        r: uint8_t,
+                        g: uint8_t,
+                        b: uint8_t,
+                        a: uint8_t)
+                        -> c_int;
+        pub fn aalineColor(renderer: *const SDL_Renderer,
+                           x1: int16_t,
+                           y1: int16_t,
+                           x2: int16_t,
+                           y2: int16_t,
+                           color: uint32_t)
+                           -> c_int;
+        pub fn aalineRGBA(renderer: *const SDL_Renderer,
+                          x1: int16_t,
+                          y1: int16_t,
+                          x2: int16_t,
+                          y2: int16_t,
+                          r: uint8_t,
+                          g: uint8_t,
+                          b: uint8_t,
+                          a: uint8_t)
+                          -> c_int;
+        pub fn thickLineColor(renderer: *const SDL_Renderer,
+                              x1: int16_t,
+                              y1: int16_t,
+                              x2: int16_t,
+                              y2: int16_t,
+                              width: uint8_t,
+                              color: uint32_t)
+                              -> c_int;
+        pub fn thickLineRGBA(renderer: *const SDL_Renderer,
+                             x1: int16_t,
+                             y1: int16_t,
+                             x2: int16_t,
+                             y2: int16_t,
+                             width: uint8_t,
+                             r: uint8_t,
+                             g: uint8_t,
+                             b: uint8_t,
+                             a: uint8_t)
+                             -> c_int;
+        pub fn circleColor(renderer: *const SDL_Renderer,
+                           x: int16_t,
+                           y: int16_t,
+                           rad: int16_t,
+                           color: uint32_t)
+                           -> c_int;
+        pub fn circleRGBA(renderer: *const SDL_Renderer,
+                          x: int16_t,
+                          y: int16_t,
+                          rad: int16_t,
+                          r: uint8_t,
+                          g: uint8_t,
+                          b: uint8_t,
+                          a: uint8_t)
+                          -> c_int;
+        pub fn arcColor(renderer: *const SDL_Renderer,
+                        x: int16_t,
+                        y: int16_t,
+                        rad: int16_t,
+                        start: int16_t,
+                        end: int16_t,
+                        color: uint32_t)
+                        -> c_int;
+        pub fn arcRGBA(renderer: *const SDL_Renderer,
+                       x: int16_t,
+                       y: int16_t,
+                       rad: int16_t,
+                       start: int16_t,
+                       end: int16_t,
+                       r: uint8_t,
+                       g: uint8_t,
+                       b: uint8_t,
+                       a: uint8_t)
+                       -> c_int;
+        pub fn aacircleColor(renderer: *const SDL_Renderer,
+                             x: int16_t,
+                             y: int16_t,
+                             rad: int16_t,
+                             color: uint32_t)
+                             -> c_int;
+        pub fn aacircleRGBA(renderer: *const SDL_Renderer,
+                            x: int16_t,
+                            y: int16_t,
+                            rad: int16_t,
+                            r: uint8_t,
+                            g: uint8_t,
+                            b: uint8_t,
+                            a: uint8_t)
                             -> c_int;
-        pub fn filledCircleColor(renderer: *const SDL_Renderer, x: int16_t,
-                                 y: int16_t, r: int16_t, color: uint32_t) -> c_int;
-        pub fn filledCircleRGBA(renderer: *const SDL_Renderer, x: int16_t, y: int16_t,
-                                rad: int16_t, r: uint8_t, g: uint8_t, b: uint8_t,
-                                a: uint8_t) -> c_int;
-        pub fn ellipseColor(renderer: *const SDL_Renderer, x: int16_t, y: int16_t,
-                            rx: int16_t, ry: int16_t, color: uint32_t) -> c_int;
-        pub fn ellipseRGBA(renderer: *const SDL_Renderer, x: int16_t, y: int16_t,
-                           rx: int16_t, ry: int16_t, r: uint8_t, g: uint8_t, b: uint8_t,
-                           a: uint8_t) -> c_int;
-        pub fn aaellipseColor(renderer: *const SDL_Renderer, x: int16_t, y: int16_t,
-                              rx: int16_t, ry: int16_t, color: uint32_t) -> c_int;
-        pub fn aaellipseRGBA(renderer: *const SDL_Renderer, x: int16_t, y: int16_t,
-                             rx: int16_t, ry: int16_t, r: uint8_t, g: uint8_t, b: uint8_t,
-                             a: uint8_t) -> c_int;
-        pub fn filledEllipseColor(renderer: *const SDL_Renderer, x: int16_t,
-                                  y: int16_t, rx: int16_t, ry: int16_t,
-                                  color: uint32_t) -> c_int;
-        pub fn filledEllipseRGBA(renderer: *const SDL_Renderer, x: int16_t,
-                                 y: int16_t, rx: int16_t, ry: int16_t, r: uint8_t,
-                                 g: uint8_t, b: uint8_t, a: uint8_t) -> c_int;
-        pub fn pieColor(renderer: *const SDL_Renderer, x: int16_t, y: int16_t,
-                        rad: int16_t, start: int16_t, end: int16_t, color: uint32_t) ->
-            c_int;
-        pub fn pieRGBA(renderer: *const SDL_Renderer, x: int16_t, y: int16_t,
-                       rad: int16_t, start: int16_t, end: int16_t, r: uint8_t,
-                       g: uint8_t, b: uint8_t, a: uint8_t) -> c_int;
-        pub fn filledPieColor(renderer: *const SDL_Renderer, x: int16_t, y: int16_t,
-                              rad: int16_t, start: int16_t, end: int16_t,
-                              color: uint32_t) -> c_int;
-        pub fn filledPieRGBA(renderer: *const SDL_Renderer, x: int16_t, y: int16_t,
-                             rad: int16_t, start: int16_t, end: int16_t, r: uint8_t,
-                             g: uint8_t, b: uint8_t, a: uint8_t) -> c_int;
-        pub fn trigonColor(renderer: *const SDL_Renderer, x1: int16_t, y1: int16_t,
-                           x2: int16_t, y2: int16_t, x3: int16_t, y3: int16_t,
-                           color: uint32_t) -> c_int;
-        pub fn trigonRGBA(renderer: *const SDL_Renderer, x1: int16_t, y1: int16_t,
-                          x2: int16_t, y2: int16_t, x3: int16_t, y3: int16_t,
-                          r: uint8_t, g: uint8_t, b: uint8_t, a: uint8_t) -> c_int;
-        pub fn aatrigonColor(renderer: *const SDL_Renderer, x1: int16_t, y1: int16_t,
-                             x2: int16_t, y2: int16_t, x3: int16_t, y3: int16_t,
-                             color: uint32_t) -> c_int;
-        pub fn aatrigonRGBA(renderer: *const SDL_Renderer, x1: int16_t, y1: int16_t,
-                            x2: int16_t, y2: int16_t, x3: int16_t, y3: int16_t,
-                            r: uint8_t, g: uint8_t, b: uint8_t, a: uint8_t) -> c_int;
-        pub fn filledTrigonColor(renderer: *const SDL_Renderer, x1: int16_t,
-                                 y1: int16_t, x2: int16_t, y2: int16_t, x3: int16_t,
-                                 y3: int16_t, color: uint32_t) -> c_int;
-        pub fn filledTrigonRGBA(renderer: *const SDL_Renderer, x1: int16_t,
-                                y1: int16_t, x2: int16_t, y2: int16_t, x3: int16_t,
-                                y3: int16_t, r: uint8_t, g: uint8_t, b: uint8_t,
-                                a: uint8_t) -> c_int;
-        pub fn polygonColor(renderer: *const SDL_Renderer, vx: *const int16_t, vy: *const int16_t,
-                            n: c_int, color: uint32_t) -> c_int;
-        pub fn polygonRGBA(renderer: *const SDL_Renderer, vx: *const int16_t, vy: *const int16_t,
-                           n: c_int, r: uint8_t, g: uint8_t, b: uint8_t, a: uint8_t) ->
-            c_int;
-        pub fn aapolygonColor(renderer: *const SDL_Renderer, vx: *const int16_t,
-                              vy: *const int16_t, n: c_int, color: uint32_t) -> c_int;
-        pub fn aapolygonRGBA(renderer: *const SDL_Renderer, vx: *const int16_t,
-                             vy: *const int16_t, n: c_int, r: uint8_t, g: uint8_t, b: uint8_t,
-                             a: uint8_t) -> c_int;
-        pub fn filledPolygonColor(renderer: *const SDL_Renderer, vx: *const int16_t,
-                                  vy: *const int16_t, n: c_int, color: uint32_t) -> c_int;
-        pub fn filledPolygonRGBA(renderer: *const SDL_Renderer, vx: *const int16_t,
-                                 vy: *const int16_t, n: c_int, r: uint8_t, g: uint8_t,
-                                 b: uint8_t, a: uint8_t) -> c_int;
-        pub fn texturedPolygon(renderer: *const SDL_Renderer, vx: *const int16_t,
-                               vy: *const int16_t, n: c_int, texture: *mut SDL_Surface,
-                               texture_dx: c_int, texture_dy: c_int) -> c_int;
-        pub fn bezierColor(renderer: *const SDL_Renderer, vx: *const int16_t, vy: *const int16_t,
-                           n: c_int, s: c_int, color: uint32_t) -> c_int;
-        pub fn bezierRGBA(renderer: *const SDL_Renderer, vx: *const int16_t, vy: *const int16_t,
-                          n: c_int, s: c_int, r: uint8_t, g: uint8_t, b: uint8_t,
-                          a: uint8_t) -> c_int;
+        pub fn filledCircleColor(renderer: *const SDL_Renderer,
+                                 x: int16_t,
+                                 y: int16_t,
+                                 r: int16_t,
+                                 color: uint32_t)
+                                 -> c_int;
+        pub fn filledCircleRGBA(renderer: *const SDL_Renderer,
+                                x: int16_t,
+                                y: int16_t,
+                                rad: int16_t,
+                                r: uint8_t,
+                                g: uint8_t,
+                                b: uint8_t,
+                                a: uint8_t)
+                                -> c_int;
+        pub fn ellipseColor(renderer: *const SDL_Renderer,
+                            x: int16_t,
+                            y: int16_t,
+                            rx: int16_t,
+                            ry: int16_t,
+                            color: uint32_t)
+                            -> c_int;
+        pub fn ellipseRGBA(renderer: *const SDL_Renderer,
+                           x: int16_t,
+                           y: int16_t,
+                           rx: int16_t,
+                           ry: int16_t,
+                           r: uint8_t,
+                           g: uint8_t,
+                           b: uint8_t,
+                           a: uint8_t)
+                           -> c_int;
+        pub fn aaellipseColor(renderer: *const SDL_Renderer,
+                              x: int16_t,
+                              y: int16_t,
+                              rx: int16_t,
+                              ry: int16_t,
+                              color: uint32_t)
+                              -> c_int;
+        pub fn aaellipseRGBA(renderer: *const SDL_Renderer,
+                             x: int16_t,
+                             y: int16_t,
+                             rx: int16_t,
+                             ry: int16_t,
+                             r: uint8_t,
+                             g: uint8_t,
+                             b: uint8_t,
+                             a: uint8_t)
+                             -> c_int;
+        pub fn filledEllipseColor(renderer: *const SDL_Renderer,
+                                  x: int16_t,
+                                  y: int16_t,
+                                  rx: int16_t,
+                                  ry: int16_t,
+                                  color: uint32_t)
+                                  -> c_int;
+        pub fn filledEllipseRGBA(renderer: *const SDL_Renderer,
+                                 x: int16_t,
+                                 y: int16_t,
+                                 rx: int16_t,
+                                 ry: int16_t,
+                                 r: uint8_t,
+                                 g: uint8_t,
+                                 b: uint8_t,
+                                 a: uint8_t)
+                                 -> c_int;
+        pub fn pieColor(renderer: *const SDL_Renderer,
+                        x: int16_t,
+                        y: int16_t,
+                        rad: int16_t,
+                        start: int16_t,
+                        end: int16_t,
+                        color: uint32_t)
+                        -> c_int;
+        pub fn pieRGBA(renderer: *const SDL_Renderer,
+                       x: int16_t,
+                       y: int16_t,
+                       rad: int16_t,
+                       start: int16_t,
+                       end: int16_t,
+                       r: uint8_t,
+                       g: uint8_t,
+                       b: uint8_t,
+                       a: uint8_t)
+                       -> c_int;
+        pub fn filledPieColor(renderer: *const SDL_Renderer,
+                              x: int16_t,
+                              y: int16_t,
+                              rad: int16_t,
+                              start: int16_t,
+                              end: int16_t,
+                              color: uint32_t)
+                              -> c_int;
+        pub fn filledPieRGBA(renderer: *const SDL_Renderer,
+                             x: int16_t,
+                             y: int16_t,
+                             rad: int16_t,
+                             start: int16_t,
+                             end: int16_t,
+                             r: uint8_t,
+                             g: uint8_t,
+                             b: uint8_t,
+                             a: uint8_t)
+                             -> c_int;
+        pub fn trigonColor(renderer: *const SDL_Renderer,
+                           x1: int16_t,
+                           y1: int16_t,
+                           x2: int16_t,
+                           y2: int16_t,
+                           x3: int16_t,
+                           y3: int16_t,
+                           color: uint32_t)
+                           -> c_int;
+        pub fn trigonRGBA(renderer: *const SDL_Renderer,
+                          x1: int16_t,
+                          y1: int16_t,
+                          x2: int16_t,
+                          y2: int16_t,
+                          x3: int16_t,
+                          y3: int16_t,
+                          r: uint8_t,
+                          g: uint8_t,
+                          b: uint8_t,
+                          a: uint8_t)
+                          -> c_int;
+        pub fn aatrigonColor(renderer: *const SDL_Renderer,
+                             x1: int16_t,
+                             y1: int16_t,
+                             x2: int16_t,
+                             y2: int16_t,
+                             x3: int16_t,
+                             y3: int16_t,
+                             color: uint32_t)
+                             -> c_int;
+        pub fn aatrigonRGBA(renderer: *const SDL_Renderer,
+                            x1: int16_t,
+                            y1: int16_t,
+                            x2: int16_t,
+                            y2: int16_t,
+                            x3: int16_t,
+                            y3: int16_t,
+                            r: uint8_t,
+                            g: uint8_t,
+                            b: uint8_t,
+                            a: uint8_t)
+                            -> c_int;
+        pub fn filledTrigonColor(renderer: *const SDL_Renderer,
+                                 x1: int16_t,
+                                 y1: int16_t,
+                                 x2: int16_t,
+                                 y2: int16_t,
+                                 x3: int16_t,
+                                 y3: int16_t,
+                                 color: uint32_t)
+                                 -> c_int;
+        pub fn filledTrigonRGBA(renderer: *const SDL_Renderer,
+                                x1: int16_t,
+                                y1: int16_t,
+                                x2: int16_t,
+                                y2: int16_t,
+                                x3: int16_t,
+                                y3: int16_t,
+                                r: uint8_t,
+                                g: uint8_t,
+                                b: uint8_t,
+                                a: uint8_t)
+                                -> c_int;
+        pub fn polygonColor(renderer: *const SDL_Renderer,
+                            vx: *const int16_t,
+                            vy: *const int16_t,
+                            n: c_int,
+                            color: uint32_t)
+                            -> c_int;
+        pub fn polygonRGBA(renderer: *const SDL_Renderer,
+                           vx: *const int16_t,
+                           vy: *const int16_t,
+                           n: c_int,
+                           r: uint8_t,
+                           g: uint8_t,
+                           b: uint8_t,
+                           a: uint8_t)
+                           -> c_int;
+        pub fn aapolygonColor(renderer: *const SDL_Renderer,
+                              vx: *const int16_t,
+                              vy: *const int16_t,
+                              n: c_int,
+                              color: uint32_t)
+                              -> c_int;
+        pub fn aapolygonRGBA(renderer: *const SDL_Renderer,
+                             vx: *const int16_t,
+                             vy: *const int16_t,
+                             n: c_int,
+                             r: uint8_t,
+                             g: uint8_t,
+                             b: uint8_t,
+                             a: uint8_t)
+                             -> c_int;
+        pub fn filledPolygonColor(renderer: *const SDL_Renderer,
+                                  vx: *const int16_t,
+                                  vy: *const int16_t,
+                                  n: c_int,
+                                  color: uint32_t)
+                                  -> c_int;
+        pub fn filledPolygonRGBA(renderer: *const SDL_Renderer,
+                                 vx: *const int16_t,
+                                 vy: *const int16_t,
+                                 n: c_int,
+                                 r: uint8_t,
+                                 g: uint8_t,
+                                 b: uint8_t,
+                                 a: uint8_t)
+                                 -> c_int;
+        pub fn texturedPolygon(renderer: *const SDL_Renderer,
+                               vx: *const int16_t,
+                               vy: *const int16_t,
+                               n: c_int,
+                               texture: *mut SDL_Surface,
+                               texture_dx: c_int,
+                               texture_dy: c_int)
+                               -> c_int;
+        pub fn bezierColor(renderer: *const SDL_Renderer,
+                           vx: *const int16_t,
+                           vy: *const int16_t,
+                           n: c_int,
+                           s: c_int,
+                           color: uint32_t)
+                           -> c_int;
+        pub fn bezierRGBA(renderer: *const SDL_Renderer,
+                          vx: *const int16_t,
+                          vy: *const int16_t,
+                          n: c_int,
+                          s: c_int,
+                          r: uint8_t,
+                          g: uint8_t,
+                          b: uint8_t,
+                          a: uint8_t)
+                          -> c_int;
         pub fn gfxPrimitivesSetFont(fontdata: *const c_void, cw: uint32_t, ch: uint32_t);
         pub fn gfxPrimitivesSetFontRotation(rotation: uint32_t);
-        pub fn characterColor(renderer: *const SDL_Renderer, x: int16_t, y: int16_t,
-                              c: c_char, color: uint32_t) -> c_int;
-        pub fn characterRGBA(renderer: *const SDL_Renderer, x: int16_t, y: int16_t,
-                             c: c_char, r: uint8_t, g: uint8_t, b: uint8_t, a: uint8_t)
+        pub fn characterColor(renderer: *const SDL_Renderer,
+                              x: int16_t,
+                              y: int16_t,
+                              c: c_char,
+                              color: uint32_t)
+                              -> c_int;
+        pub fn characterRGBA(renderer: *const SDL_Renderer,
+                             x: int16_t,
+                             y: int16_t,
+                             c: c_char,
+                             r: uint8_t,
+                             g: uint8_t,
+                             b: uint8_t,
+                             a: uint8_t)
                              -> c_int;
-        pub fn stringColor(renderer: *const SDL_Renderer, x: int16_t, y: int16_t,
-                           s: *mut c_char, color: uint32_t) -> c_int;
-        pub fn stringRGBA(renderer: *const SDL_Renderer, x: int16_t, y: int16_t,
-                          s: *mut c_char, r: uint8_t, g: uint8_t, b: uint8_t, a: uint8_t) ->
-            c_int;
+        pub fn stringColor(renderer: *const SDL_Renderer,
+                           x: int16_t,
+                           y: int16_t,
+                           s: *mut c_char,
+                           color: uint32_t)
+                           -> c_int;
+        pub fn stringRGBA(renderer: *const SDL_Renderer,
+                          x: int16_t,
+                          y: int16_t,
+                          s: *mut c_char,
+                          r: uint8_t,
+                          g: uint8_t,
+                          b: uint8_t,
+                          a: uint8_t)
+                          -> c_int;
     }
 }
 
@@ -237,29 +567,132 @@ pub trait DrawRenderer {
     fn pixel<C: ToColor>(&self, x: i16, y: i16, color: C) -> Result<(), String>;
     fn hline<C: ToColor>(&self, x1: i16, x2: i16, y: i16, color: C) -> Result<(), String>;
     fn vline<C: ToColor>(&self, x: i16, y1: i16, y2: i16, color: C) -> Result<(), String>;
-    fn rectangle<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, color: C) -> Result<(), String>;
-    fn rounded_rectangle<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, rad: i16, color: C) -> Result<(), String>;
+    fn rectangle<C: ToColor>(&self,
+                             x1: i16,
+                             y1: i16,
+                             x2: i16,
+                             y2: i16,
+                             color: C)
+                             -> Result<(), String>;
+    fn rounded_rectangle<C: ToColor>(&self,
+                                     x1: i16,
+                                     y1: i16,
+                                     x2: i16,
+                                     y2: i16,
+                                     rad: i16,
+                                     color: C)
+                                     -> Result<(), String>;
     fn box_<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, color: C) -> Result<(), String>;
-    fn rounded_box<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, rad: i16, color: C) -> Result<(), String>;
+    fn rounded_box<C: ToColor>(&self,
+                               x1: i16,
+                               y1: i16,
+                               x2: i16,
+                               y2: i16,
+                               rad: i16,
+                               color: C)
+                               -> Result<(), String>;
     fn line<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, color: C) -> Result<(), String>;
-    fn aa_line<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, color: C) -> Result<(), String>;
-    fn thick_line<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, width: u8, color: C) -> Result<(), String>;
+    fn aa_line<C: ToColor>(&self,
+                           x1: i16,
+                           y1: i16,
+                           x2: i16,
+                           y2: i16,
+                           color: C)
+                           -> Result<(), String>;
+    fn thick_line<C: ToColor>(&self,
+                              x1: i16,
+                              y1: i16,
+                              x2: i16,
+                              y2: i16,
+                              width: u8,
+                              color: C)
+                              -> Result<(), String>;
     fn circle<C: ToColor>(&self, x: i16, y: i16, rad: i16, color: C) -> Result<(), String>;
     fn aa_circle<C: ToColor>(&self, x: i16, y: i16, rad: i16, color: C) -> Result<(), String>;
     fn filled_circle<C: ToColor>(&self, x: i16, y: i16, rad: i16, color: C) -> Result<(), String>;
-    fn arc<C: ToColor>(&self, x: i16, y: i16, rad: i16, start: i16, end: i16, color: C) -> Result<(), String>;
-    fn ellipse<C: ToColor>(&self, x: i16, y: i16, rx: i16, ry: i16, color: C) -> Result<(), String>;
-    fn aa_ellipse<C: ToColor>(&self, x: i16, y: i16, rx: i16, ry: i16, color: C) -> Result<(), String>;
-    fn filled_ellipse<C: ToColor>(&self, x: i16, y: i16, rx: i16, ry: i16, color: C) -> Result<(), String>;
-    fn pie<C: ToColor>(&self, x: i16, y: i16, rad: i16, start: i16, end: i16, color: C) -> Result<(), String>;
-    fn filled_pie<C: ToColor>(&self, x: i16, y: i16, rad: i16, start: i16, end: i16, color: C) -> Result<(), String>;
-    fn trigon<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, x3: i16, y3: i16, color: C) -> Result<(), String>;
-    fn aa_trigon<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, x3: i16, y3: i16, color: C) -> Result<(), String>;
-    fn filled_trigon<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, x3: i16, y3: i16, color: C) -> Result<(), String>;
+    fn arc<C: ToColor>(&self,
+                       x: i16,
+                       y: i16,
+                       rad: i16,
+                       start: i16,
+                       end: i16,
+                       color: C)
+                       -> Result<(), String>;
+    fn ellipse<C: ToColor>(&self,
+                           x: i16,
+                           y: i16,
+                           rx: i16,
+                           ry: i16,
+                           color: C)
+                           -> Result<(), String>;
+    fn aa_ellipse<C: ToColor>(&self,
+                              x: i16,
+                              y: i16,
+                              rx: i16,
+                              ry: i16,
+                              color: C)
+                              -> Result<(), String>;
+    fn filled_ellipse<C: ToColor>(&self,
+                                  x: i16,
+                                  y: i16,
+                                  rx: i16,
+                                  ry: i16,
+                                  color: C)
+                                  -> Result<(), String>;
+    fn pie<C: ToColor>(&self,
+                       x: i16,
+                       y: i16,
+                       rad: i16,
+                       start: i16,
+                       end: i16,
+                       color: C)
+                       -> Result<(), String>;
+    fn filled_pie<C: ToColor>(&self,
+                              x: i16,
+                              y: i16,
+                              rad: i16,
+                              start: i16,
+                              end: i16,
+                              color: C)
+                              -> Result<(), String>;
+    fn trigon<C: ToColor>(&self,
+                          x1: i16,
+                          y1: i16,
+                          x2: i16,
+                          y2: i16,
+                          x3: i16,
+                          y3: i16,
+                          color: C)
+                          -> Result<(), String>;
+    fn aa_trigon<C: ToColor>(&self,
+                             x1: i16,
+                             y1: i16,
+                             x2: i16,
+                             y2: i16,
+                             x3: i16,
+                             y3: i16,
+                             color: C)
+                             -> Result<(), String>;
+    fn filled_trigon<C: ToColor>(&self,
+                                 x1: i16,
+                                 y1: i16,
+                                 x2: i16,
+                                 y2: i16,
+                                 x3: i16,
+                                 y3: i16,
+                                 color: C)
+                                 -> Result<(), String>;
     fn polygon<C: ToColor>(&self, vx: &[i16], vy: &[i16], color: C) -> Result<(), String>;
     fn aa_polygon<C: ToColor>(&self, vx: &[i16], vy: &[i16], color: C) -> Result<(), String>;
     fn filled_polygon<C: ToColor>(&self, vx: &[i16], vy: &[i16], color: C) -> Result<(), String>;
-    fn textured_polygon<C: ToColor>(&self, vx: &[i16], vy: &[i16], texture: &Surface, texture_dx: i16, texture_dy: i16, color: C) -> Result<(), String>;
+    fn textured_polygon<C: ToColor>(&self,
+                                    vx: &[i16],
+                                    vy: &[i16],
+                                    texture: &Surface,
+                                    texture_dx: i16,
+                                    texture_dy: i16,
+                                    color: C)
+                                    -> Result<(), String>;
     fn bezier<C: ToColor>(&self, vx: &[i16], vy: &[i16], s: i32, color: C) -> Result<(), String>;
     fn character<C: ToColor>(&self, x: i16, y: i16, c: char, color: C) -> Result<(), String>;
     fn string<C: ToColor>(&self, x: i16, y: i16, s: &str, color: C) -> Result<(), String>;
@@ -267,178 +700,206 @@ pub trait DrawRenderer {
 
 impl<'a> DrawRenderer for Renderer<'a> {
     fn pixel<C: ToColor>(&self, x: i16, y: i16, color: C) -> Result<(), String> {
-        let ret = unsafe {
-            ll::pixelColor(self.raw(), x, y, color.as_u32())
-        };
-        if ret == 0 { Ok(()) }
-        else { Err(get_error()) }
+        let ret = unsafe { ll::pixelColor(self.raw(), x, y, color.as_u32()) };
+        if ret == 0 { Ok(()) } else { Err(get_error()) }
     }
     fn hline<C: ToColor>(&self, x1: i16, x2: i16, y: i16, color: C) -> Result<(), String> {
-        let ret = unsafe {
-            ll::hlineColor(self.raw(), x1, x2, y, color.as_u32())
-        };
-        if ret == 0 { Ok(()) }
-        else { Err(get_error()) }
+        let ret = unsafe { ll::hlineColor(self.raw(), x1, x2, y, color.as_u32()) };
+        if ret == 0 { Ok(()) } else { Err(get_error()) }
     }
     fn vline<C: ToColor>(&self, x: i16, y1: i16, y2: i16, color: C) -> Result<(), String> {
-        let ret = unsafe {
-            ll::vlineColor(self.raw(), x, y1, y2, color.as_u32())
-        };
-        if ret == 0 { Ok(()) }
-        else { Err(get_error()) }
+        let ret = unsafe { ll::vlineColor(self.raw(), x, y1, y2, color.as_u32()) };
+        if ret == 0 { Ok(()) } else { Err(get_error()) }
     }
-    fn rectangle<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, color: C) -> Result<(), String> {
-        let ret = unsafe {
-            ll::rectangleColor(self.raw(), x1, y1, x2, y2, color.as_u32())
-        };
-        if ret == 0 { Ok(()) }
-        else { Err(get_error()) }
+    fn rectangle<C: ToColor>(&self,
+                             x1: i16,
+                             y1: i16,
+                             x2: i16,
+                             y2: i16,
+                             color: C)
+                             -> Result<(), String> {
+        let ret = unsafe { ll::rectangleColor(self.raw(), x1, y1, x2, y2, color.as_u32()) };
+        if ret == 0 { Ok(()) } else { Err(get_error()) }
     }
-    fn rounded_rectangle<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, rad: i16, color: C) -> Result<(), String> {
-        let ret = unsafe {
-            ll::roundedRectangleColor(self.raw(), x1, y1, x2, y2, rad, color.as_u32())
-        };
-        if ret == 0 { Ok(()) }
-        else { Err(get_error()) }
+    fn rounded_rectangle<C: ToColor>(&self,
+                                     x1: i16,
+                                     y1: i16,
+                                     x2: i16,
+                                     y2: i16,
+                                     rad: i16,
+                                     color: C)
+                                     -> Result<(), String> {
+        let ret =
+            unsafe { ll::roundedRectangleColor(self.raw(), x1, y1, x2, y2, rad, color.as_u32()) };
+        if ret == 0 { Ok(()) } else { Err(get_error()) }
     }
     fn box_<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, color: C) -> Result<(), String> {
-        let ret = unsafe {
-            ll::boxColor(self.raw(), x1, y1, x2, y2, color.as_u32())
-        };
-        if ret == 0 { Ok(()) }
-        else { Err(get_error()) }
+        let ret = unsafe { ll::boxColor(self.raw(), x1, y1, x2, y2, color.as_u32()) };
+        if ret == 0 { Ok(()) } else { Err(get_error()) }
     }
-    fn rounded_box<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, rad: i16, color: C) -> Result<(), String> {
-        let ret = unsafe {
-            ll::roundedBoxColor(self.raw(), x1, y1, x2, y2, rad, color.as_u32())
-        };
-        if ret == 0 { Ok(()) }
-        else { Err(get_error()) }
+    fn rounded_box<C: ToColor>(&self,
+                               x1: i16,
+                               y1: i16,
+                               x2: i16,
+                               y2: i16,
+                               rad: i16,
+                               color: C)
+                               -> Result<(), String> {
+        let ret = unsafe { ll::roundedBoxColor(self.raw(), x1, y1, x2, y2, rad, color.as_u32()) };
+        if ret == 0 { Ok(()) } else { Err(get_error()) }
     }
     fn line<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, color: C) -> Result<(), String> {
-        let ret = unsafe {
-            ll::lineColor(self.raw(), x1, y1, x2, y2, color.as_u32())
-        };
-        if ret == 0 { Ok(()) }
-        else { Err(get_error()) }
+        let ret = unsafe { ll::lineColor(self.raw(), x1, y1, x2, y2, color.as_u32()) };
+        if ret == 0 { Ok(()) } else { Err(get_error()) }
     }
-    fn aa_line<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, color: C) -> Result<(), String> {
-        let ret = unsafe {
-            ll::aalineColor(self.raw(), x1, y1, x2, y2, color.as_u32())
-        };
-        if ret == 0 { Ok(()) }
-        else { Err(get_error()) }
+    fn aa_line<C: ToColor>(&self,
+                           x1: i16,
+                           y1: i16,
+                           x2: i16,
+                           y2: i16,
+                           color: C)
+                           -> Result<(), String> {
+        let ret = unsafe { ll::aalineColor(self.raw(), x1, y1, x2, y2, color.as_u32()) };
+        if ret == 0 { Ok(()) } else { Err(get_error()) }
     }
-    fn thick_line<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, width: u8, color: C) -> Result<(), String> {
-        let ret = unsafe {
-            ll::thickLineColor(self.raw(), x1, y1, x2, y2, width, color.as_u32())
-        };
-        if ret == 0 { Ok(()) }
-        else { Err(get_error()) }
+    fn thick_line<C: ToColor>(&self,
+                              x1: i16,
+                              y1: i16,
+                              x2: i16,
+                              y2: i16,
+                              width: u8,
+                              color: C)
+                              -> Result<(), String> {
+        let ret = unsafe { ll::thickLineColor(self.raw(), x1, y1, x2, y2, width, color.as_u32()) };
+        if ret == 0 { Ok(()) } else { Err(get_error()) }
     }
     fn circle<C: ToColor>(&self, x: i16, y: i16, rad: i16, color: C) -> Result<(), String> {
-        let ret = unsafe {
-            ll::circleColor(self.raw(), x, y, rad, color.as_u32())
-        };
-        if ret == 0 { Ok(()) }
-        else { Err(get_error()) }
+        let ret = unsafe { ll::circleColor(self.raw(), x, y, rad, color.as_u32()) };
+        if ret == 0 { Ok(()) } else { Err(get_error()) }
     }
     fn aa_circle<C: ToColor>(&self, x: i16, y: i16, rad: i16, color: C) -> Result<(), String> {
-        let ret = unsafe {
-            ll::aacircleColor(self.raw(), x, y, rad, color.as_u32())
-        };
-        if ret == 0 { Ok(()) }
-        else { Err(get_error()) }
+        let ret = unsafe { ll::aacircleColor(self.raw(), x, y, rad, color.as_u32()) };
+        if ret == 0 { Ok(()) } else { Err(get_error()) }
     }
     fn filled_circle<C: ToColor>(&self, x: i16, y: i16, rad: i16, color: C) -> Result<(), String> {
-        let ret = unsafe {
-            ll::filledCircleColor(self.raw(), x, y, rad, color.as_u32())
-        };
-        if ret == 0 { Ok(()) }
-        else { Err(get_error()) }
+        let ret = unsafe { ll::filledCircleColor(self.raw(), x, y, rad, color.as_u32()) };
+        if ret == 0 { Ok(()) } else { Err(get_error()) }
     }
-    fn arc<C: ToColor>(&self, x: i16, y: i16, rad: i16, start: i16, end: i16, color: C) -> Result<(), String> {
-        let ret = unsafe {
-            ll::arcColor(self.raw(), x, y, rad, start, end, color.as_u32())
-        };
-        if ret == 0 { Ok(()) }
-        else { Err(get_error()) }
+    fn arc<C: ToColor>(&self,
+                       x: i16,
+                       y: i16,
+                       rad: i16,
+                       start: i16,
+                       end: i16,
+                       color: C)
+                       -> Result<(), String> {
+        let ret = unsafe { ll::arcColor(self.raw(), x, y, rad, start, end, color.as_u32()) };
+        if ret == 0 { Ok(()) } else { Err(get_error()) }
     }
-    fn ellipse<C: ToColor>(&self, x: i16, y: i16, rx: i16, ry: i16, color: C) -> Result<(), String> {
-        let ret = unsafe {
-            ll::ellipseColor(self.raw(), x, y, rx, ry, color.as_u32())
-        };
-        if ret == 0 { Ok(()) }
-        else { Err(get_error()) }
+    fn ellipse<C: ToColor>(&self,
+                           x: i16,
+                           y: i16,
+                           rx: i16,
+                           ry: i16,
+                           color: C)
+                           -> Result<(), String> {
+        let ret = unsafe { ll::ellipseColor(self.raw(), x, y, rx, ry, color.as_u32()) };
+        if ret == 0 { Ok(()) } else { Err(get_error()) }
     }
-    fn aa_ellipse<C: ToColor>(&self, x: i16, y: i16, rx: i16, ry: i16, color: C) -> Result<(), String> {
-        let ret = unsafe {
-            ll::aaellipseColor(self.raw(), x, y, rx, ry, color.as_u32())
-        };
-        if ret == 0 { Ok(()) }
-        else { Err(get_error()) }
+    fn aa_ellipse<C: ToColor>(&self,
+                              x: i16,
+                              y: i16,
+                              rx: i16,
+                              ry: i16,
+                              color: C)
+                              -> Result<(), String> {
+        let ret = unsafe { ll::aaellipseColor(self.raw(), x, y, rx, ry, color.as_u32()) };
+        if ret == 0 { Ok(()) } else { Err(get_error()) }
     }
-    fn filled_ellipse<C: ToColor>(&self, x: i16, y: i16, rx: i16, ry: i16, color: C) -> Result<(), String> {
-        let ret = unsafe {
-            ll::filledEllipseColor(self.raw(), x, y, rx, ry, color.as_u32())
-        };
-        if ret == 0 { Ok(()) }
-        else { Err(get_error()) }
+    fn filled_ellipse<C: ToColor>(&self,
+                                  x: i16,
+                                  y: i16,
+                                  rx: i16,
+                                  ry: i16,
+                                  color: C)
+                                  -> Result<(), String> {
+        let ret = unsafe { ll::filledEllipseColor(self.raw(), x, y, rx, ry, color.as_u32()) };
+        if ret == 0 { Ok(()) } else { Err(get_error()) }
     }
-    fn pie<C: ToColor>(&self, x: i16, y: i16, rad: i16, start: i16, end: i16, color: C) -> Result<(), String> {
-        let ret = unsafe {
-            ll::pieColor(self.raw(), x, y, rad, start, end, color.as_u32())
-        };
-        if ret == 0 { Ok(()) }
-        else { Err(get_error()) }
+    fn pie<C: ToColor>(&self,
+                       x: i16,
+                       y: i16,
+                       rad: i16,
+                       start: i16,
+                       end: i16,
+                       color: C)
+                       -> Result<(), String> {
+        let ret = unsafe { ll::pieColor(self.raw(), x, y, rad, start, end, color.as_u32()) };
+        if ret == 0 { Ok(()) } else { Err(get_error()) }
     }
-    fn filled_pie<C: ToColor>(&self, x: i16, y: i16, rad: i16, start: i16, end: i16, color: C) -> Result<(), String> {
-        let ret = unsafe {
-            ll::filledPieColor(self.raw(), x, y, rad, start, end, color.as_u32())
-        };
-        if ret == 0 { Ok(()) }
-        else { Err(get_error()) }
+    fn filled_pie<C: ToColor>(&self,
+                              x: i16,
+                              y: i16,
+                              rad: i16,
+                              start: i16,
+                              end: i16,
+                              color: C)
+                              -> Result<(), String> {
+        let ret = unsafe { ll::filledPieColor(self.raw(), x, y, rad, start, end, color.as_u32()) };
+        if ret == 0 { Ok(()) } else { Err(get_error()) }
     }
-    fn trigon<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, x3: i16, y3: i16, color: C) -> Result<(), String> {
-        let ret = unsafe {
-            ll::trigonColor(self.raw(), x1, y1, x2, y2, x3, y3, color.as_u32())
-        };
-        if ret == 0 { Ok(()) }
-        else { Err(get_error()) }
+    fn trigon<C: ToColor>(&self,
+                          x1: i16,
+                          y1: i16,
+                          x2: i16,
+                          y2: i16,
+                          x3: i16,
+                          y3: i16,
+                          color: C)
+                          -> Result<(), String> {
+        let ret = unsafe { ll::trigonColor(self.raw(), x1, y1, x2, y2, x3, y3, color.as_u32()) };
+        if ret == 0 { Ok(()) } else { Err(get_error()) }
     }
-    fn aa_trigon<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, x3: i16, y3: i16, color: C) -> Result<(), String> {
-        let ret = unsafe {
-            ll::aatrigonColor(self.raw(), x1, y1, x2, y2, x3, y3, color.as_u32())
-        };
-        if ret == 0 { Ok(()) }
-        else { Err(get_error()) }
+    fn aa_trigon<C: ToColor>(&self,
+                             x1: i16,
+                             y1: i16,
+                             x2: i16,
+                             y2: i16,
+                             x3: i16,
+                             y3: i16,
+                             color: C)
+                             -> Result<(), String> {
+        let ret = unsafe { ll::aatrigonColor(self.raw(), x1, y1, x2, y2, x3, y3, color.as_u32()) };
+        if ret == 0 { Ok(()) } else { Err(get_error()) }
     }
-    fn filled_trigon<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, x3: i16, y3: i16, color: C) -> Result<(), String> {
-        let ret = unsafe {
-            ll::filledTrigonColor(self.raw(), x1, y1, x2, y2, x3, y3, color.as_u32())
-        };
-        if ret == 0 { Ok(()) }
-        else { Err(get_error()) }
+    fn filled_trigon<C: ToColor>(&self,
+                                 x1: i16,
+                                 y1: i16,
+                                 x2: i16,
+                                 y2: i16,
+                                 x3: i16,
+                                 y3: i16,
+                                 color: C)
+                                 -> Result<(), String> {
+        let ret =
+            unsafe { ll::filledTrigonColor(self.raw(), x1, y1, x2, y2, x3, y3, color.as_u32()) };
+        if ret == 0 { Ok(()) } else { Err(get_error()) }
     }
     // FIXME: may we use pointer tuple?
     fn polygon<C: ToColor>(&self, vx: &[i16], vy: &[i16], color: C) -> Result<(), String> {
         assert_eq!(vx.len(), vy.len());
         let n = vx.len() as c_int;
-        let ret = unsafe {
-            ll::polygonColor(self.raw(), vx.as_ptr(), vy.as_ptr(), n, color.as_u32())
-        };
-        if ret == 0 { Ok(()) }
-        else { Err(get_error()) }
+        let ret =
+            unsafe { ll::polygonColor(self.raw(), vx.as_ptr(), vy.as_ptr(), n, color.as_u32()) };
+        if ret == 0 { Ok(()) } else { Err(get_error()) }
     }
 
     fn aa_polygon<C: ToColor>(&self, vx: &[i16], vy: &[i16], color: C) -> Result<(), String> {
         assert_eq!(vx.len(), vy.len());
         let n = vx.len() as c_int;
-        let ret = unsafe {
-            ll::aapolygonColor(self.raw(), vx.as_ptr(), vy.as_ptr(), n, color.as_u32())
-        };
-        if ret == 0 { Ok(()) }
-        else { Err(get_error()) }
+        let ret =
+            unsafe { ll::aapolygonColor(self.raw(), vx.as_ptr(), vy.as_ptr(), n, color.as_u32()) };
+        if ret == 0 { Ok(()) } else { Err(get_error()) }
     }
 
     fn filled_polygon<C: ToColor>(&self, vx: &[i16], vy: &[i16], color: C) -> Result<(), String> {
@@ -447,11 +908,17 @@ impl<'a> DrawRenderer for Renderer<'a> {
         let ret = unsafe {
             ll::filledPolygonColor(self.raw(), vx.as_ptr(), vy.as_ptr(), n, color.as_u32())
         };
-        if ret == 0 { Ok(()) }
-        else { Err(get_error()) }
+        if ret == 0 { Ok(()) } else { Err(get_error()) }
     }
     #[allow(unused_variables)]
-    fn textured_polygon<C: ToColor>(&self, vx: &[i16], vy: &[i16], texture: &Surface, texture_dx: i16, texture_dy: i16, color: C) -> Result<(), String> {
+    fn textured_polygon<C: ToColor>(&self,
+                                    vx: &[i16],
+                                    vy: &[i16],
+                                    texture: &Surface,
+                                    texture_dx: i16,
+                                    texture_dy: i16,
+                                    color: C)
+                                    -> Result<(), String> {
         unimplemented!()
     }
 
@@ -459,18 +926,19 @@ impl<'a> DrawRenderer for Renderer<'a> {
         assert_eq!(vx.len(), vy.len());
         let n = vx.len() as c_int;
         let ret = unsafe {
-            ll::bezierColor(self.raw(), vx.as_ptr(), vy.as_ptr(), n, s as c_int, color.as_u32())
+            ll::bezierColor(self.raw(),
+                            vx.as_ptr(),
+                            vy.as_ptr(),
+                            n,
+                            s as c_int,
+                            color.as_u32())
         };
-        if ret == 0 { Ok(()) }
-        else { Err(get_error()) }
+        if ret == 0 { Ok(()) } else { Err(get_error()) }
     }
 
     fn character<C: ToColor>(&self, x: i16, y: i16, c: char, color: C) -> Result<(), String> {
-        let ret = unsafe {
-            ll::characterColor(self.raw(), x, y, c as c_char, color.as_u32())
-        };
-        if ret == 0 { Ok(()) }
-        else { Err(get_error()) }
+        let ret = unsafe { ll::characterColor(self.raw(), x, y, c as c_char, color.as_u32()) };
+        if ret == 0 { Ok(()) } else { Err(get_error()) }
     }
 
     fn string<C: ToColor>(&self, x: i16, y: i16, s: &str, color: C) -> Result<(), String> {
@@ -478,22 +946,19 @@ impl<'a> DrawRenderer for Renderer<'a> {
             let buf = CString::new(s).unwrap().as_bytes().as_ptr();
             ll::stringColor(self.raw(), x, y, buf as *mut i8, color.as_u32())
         };
-        if ret == 0 { Ok(()) }
-        else { Err(get_error()) }
+        if ret == 0 { Ok(()) } else { Err(get_error()) }
     }
 }
 
 /// Sets or resets the current global font data.
 pub fn set_font<'b, F>(fontdata: F, cw: u32, ch: u32)
-where F: Into<Option<&'b [u8]>>
+    where F: Into<Option<&'b [u8]>>
 {
     let actual_fontdata = match fontdata.into() {
-        None  => ptr::null(),
-        Some(v) => v.as_ptr()
+        None => ptr::null(),
+        Some(v) => v.as_ptr(),
     };
-    unsafe {
-        ll::gfxPrimitivesSetFont(actual_fontdata as *const c_void, cw, ch)
-    }
+    unsafe { ll::gfxPrimitivesSetFont(actual_fontdata as *const c_void, cw, ch) }
 }
 
 /// Sets current global font character rotation steps.

--- a/src/sdl2/image/mod.rs
+++ b/src/sdl2/image/mod.rs
@@ -1,7 +1,7 @@
 //!
 //! A binding for the library `SDL2_image`
 //!
-//! 
+//!
 //! Note that you need to build with the
 //! feature `image` for this module to be enabled,
 //! like so:
@@ -23,11 +23,11 @@
 use std::os::raw::{c_int, c_char};
 use std::ffi::CString;
 use std::path::Path;
-use ::surface::Surface;
-use ::render::{Renderer, Texture};
-use ::rwops::RWops;
-use ::version::Version;
-use ::get_error;
+use surface::Surface;
+use render::{Renderer, Texture};
+use rwops::RWops;
+use version::Version;
+use get_error;
 use sys;
 
 // Setup linking for all targets.
@@ -35,17 +35,17 @@ use sys;
 mod mac {
     #[cfg(any(mac_framework, feature="use_mac_framework"))]
     #[link(kind="framework", name="SDL2_image")]
-    extern {}
+    extern "C" {}
 
     #[cfg(not(any(mac_framework, feature="use_mac_framework")))]
     #[link(name="SDL2_image")]
-    extern {}
+    extern "C" {}
 }
 
 #[cfg(any(target_os="windows", target_os="linux", target_os="freebsd"))]
 mod others {
     #[link(name="SDL2_image")]
-    extern {}
+    extern "C" {}
 }
 
 #[allow(non_camel_case_types, dead_code)]
@@ -178,7 +178,9 @@ pub struct Sdl2ImageContext;
 
 impl Drop for Sdl2ImageContext {
     fn drop(&mut self) {
-        unsafe { ffi::IMG_Quit(); }
+        unsafe {
+            ffi::IMG_Quit();
+        }
     }
 }
 
@@ -205,9 +207,7 @@ pub fn init(flags: InitFlag) -> Result<Sdl2ImageContext, String> {
 
 /// Returns the version of the dynamically linked `SDL_image` library
 pub fn get_linked_version() -> Version {
-    unsafe {
-        Version::from_ll(*ffi::IMG_Linked_Version())
-    }
+    unsafe { Version::from_ll(*ffi::IMG_Linked_Version()) }
 }
 
 #[inline]
@@ -238,7 +238,7 @@ pub trait ImageRWops {
     fn load_png(&self) -> Result<Surface, String>;
     fn load_tga(&self) -> Result<Surface, String>;
     fn load_lbm(&self) -> Result<Surface, String>;
-    fn load_xv(&self)  -> Result<Surface, String>;
+    fn load_xv(&self) -> Result<Surface, String>;
     fn load_webp(&self) -> Result<Surface, String>;
 
     fn is_cur(&self) -> bool;
@@ -253,15 +253,13 @@ pub trait ImageRWops {
     fn is_tif(&self) -> bool;
     fn is_png(&self) -> bool;
     fn is_lbm(&self) -> bool;
-    fn is_xv(&self)  -> bool;
+    fn is_xv(&self) -> bool;
     fn is_webp(&self) -> bool;
 }
 
 impl<'a> ImageRWops for RWops<'a> {
     fn load(&self) -> Result<Surface, String> {
-        let raw = unsafe {
-            ffi::IMG_Load_RW(self.raw(), 0)
-        };
+        let raw = unsafe { ffi::IMG_Load_RW(self.raw(), 0) };
         to_surface_result(raw)
     }
     fn load_typed(&self, _type: &str) -> Result<Surface, String> {
@@ -324,11 +322,11 @@ impl<'a> ImageRWops for RWops<'a> {
         let raw = unsafe { ffi::IMG_LoadLBM_RW(self.raw()) };
         to_surface_result(raw)
     }
-    fn load_xv(&self)  -> Result<Surface, String> {
+    fn load_xv(&self) -> Result<Surface, String> {
         let raw = unsafe { ffi::IMG_LoadXV_RW(self.raw()) };
         to_surface_result(raw)
     }
-    fn load_webp(&self)  -> Result<Surface, String> {
+    fn load_webp(&self) -> Result<Surface, String> {
         let raw = unsafe { ffi::IMG_LoadWEBP_RW(self.raw()) };
         to_surface_result(raw)
     }
@@ -369,10 +367,10 @@ impl<'a> ImageRWops for RWops<'a> {
     fn is_lbm(&self) -> bool {
         unsafe { ffi::IMG_isLBM(self.raw()) == 1 }
     }
-    fn is_xv(&self)  -> bool {
-        unsafe { ffi::IMG_isXV(self.raw())  == 1 }
+    fn is_xv(&self) -> bool {
+        unsafe { ffi::IMG_isXV(self.raw()) == 1 }
     }
     fn is_webp(&self) -> bool {
-        unsafe { ffi::IMG_isWEBP(self.raw())  == 1 }
+        unsafe { ffi::IMG_isWEBP(self.raw()) == 1 }
     }
 }

--- a/src/sdl2/image/mod.rs
+++ b/src/sdl2/image/mod.rs
@@ -24,7 +24,7 @@ use std::os::raw::{c_int, c_char};
 use std::ffi::CString;
 use std::path::Path;
 use surface::Surface;
-use render::{Renderer, Texture};
+use render::{TextureCreator, Texture};
 use rwops::RWops;
 use version::Version;
 use get_error;
@@ -152,12 +152,12 @@ impl<'a> SaveSurface for Surface<'a> {
     }
 }
 
-/// Method extensions for creating Textures from a Renderer
+/// Method extensions for creating Textures from a TextureCreator
 pub trait LoadTexture {
     fn load_texture<P: AsRef<Path>>(&self, filename: P) -> Result<Texture, String>;
 }
 
-impl<'a> LoadTexture for Renderer<'a> {
+impl<T> LoadTexture for TextureCreator<T> {
     fn load_texture<P: AsRef<Path>>(&self, filename: P) -> Result<Texture, String> {
         //! Loads an SDL Texture from a file
         unsafe {
@@ -166,7 +166,7 @@ impl<'a> LoadTexture for Renderer<'a> {
             if (raw as *mut ()).is_null() {
                 Err(get_error())
             } else {
-                Ok(Texture::from_ll(self, raw))
+                Ok(self.raw_create_texture(raw))
             }
         }
     }

--- a/src/sdl2/messagebox.rs
+++ b/src/sdl2/messagebox.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use std::ptr;
 use std::os::raw::{c_char,c_int};
 
-use video::WindowRef;
+use video::Window;
 use get_error;
 
 use sys::messagebox as ll;
@@ -144,7 +144,7 @@ impl error::Error for ShowMessageError {
 pub fn show_simple_message_box<'a, W>(flags: MessageBoxFlag, title: &str,
         message: &str, window: W)
         -> Result<(), ShowMessageError> 
-where W: Into<Option<&'a WindowRef>>
+where W: Into<Option<&'a Window>>
 {
     use self::ShowMessageError::*;
     let result = unsafe {
@@ -183,7 +183,7 @@ where W: Into<Option<&'a WindowRef>>
 pub fn show_message_box<'a, 'b, W, M>(flags:MessageBoxFlag, buttons:&'a [ButtonData], title:&str,
     message:&str, window: W, scheme: M)
     -> Result<ClickedButton<'a>,ShowMessageError> 
-where W: Into<Option<&'b WindowRef>>,
+where W: Into<Option<&'b Window>>,
       M: Into<Option<MessageBoxColorScheme>>,
 {
     let window = window.into();

--- a/src/sdl2/mouse/mod.rs
+++ b/src/sdl2/mouse/mod.rs
@@ -344,7 +344,7 @@ impl MouseUtil {
         }
     }
 
-    pub fn warp_mouse_in_window(&self, window: &video::WindowRef, x: i32, y: i32) {
+    pub fn warp_mouse_in_window(&self, window: &video::Window, x: i32, y: i32) {
         unsafe { ll::SDL_WarpMouseInWindow(window.raw(), x, y); }
     }
 

--- a/src/sdl2/pixels.rs
+++ b/src/sdl2/pixels.rs
@@ -339,6 +339,17 @@ impl PixelFormatEnum {
                 => panic!("not supported format: {:?}", *self),
         }
     }
+
+    pub fn supports_alpha(&self) -> bool {
+        use ::pixels::PixelFormatEnum::*;
+        match *self {
+            ARGB4444 | ARGB1555 | ARGB8888 | ARGB2101010 |
+            ABGR4444 | ABGR1555 | ABGR8888 |
+            BGRA4444 | BGRA5551 | BGRA8888 |
+            RGBA4444 | RGBA5551 | RGBA8888 => true,
+            _ => false
+        }
+    }
 }
 
 impl Into<ll::SDL_PixelFormatEnum> for PixelFormatEnum {

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -214,7 +214,7 @@ impl<T> RendererContext<T> {
     }
 
     /// Gets the raw pointer to the SDL_Renderer
-    pub unsafe fn raw(&self) -> *mut ll::SDL_Renderer {
+    pub fn raw(&self) -> *mut ll::SDL_Renderer {
         self.raw
     }
 
@@ -550,7 +550,7 @@ impl Error for TextureValueError {
 
 /// Texture-creating methods for the renderer
 impl<T> TextureCreator<T> {
-    pub unsafe fn raw(&self) -> *mut ll::SDL_Renderer {
+    pub fn raw(&self) -> *mut ll::SDL_Renderer {
         self.context.raw()
     }
 
@@ -675,7 +675,7 @@ impl<'r, 't, TC: TextureOwner> Drop for TextureTarget<'r, 't, TC> {
 
 /// Drawing methods
 impl<T: RenderTarget> Canvas<T> {
-    pub unsafe fn raw(&self) -> *mut ll::SDL_Renderer {
+    pub fn raw(&self) -> *mut ll::SDL_Renderer {
         self.context.raw()
     }
 
@@ -1682,7 +1682,7 @@ impl<'r> Texture<'r> {
         }
     }
 
-    pub unsafe fn raw(&self) -> *mut ll::SDL_Texture {
+    pub fn raw(&self) -> *mut ll::SDL_Texture {
         self.raw
     }
 }

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -254,7 +254,7 @@ impl<'s> RenderTarget for Surface<'s> {
     type Context = SurfaceContext<'s>;
 }
 
-impl<'r, 't, TC: TextureOwner> RenderTarget for TextureTarget<'r, 't, TC> {
+impl<'r, 't, TC> RenderTarget for TextureTarget<'r, 't, TC> {
     type Context = TC;
 }
 
@@ -440,9 +440,7 @@ impl Canvas<Window> {
     }
 }
 
-impl<T: RenderTarget> Canvas<T>
-    where T::Context: TextureOwner
-{
+impl<T: RenderTarget> Canvas<T> {
     /// Determine whether a window supports the use of render targets.
     pub fn render_target_supported(&self) -> bool {
         unsafe { ll::SDL_RenderTargetSupported(self.context.raw) == 1 }
@@ -720,7 +718,7 @@ impl<T> TextureCreator<T> {
     }
 }
 
-pub struct TextureTarget<'r, 't, TC: TextureOwner> {
+pub struct TextureTarget<'r, 't, TC> {
     raw_renderer: &'r *mut ll::SDL_Renderer,
     _texture_marker: PhantomData<&'t ()>,
     // unfortunately there is no way to know which kind of Renderer we have here at compile time,
@@ -728,16 +726,7 @@ pub struct TextureTarget<'r, 't, TC: TextureOwner> {
     _texture_target: PhantomData<TC>,
 }
 
-/// Represents structs that are the "source" of the Renderer.
-///
-/// You should *not* implement this trait outside of this crate.
-pub trait TextureOwner {}
-
-impl<'s> TextureOwner for SurfaceContext<'s> {}
-
-impl TextureOwner for WindowContext {}
-
-impl<'r, 't, TC: TextureOwner> Drop for TextureTarget<'r, 't, TC> {
+impl<'r, 't, TC> Drop for TextureTarget<'r, 't, TC> {
     // `Drop` cannot be specialized. Get around this through run-time check of Target Kind
     fn drop(&mut self) {
         unsafe {
@@ -1192,7 +1181,7 @@ impl<T: RenderTarget> Canvas<T> {
 /// ```
 pub type TextureCanvas<'r, 't, TC> = Canvas<TextureTarget<'r, 't, TC>>;
 
-impl<'r, 't, TC: TextureOwner> Canvas<TextureTarget<'r, 't, TC>> {
+impl<'r, 't, TC> Canvas<TextureTarget<'r, 't, TC>> {
     /// Replace the target of the `TextureCanvas` with a different `Texture`
     ///
     /// Returns the new `TextureCanvas` and releases the `&mut` borrow on the old `Texture`

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -276,7 +276,9 @@ impl<'r, 't, TC: TextureOwner> RenderTarget for TextureTarget<'r, 't, TC> {
 /// # Examples
 ///
 /// ```rust,no_run
-/// # use sdl2::window::Window;
+/// # use sdl2::render::Canvas;
+/// # use sdl2::video::Window;
+/// # use sdl2::pixels::Color;
 /// # use sdl2::rect::Rect;
 /// # let sdl_context = sdl2::init().unwrap();
 /// # let video_subsystem = sdl_context.video().unwrap();

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -382,7 +382,7 @@ impl<'s> Canvas<Surface<'s>> {
     pub fn texture_creator(&self) -> TextureCreator<SurfaceContext<'s>> {
         TextureCreator {
             context: self.context.clone(),
-            default_pixel_format: self.surface().pixel_format_enum()
+            default_pixel_format: self.surface().pixel_format_enum(),
         }
     }
 }
@@ -435,20 +435,23 @@ impl Canvas<Window> {
     pub fn texture_creator(&self) -> TextureCreator<WindowContext> {
         TextureCreator {
             context: self.context.clone(),
-            default_pixel_format: self.window().window_pixel_format()
+            default_pixel_format: self.window().window_pixel_format(),
         }
     }
 }
 
-impl<T: RenderTarget> Canvas<T> where T::Context: TextureOwner {
+impl<T: RenderTarget> Canvas<T>
+    where T::Context: TextureOwner
+{
     /// Determine whether a window supports the use of render targets.
     pub fn render_target_supported(&self) -> bool {
         unsafe { ll::SDL_RenderTargetSupported(self.context.raw) == 1 }
     }
 
-    fn internal_with_target<'r, 't, 'a>(&'r mut self,
-                                        texture: &'t mut Texture<'a>)
-                                        -> Result<TextureCanvas<'r, 't, T::Context>, TargetRenderError> {
+    fn internal_with_target<'r, 't, 'a>
+        (&'r mut self,
+         texture: &'t mut Texture<'a>)
+         -> Result<TextureCanvas<'r, 't, T::Context>, TargetRenderError> {
         if self.render_target_supported() {
             unsafe { self.set_raw_target(texture.raw) }
                 .map_err(|e| TargetRenderError::SdlError(e))?;
@@ -619,12 +622,13 @@ impl<T> TextureCreator<T> {
     /// unsupported Pixel Formats that can cause errors. However, be careful with the default
     /// `PixelFormat` if you want to create transparent textures.
     pub fn create_texture<F>(&self,
-                          format: F,
-                          access: TextureAccess,
-                          width: u32,
-                          height: u32)
-                          -> Result<Texture, TextureValueError>
-                          where F: Into<Option<PixelFormatEnum>> {
+                             format: F,
+                             access: TextureAccess,
+                             width: u32,
+                             height: u32)
+                             -> Result<Texture, TextureValueError>
+        where F: Into<Option<PixelFormatEnum>>
+    {
         use self::TextureValueError::*;
         let w = match validate_int(width, "width") {
             Ok(w) => w,
@@ -634,7 +638,7 @@ impl<T> TextureCreator<T> {
             Ok(h) => h,
             Err(_) => return Err(HeightOverflows(height)),
         };
-        let format : PixelFormatEnum = format.into().unwrap_or(self.default_pixel_format);
+        let format: PixelFormatEnum = format.into().unwrap_or(self.default_pixel_format);
 
         // If the pixel format is YUV 4:2:0 and planar, the width and height must
         // be multiples-of-two. See issue #334 for details.
@@ -664,7 +668,8 @@ impl<T> TextureCreator<T> {
                                     width: u32,
                                     height: u32)
                                     -> Result<Texture, TextureValueError>
-                                    where F: Into<Option<PixelFormatEnum>> {
+        where F: Into<Option<PixelFormatEnum>>
+    {
         self.create_texture(format, TextureAccess::Static, width, height)
     }
 
@@ -674,7 +679,8 @@ impl<T> TextureCreator<T> {
                                        width: u32,
                                        height: u32)
                                        -> Result<Texture, TextureValueError>
-                                       where F: Into<Option<PixelFormatEnum>> {
+        where F: Into<Option<PixelFormatEnum>>
+    {
         self.create_texture(format, TextureAccess::Streaming, width, height)
     }
 
@@ -684,7 +690,8 @@ impl<T> TextureCreator<T> {
                                     width: u32,
                                     height: u32)
                                     -> Result<Texture, TextureValueError>
-                                    where F: Into<Option<PixelFormatEnum>> {
+        where F: Into<Option<PixelFormatEnum>>
+    {
         self.create_texture(format, TextureAccess::Target, width, height)
     }
 
@@ -726,11 +733,9 @@ pub struct TextureTarget<'r, 't, TC: TextureOwner> {
 /// You should *not* implement this trait outside of this crate.
 pub trait TextureOwner {}
 
-impl<'s> TextureOwner for SurfaceContext<'s> {
-}
+impl<'s> TextureOwner for SurfaceContext<'s> {}
 
-impl TextureOwner for WindowContext {
-}
+impl TextureOwner for WindowContext {}
 
 impl<'r, 't, TC: TextureOwner> Drop for TextureTarget<'r, 't, TC> {
     // `Drop` cannot be specialized. Get around this through run-time check of Target Kind


### PR DESCRIPTION
This is my initial attempt at separating the LoadTexture (from the image feature) from the rest of the renderer. A lot of the changes are just rustfmt doing it's business as I coded away. It addresses #630 

All tests pass, and all the examples run (the only example I could not run on my machine was the audio-queue-square-wave since it requires SDL2.0.4 and I have 2.0.0 but I did not change anything on the audio feature I am confident that it works. 

Pros of my current approach:
- The SDL image context is now required for loading images, which means that we will not accidentally try to load an image after this context has been dropped. 
- LoadImage is separate from the rendering functions which allows the user to create a ResourceManager that holds the ImageLoader (the sdl image context) without blocking the rendering functions. 

Cons:
- Lifetimes went up. Both the `Renderer` and the `Sdl2ImageContext` hold a reference to the `RenderContext` which means that they now introduce a explicit lifetime.
- The users has to explicitely keep a hold of the `RenderContext` since neither the `Renderer` nor the `Sdl2ImageContext` own it. An alternative would be holding an `Rc<RenderContext>` which would get rid of the lifetime, and it won't force the user to hold the context just to keep it alive. A con to this would be having to store it in an Rc. 

I tried to touch as little actual code as possible so the `Renderer` currently is still in charge of other texture creation methods. This could possibly also be moved but I wanted to get a WIP out first for review.

I would also like to get rid of the `is_alive` param that exists in the `Texture` and the `RenderContext`. This could possibly be done by using a lifetime similarly to how Font Loading works? The downside would be the added complexity that explicit lifetimes entail. From my experience Font Loading and caching were also a little hard to deal with. That being said it might be worth to standardize how we handle checking that the context is alive (lifetime vs the is_alive check). 

I am open for any thoughts or nits to touch up on. 