### PR TITLE
Add /usr/local/lib to linker seach path on macOS

### DIFF
--- a/sdl2-sys/build.rs
+++ b/sdl2-sys/build.rs
@@ -11,6 +11,10 @@ fn main() {
         } else {
             println!("cargo:rustc-flags=-l SDL2");
         }
+
+        if target_os == "darwin" {
+            println!("cargo:rustc-link-search=/usr/local/lib");
+        }
     }
 }
 


### PR DESCRIPTION
When sdl is installed with homebrew on macOS, the static libraries are
placed in /usr/local/lib. Recently cargo seems to have stopped searching
in /usr/local/lib for libraries on macOS, which means you get linker
errors on macOS unless you build with `cargo rustc -- -L /usr/local/lib.
This modifies the sdl2-sys build script to add /usr/local/libh to the
linker search path when building on macOS.