### PR TITLE
Add link directives for iOS frameworks

### DIFF
--- a/sdl2-sys/build.rs
+++ b/sdl2-sys/build.rs
@@ -2,15 +2,28 @@
 extern crate pkg_config;
 
 fn main() {
-    if !build_pkgconfig() {
-        let target = ::std::env::var("TARGET").expect("Cargo build scripts always have TARGET");
-        let target_os = target.splitn(3, "-").nth(2).unwrap();
+    let target = ::std::env::var("TARGET").expect("Cargo build scripts always have TARGET");
+    let target_os = target.splitn(3, "-").nth(2).unwrap();
 
+    if !build_pkgconfig() {
         if cfg!(feature="use_mac_framework") && target_os == "darwin" {
             println!("cargo:rustc-flags=-l framework=SDL2");
         } else {
             println!("cargo:rustc-flags=-l SDL2");
         }
+    }
+
+    if target_os == "ios" {
+        println!("cargo:rustc-flags=-l framework=AVFoundation");
+        println!("cargo:rustc-flags=-l framework=AudioToolbox");
+        println!("cargo:rustc-flags=-l framework=CoreAudio");
+        println!("cargo:rustc-flags=-l framework=CoreGraphics");
+        println!("cargo:rustc-flags=-l framework=CoreMotion");
+        println!("cargo:rustc-flags=-l framework=Foundation");
+        println!("cargo:rustc-flags=-l framework=GameController");
+        println!("cargo:rustc-flags=-l framework=OpenGLES");
+        println!("cargo:rustc-flags=-l framework=QuartzCore");
+        println!("cargo:rustc-flags=-l framework=UIKit");
     }
 }
 


### PR DESCRIPTION
These frameworks are necessary to link SDL2 into an iOS program.
https://github.com/spurious/SDL-mirror/blob/a4a9743a983dfccd6e7cc16fa3cb0f6d468041c1/configure.in#L3524-L3533